### PR TITLE
Release v0.2.1 — SFTP folder download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-04-29
+
 ### Added
+- SFTP folder download: right-click a remote folder (or select + use the toolbar / drag-drop) to download it recursively. Reports a single aggregate transfer with combined byte progress instead of one entry per file.
 - Persisted workspace snapshots keyed by stable identity (`profileId + userId`) so the app remembers the last active workspace per connection context.
 
 ### Changed
@@ -15,4 +18,5 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Applied `startupDirectory` as the initial SFTP remote fallback when no saved workspace snapshot exists.
 
 ### Notes
+- Folder download skips symlinks (logs a warning) to avoid loops; partial files are left on disk on failure for inspection.
 - Live SSH handles, PTYs, and dead terminal processes are intentionally not persisted; only safe UI/workspace state is restored.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexterm",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2457,7 +2457,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nexterm"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -2482,12 +2482,14 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-shell",
  "tauri-plugin-updater",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "windows 0.61.3",
  "zeroize",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexterm"
-version = "0.2.0"
+version = "0.2.1"
 description = "NexTerm — Cross-platform SSH client with terminal, SFTP, and tunneling"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -75,3 +75,18 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 [target."cfg(not(any(target_os = \"android\", target_os = \"ios\")))".dependencies]
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
+
+# Windows-only — used by fs_secure::windows for owner-only NTFS DACLs.
+# Already pulled transitively via tauri-plugin-updater; declared explicitly
+# here because we use it directly. Zero binary-size impact.
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.61", features = [
+  "Win32_Foundation",
+  "Win32_Security",
+  "Win32_Security_Authorization",
+  "Win32_System_Memory",
+  "Win32_System_Threading",
+] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/src-tauri/src/commands/profile.rs
+++ b/src-tauri/src/commands/profile.rs
@@ -323,6 +323,14 @@ pub async fn export_profiles(
             .map_err(|e| AppError::ProfileError(format!("Failed to write export file: {e}")))?;
     }
 
+    // Best-effort hardening of the user-chosen destination. The path may live
+    // on FAT32, a network share, or a cloud-sync folder where ACL operations
+    // can fail; in those cases we log a warning but do NOT fail the export.
+    // TODO(ux): surface a localized warning to the frontend when this returns
+    // false, so users on unsupported filesystems know to move the export to a
+    // local NTFS/APFS/ext4 location for owner-only protection.
+    let _hardened = crate::fs_secure::best_effort_harden(std::path::Path::new(&export_path));
+
     Ok(count)
 }
 

--- a/src-tauri/src/commands/sftp.rs
+++ b/src-tauri/src/commands/sftp.rs
@@ -572,6 +572,90 @@ pub async fn sftp_download(
     result
 }
 
+/// Recursively download a remote directory tree to the local filesystem.
+///
+/// Reports progress as ONE aggregate transfer (total bytes summed from a
+/// pre-walk of the remote tree) so the UI shows a single entry in the
+/// transfer overlay rather than one per file.
+///
+/// Lock strategy: same as sftp_download — clone Arc, drop lock,
+/// run I/O without holding the global sessions lock.
+#[tauri::command]
+pub async fn sftp_download_folder(
+    state: State<'_, AppState>,
+    session_id: SessionId,
+    remote_path: String,
+    local_path: String,
+    on_progress: Channel<TransferEvent>,
+) -> Result<TransferId, AppError> {
+    let local = PathBuf::from(&local_path);
+    let folder_name = remote_path
+        .rsplit('/')
+        .find(|s| !s.is_empty())
+        .unwrap_or("folder")
+        .to_string();
+
+    let cancel_token = CancellationToken::new();
+    let transfer_id = Uuid::new_v4();
+
+    let sftp_session = {
+        let mut sessions = state.sessions.lock().await;
+        let handle = sessions
+            .get_mut(&session_id)
+            .ok_or(AppError::SessionNotFound(session_id))?;
+
+        if handle.state != crate::state::SessionState::Connected {
+            return Err(AppError::NotConnected);
+        }
+
+        if handle.sftp.is_none() {
+            let ssh = handle.ssh_handle.as_ref().ok_or(AppError::NotConnected)?;
+            let sftp_handle = sftp::open_sftp(ssh).await?;
+            handle.sftp = Some(sftp_handle);
+            tracing::info!("SFTP subsystem opened for session {session_id}");
+        }
+
+        let sftp_handle = handle.sftp.as_mut().expect("SFTP just ensured above");
+
+        // total_bytes is computed during the recursive walk inside download_dir,
+        // so we register the transfer with 0 and let the Started event update the UI.
+        sftp_handle.active_transfers.insert(
+            transfer_id,
+            TransferState {
+                id: transfer_id,
+                direction: TransferDirection::Download,
+                file_name: folder_name,
+                total_bytes: 0,
+                bytes_transferred: 0,
+                cancel_token: cancel_token.clone(),
+            },
+        );
+
+        sftp_handle.session.clone()
+    };
+
+    let result = sftp::download_dir(
+        &sftp_session,
+        &remote_path,
+        &local,
+        transfer_id,
+        on_progress,
+        cancel_token,
+    )
+    .await;
+
+    {
+        let mut sessions = state.sessions.lock().await;
+        if let Some(handle) = sessions.get_mut(&session_id) {
+            if let Some(ref mut sftp_handle) = handle.sftp {
+                sftp_handle.active_transfers.remove(&transfer_id);
+            }
+        }
+    }
+
+    result
+}
+
 /// Cancel an active file transfer.
 #[tauri::command]
 pub async fn sftp_cancel_transfer(

--- a/src-tauri/src/fs_secure/fallback.rs
+++ b/src-tauri/src/fs_secure/fallback.rs
@@ -1,0 +1,17 @@
+// fs_secure::fallback — No-op for unsupported platforms.
+//
+// Reached only on targets that are neither `unix` nor `windows`. Returns
+// success without modifying permissions. This is a soft failure: the file
+// will exist with default platform permissions, which on supported targets
+// would have been tightened.
+
+use std::io;
+use std::path::Path;
+
+pub(super) fn set_owner_only(_path: &Path) -> io::Result<()> {
+    tracing::warn!(
+        "fs_secure: no owner-only permission support on this platform; \
+         file will inherit default permissions"
+    );
+    Ok(())
+}

--- a/src-tauri/src/fs_secure/mod.rs
+++ b/src-tauri/src/fs_secure/mod.rs
@@ -1,0 +1,241 @@
+// fs_secure — Cross-platform secure file writes for sensitive local data.
+//
+// Centralizes platform-specific permission/ACL handling so callers (vault,
+// profile persistence) do not need #[cfg(unix)] / #[cfg(windows)] branches.
+// Permissions are applied to the temp file BEFORE rename to close the race
+// window where the final file briefly exists with inherited permissions.
+//
+// Known limitations:
+// - On Windows in GPO-managed environments, Group Policy can re-assert
+//   inherited ACLs after this code runs. This cannot be mitigated at the
+//   application layer.
+// - Networked or cloud-sync filesystems (FAT32, SMB shares, OneDrive folders)
+//   may reject ACL operations. Callers that must tolerate this should use
+//   `best_effort_harden` instead of the strict variants.
+
+use std::ffi::OsString;
+use std::io;
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+mod unix;
+#[cfg(unix)]
+use unix as platform;
+
+#[cfg(windows)]
+mod windows;
+#[cfg(windows)]
+use windows as platform;
+
+#[cfg(not(any(unix, windows)))]
+mod fallback;
+#[cfg(not(any(unix, windows)))]
+use fallback as platform;
+
+/// Build the temp-file path for an atomic write by appending `.tmp` to the
+/// final file name. Keeps the temp file in the same directory as the
+/// destination so rename stays on the same volume.
+fn tmp_path_for(path: &Path) -> PathBuf {
+    let mut p = path.to_path_buf();
+    let name = p
+        .file_name()
+        .map(|n| {
+            let mut s = OsString::from(n);
+            s.push(".tmp");
+            s
+        })
+        .unwrap_or_else(|| OsString::from(".tmp"));
+    p.set_file_name(name);
+    p
+}
+
+/// Atomically write `bytes` to `path` with owner-only access.
+///
+/// Sequence: write to temp file → apply owner-only permissions/ACL to the
+/// temp file → rename into place. Same-volume rename preserves the explicit
+/// DACL/mode on NTFS, ext4, and APFS.
+///
+/// On error, the temp file is best-effort removed so we don't leak
+/// `<path>.tmp` files on failure.
+pub fn secure_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let tmp = tmp_path_for(path);
+
+    if let Err(e) = std::fs::write(&tmp, bytes) {
+        return Err(e);
+    }
+
+    if let Err(e) = platform::set_owner_only(&tmp) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
+    }
+
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
+    }
+
+    Ok(())
+}
+
+/// Copy `from` to `to` and apply owner-only access on the destination.
+///
+/// Used for files where atomic write isn't appropriate (e.g. one-shot
+/// migration backups). Permissions are applied AFTER copy because there
+/// is no temp-file step to harden first.
+pub fn secure_copy(from: &Path, to: &Path) -> io::Result<()> {
+    std::fs::copy(from, to)?;
+    platform::set_owner_only(to)
+}
+
+/// Re-apply owner-only access to an existing file.
+///
+/// Idempotent. Used to migrate files that were created before this module
+/// existed (or by older versions of the app) so they pick up the stricter
+/// permissions on first read.
+///
+/// Returns Ok(()) if the file does not exist (nothing to harden) so this
+/// is safe to call unconditionally on a path that may not yet be present.
+pub fn harden_existing(path: &Path) -> io::Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+    platform::set_owner_only(path)
+}
+
+/// Best-effort variant of `harden_existing` for export targets.
+///
+/// Logs a warning on failure but never returns an error. Use this when the
+/// destination filesystem may not support ACL operations (FAT32, network
+/// shares, cloud-sync folders) and failing the operation entirely would
+/// be a worse user experience than a degraded permission state.
+///
+/// Returns true if hardening succeeded, false otherwise.
+pub fn best_effort_harden(path: &Path) -> bool {
+    match harden_existing(path) {
+        Ok(()) => true,
+        Err(e) => {
+            tracing::warn!("best-effort hardening failed for {:?}: {}", path, e);
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tmp_path_appends_tmp_suffix() {
+        let p = Path::new("/foo/bar.json");
+        assert_eq!(tmp_path_for(p), PathBuf::from("/foo/bar.json.tmp"));
+    }
+
+    #[test]
+    fn tmp_path_handles_no_extension() {
+        let p = Path::new("/foo/bar");
+        assert_eq!(tmp_path_for(p), PathBuf::from("/foo/bar.tmp"));
+    }
+
+    #[test]
+    fn tmp_path_handles_multi_extension() {
+        let p = Path::new("/foo/archive.tar.gz");
+        assert_eq!(tmp_path_for(p), PathBuf::from("/foo/archive.tar.gz.tmp"));
+    }
+
+    #[test]
+    fn secure_write_then_read_roundtrips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.json");
+        let payload = b"{\"hello\":\"world\"}";
+
+        secure_write(&path, payload).unwrap();
+
+        let read_back = std::fs::read(&path).unwrap();
+        assert_eq!(read_back, payload);
+    }
+
+    #[test]
+    fn secure_write_overwrites_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.json");
+
+        secure_write(&path, b"first").unwrap();
+        secure_write(&path, b"second").unwrap();
+
+        let read_back = std::fs::read(&path).unwrap();
+        assert_eq!(read_back, b"second");
+    }
+
+    #[test]
+    fn secure_write_leaves_no_tmp_file_on_success() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.json");
+
+        secure_write(&path, b"payload").unwrap();
+
+        let tmp = tmp_path_for(&path);
+        assert!(!tmp.exists(), "temp file should not exist after success");
+    }
+
+    #[test]
+    fn harden_existing_is_noop_on_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("does-not-exist.json");
+        assert!(harden_existing(&path).is_ok());
+    }
+
+    #[test]
+    fn harden_existing_succeeds_on_present_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.json");
+        std::fs::write(&path, b"x").unwrap();
+
+        assert!(harden_existing(&path).is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn secure_write_results_in_owner_only_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.json");
+
+        secure_write(&path, b"payload").unwrap();
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "expected 0o600, got {:o}", mode);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn secure_copy_results_in_owner_only_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src.json");
+        let dst = dir.path().join("dst.json");
+        std::fs::write(&src, b"x").unwrap();
+
+        secure_copy(&src, &dst).unwrap();
+
+        let mode = std::fs::metadata(&dst).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "expected 0o600, got {:o}", mode);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn harden_existing_tightens_loose_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("loose.json");
+        std::fs::write(&path, b"x").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        harden_existing(&path).unwrap();
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+}

--- a/src-tauri/src/fs_secure/unix.rs
+++ b/src-tauri/src/fs_secure/unix.rs
@@ -1,0 +1,12 @@
+// fs_secure::unix — Owner-only file permissions on Unix-family systems.
+//
+// Sets mode 0o600 (read/write for owner, nothing for group or other).
+// Same behaviour on Linux, macOS, and BSDs.
+
+use std::io;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+pub(super) fn set_owner_only(path: &Path) -> io::Result<()> {
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+}

--- a/src-tauri/src/fs_secure/windows.rs
+++ b/src-tauri/src/fs_secure/windows.rs
@@ -1,0 +1,165 @@
+// fs_secure::windows — Owner-only NTFS ACL via SetNamedSecurityInfoW.
+//
+// Builds a protected DACL containing exactly one ACE: GENERIC_ALL for the
+// current process user SID, no inheritance, no inherited ACEs. Removes the
+// default ACL inherited from the parent directory (typically %APPDATA%),
+// which on shared or domain-joined Windows hosts grants Users / Authenticated
+// Users read access to the file.
+//
+// The `windows` crate is already present transitively via tauri-plugin-updater
+// so adding it as an explicit `[target.'cfg(windows)'.dependencies]` entry
+// has no binary-size cost.
+//
+// COMPILE-VERIFICATION REQUIRED: this module uses Win32 APIs whose binding
+// shapes vary across windows-rs minor versions. Build on Windows and run the
+// integration tests in `tests/fs_secure_windows.rs` (or the upstream
+// contributor's PR for #2) before relying on this in production.
+
+use std::io;
+use std::os::windows::ffi::OsStrExt;
+use std::path::Path;
+
+use windows::core::PCWSTR;
+use windows::Win32::Foundation::{CloseHandle, LocalFree, HANDLE, HLOCAL};
+use windows::Win32::Security::Authorization::{SetNamedSecurityInfoW, SE_FILE_OBJECT};
+use windows::Win32::Security::{
+    AddAccessAllowedAceEx, GetLengthSid, GetTokenInformation, InitializeAcl, TokenUser, ACCESS_ALLOWED_ACE,
+    ACL, ACL_REVISION, DACL_SECURITY_INFORMATION, PROTECTED_DACL_SECURITY_INFORMATION, PSID,
+    TOKEN_QUERY, TOKEN_USER,
+};
+use windows::Win32::System::Memory::{LocalAlloc, LPTR};
+use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+/// Standard Windows access right: full access via the generic mapping.
+const GENERIC_ALL: u32 = 0x10000000;
+
+/// ACE inheritance flag value indicating "do not propagate to children".
+/// Defined as 0 in the Windows headers; the `windows` crate does not always
+/// re-export it as a named constant across minor versions, so we hardcode it
+/// with a comment for traceability.
+const NO_INHERITANCE: u32 = 0;
+
+/// RAII guard for a Windows HANDLE — closes on drop.
+struct HandleGuard(HANDLE);
+
+impl Drop for HandleGuard {
+    fn drop(&mut self) {
+        if !self.0.is_invalid() {
+            unsafe {
+                let _ = CloseHandle(self.0);
+            }
+        }
+    }
+}
+
+/// RAII guard for memory allocated via LocalAlloc — frees on drop.
+struct LocalAllocGuard(*mut std::ffi::c_void);
+
+impl Drop for LocalAllocGuard {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe {
+                let _ = LocalFree(HLOCAL(self.0));
+            }
+        }
+    }
+}
+
+pub(super) fn set_owner_only(path: &Path) -> io::Result<()> {
+    // 1. Open the current process token to query the user SID.
+    let token = unsafe {
+        let mut h = HANDLE::default();
+        OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut h)
+            .map_err(|e| io::Error::other(format!("OpenProcessToken: {e}")))?;
+        HandleGuard(h)
+    };
+
+    // 2. First call: query required buffer size for TOKEN_USER.
+    let mut needed: u32 = 0;
+    unsafe {
+        // Intentional ignore: this call is expected to fail with
+        // ERROR_INSUFFICIENT_BUFFER and write the required size into `needed`.
+        let _ = GetTokenInformation(token.0, TokenUser, None, 0, &mut needed);
+    }
+    if needed == 0 {
+        return Err(io::Error::other("GetTokenInformation size query returned 0"));
+    }
+
+    // 3. Allocate the buffer and re-call to fill it.
+    let token_user_buf = match unsafe { LocalAlloc(LPTR, needed as usize) } {
+        Ok(h) => LocalAllocGuard(h.0 as *mut _),
+        Err(e) => return Err(io::Error::other(format!("LocalAlloc TOKEN_USER: {e}"))),
+    };
+    unsafe {
+        GetTokenInformation(
+            token.0,
+            TokenUser,
+            Some(token_user_buf.0),
+            needed,
+            &mut needed,
+        )
+        .map_err(|e| io::Error::other(format!("GetTokenInformation: {e}")))?;
+    }
+
+    // 4. Extract the user SID pointer. The SID lives inside the buffer we
+    //    just allocated; we must keep `token_user_buf` alive until after
+    //    SetNamedSecurityInfoW returns.
+    let token_user_ptr = token_user_buf.0 as *const TOKEN_USER;
+    let user_sid: PSID = unsafe { (*token_user_ptr).User.Sid };
+
+    // 5. Compute ACL size: header + one ACE that is just large enough for the
+    //    SID. ACCESS_ALLOWED_ACE includes a 4-byte SidStart placeholder which
+    //    we replace with the actual SID, hence the subtraction.
+    let sid_len = unsafe { GetLengthSid(user_sid) };
+    let acl_size: u32 = (std::mem::size_of::<ACL>() as u32)
+        + (std::mem::size_of::<ACCESS_ALLOWED_ACE>() as u32)
+        - (std::mem::size_of::<u32>() as u32)
+        + sid_len;
+
+    let acl_buf = match unsafe { LocalAlloc(LPTR, acl_size as usize) } {
+        Ok(h) => LocalAllocGuard(h.0 as *mut _),
+        Err(e) => return Err(io::Error::other(format!("LocalAlloc ACL: {e}"))),
+    };
+    let acl_ptr = acl_buf.0 as *mut ACL;
+
+    // 6. Initialize the empty ACL and add a single allow-all ACE for the user.
+    unsafe {
+        InitializeAcl(acl_ptr, acl_size, ACL_REVISION.0)
+            .map_err(|e| io::Error::other(format!("InitializeAcl: {e}")))?;
+        AddAccessAllowedAceEx(
+            acl_ptr,
+            ACL_REVISION.0,
+            windows::Win32::Security::ACE_FLAGS(NO_INHERITANCE),
+            GENERIC_ALL,
+            user_sid,
+        )
+        .map_err(|e| io::Error::other(format!("AddAccessAllowedAceEx: {e}")))?;
+    }
+
+    // 7. Convert the path to a null-terminated wide string.
+    let mut wide: Vec<u16> = path.as_os_str().encode_wide().collect();
+    wide.push(0);
+
+    // 8. Apply the DACL with PROTECTED_DACL_SECURITY_INFORMATION so inherited
+    //    ACEs from the parent directory are stripped. Owner / group / SACL
+    //    are intentionally left unchanged (None / default).
+    unsafe {
+        let status = SetNamedSecurityInfoW(
+            PCWSTR(wide.as_ptr()),
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+            None,
+            None,
+            Some(acl_ptr),
+            None,
+        );
+        if status.is_err() {
+            return Err(io::Error::other(format!(
+                "SetNamedSecurityInfoW failed: {status:?}"
+            )));
+        }
+    }
+
+    // token_user_buf and acl_buf drop here, freeing both LocalAlloc blocks.
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod commands;
 pub mod error;
+pub mod fs_secure;
 pub mod profile;
 pub mod ssh;
 pub mod state;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -79,6 +79,7 @@ pub fn run() {
             commands::sftp::sftp_rename,
             commands::sftp::sftp_upload,
             commands::sftp::sftp_download,
+            commands::sftp::sftp_download_folder,
             commands::sftp::sftp_read_file,
             commands::sftp::sftp_search,
             commands::sftp::sftp_cancel_transfer,

--- a/src-tauri/src/profile.rs
+++ b/src-tauri/src/profile.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::error::AppError;
+use crate::fs_secure;
 use crate::state::TunnelConfig;
 
 // ─── User Credential ────────────────────────────────────
@@ -200,10 +201,13 @@ pub fn load_profiles_from_disk(
 
     // Persist migrated profiles (backup first)
     if migrated {
-        // Create backup before first migration write
+        // Create backup before first migration write — route through fs_secure
+        // so the backup file picks up owner-only permissions/ACL just like
+        // the live profiles file. Previously this used std::fs::copy which
+        // left the backup with default inherited permissions on every platform.
         let backup_path = path.with_extension("backup.json");
         if !backup_path.exists() {
-            if let Err(e) = std::fs::copy(&path, &backup_path) {
+            if let Err(e) = fs_secure::secure_copy(&path, &backup_path) {
                 tracing::warn!("Failed to create profiles backup: {e}");
             }
         }
@@ -213,11 +217,19 @@ pub fn load_profiles_from_disk(
         }
     }
 
+    // Idempotent migration: re-apply owner-only access to the existing
+    // profiles file in case it was created by an older version of the app
+    // before fs_secure existed.
+    if let Err(e) = fs_secure::harden_existing(&path) {
+        tracing::warn!("Failed to harden existing profiles file: {e}");
+    }
+
     profiles.sort_by_key(|p| p.display_order);
     Ok(profiles)
 }
 
-/// Save all profiles to disk (atomic write via temp file)
+/// Save all profiles to disk via fs_secure: atomic temp-file write with
+/// owner-only permissions/ACL applied BEFORE rename.
 pub fn save_profiles_to_disk(
     profiles: &[ConnectionProfile],
     app_data_dir: Option<&PathBuf>,
@@ -233,24 +245,8 @@ pub fn save_profiles_to_disk(
 
     let json = serde_json::to_string_pretty(profiles)?;
 
-    // Write to temp file then rename for atomicity
-    let tmp_path = path.with_extension("json.tmp");
-    std::fs::write(&tmp_path, &json)
-        .map_err(|e| AppError::ProfileError(format!("Failed to write profiles: {e}")))?;
-
-    std::fs::rename(&tmp_path, &path)
-        .map_err(|e| AppError::ProfileError(format!("Failed to finalize profiles write: {e}")))?;
-
-    // Restrict file permissions to owner-only on Unix (0o600)
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        std::fs::set_permissions(&path, perms)
-            .map_err(|e| AppError::ProfileError(format!("Failed to set file permissions: {e}")))?;
-    }
-
-    Ok(())
+    fs_secure::secure_write(&path, json.as_bytes())
+        .map_err(|e| AppError::ProfileError(format!("Failed to write profiles: {e}")))
 }
 
 // ─── Tests ──────────────────────────────────────────────

--- a/src-tauri/src/ssh/sftp.rs
+++ b/src-tauri/src/ssh/sftp.rs
@@ -892,6 +892,207 @@ pub async fn download_to_path_with_progress(
     Ok(())
 }
 
+// ─── Recursive Folder Download ──────────────────────────
+
+/// Walk a remote directory tree and collect every dir/file pair to mirror locally.
+///
+/// Returns `(dirs, files, total_bytes)` where:
+/// - `dirs` is parent-before-child ordered, so `create_dir_all` calls work in sequence
+/// - `files` lists `(remote_path, local_path, size)` for every regular file
+/// - `total_bytes` is the sum of file sizes — used as the aggregate progress denominator
+///
+/// Symlinks and other non-regular entries are skipped to avoid loops and ambiguity.
+async fn walk_remote_dir(
+    sftp: &SftpSession,
+    remote_root: &str,
+    local_root: &Path,
+) -> Result<
+    (
+        Vec<std::path::PathBuf>,
+        Vec<(String, std::path::PathBuf, u64)>,
+        u64,
+    ),
+    AppError,
+> {
+    let mut dirs: Vec<std::path::PathBuf> = Vec::new();
+    let mut files: Vec<(String, std::path::PathBuf, u64)> = Vec::new();
+    let mut total_bytes: u64 = 0;
+    let mut stack: Vec<(String, std::path::PathBuf)> =
+        vec![(remote_root.to_string(), local_root.to_path_buf())];
+
+    while let Some((rdir, ldir)) = stack.pop() {
+        dirs.push(ldir.clone());
+        let entries = list_dir(sftp, &rdir).await?;
+        for entry in entries {
+            let local_child = ldir.join(&entry.name);
+            match entry.file_type {
+                FileType::Directory => {
+                    stack.push((entry.path.clone(), local_child));
+                }
+                FileType::File => {
+                    total_bytes += entry.size;
+                    files.push((entry.path.clone(), local_child, entry.size));
+                }
+                FileType::Symlink | FileType::Other => {
+                    tracing::warn!(
+                        "Skipping non-regular entry during folder download: {}",
+                        entry.path
+                    );
+                }
+            }
+        }
+    }
+
+    Ok((dirs, files, total_bytes))
+}
+
+/// Recursively download a remote directory tree to a local path.
+///
+/// Reports a single aggregate transfer: pre-walks the tree to compute total bytes,
+/// emits a `Started` event with the folder name, then accumulates `bytes_transferred`
+/// across every file and emits `Progress` events as chunks land. Cancellation is
+/// honored both between files and inside chunk loops.
+///
+/// Local directories are created with `create_dir_all` (parents first). On failure
+/// or cancellation, partial files are left on disk for the user to inspect — they're
+/// not auto-cleaned because a partial multi-GB transfer may still be useful.
+pub async fn download_dir(
+    sftp: &SftpSession,
+    remote_path: &str,
+    local_path: &Path,
+    transfer_id: TransferId,
+    on_progress: Channel<TransferEvent>,
+    cancel_token: CancellationToken,
+) -> Result<TransferId, AppError> {
+    let folder_name = remote_path
+        .rsplit('/')
+        .find(|s| !s.is_empty())
+        .unwrap_or("folder")
+        .to_string();
+
+    // Pre-walk (cancellable). Computes total bytes for accurate progress.
+    let (dirs, files, total_bytes) = tokio::select! {
+        _ = cancel_token.cancelled() => {
+            let _ = on_progress.send(TransferEvent::Failed {
+                transfer_id,
+                error: "Transfer cancelled".to_string(),
+            });
+            return Err(AppError::TransferCancelled);
+        }
+        result = walk_remote_dir(sftp, remote_path, local_path) => {
+            match result {
+                Ok(v) => v,
+                Err(e) => {
+                    let _ = on_progress.send(TransferEvent::Failed {
+                        transfer_id,
+                        error: format!("Failed to walk remote directory: {e}"),
+                    });
+                    return Err(e);
+                }
+            }
+        }
+    };
+
+    let _ = on_progress.send(TransferEvent::Started {
+        transfer_id,
+        file_name: folder_name,
+        total_bytes,
+        direction: TransferDirection::Download,
+    });
+
+    for ldir in &dirs {
+        if let Err(e) = tokio::fs::create_dir_all(ldir).await {
+            let error_msg = format!(
+                "Failed to create local directory '{}': {e}",
+                ldir.display()
+            );
+            let _ = on_progress.send(TransferEvent::Failed {
+                transfer_id,
+                error: error_msg.clone(),
+            });
+            return Err(AppError::Io(e));
+        }
+    }
+
+    let mut bytes_transferred: u64 = 0;
+    let mut buf = vec![0u8; TRANSFER_CHUNK_SIZE];
+
+    for (rfile, lfile, _size) in &files {
+        if cancel_token.is_cancelled() {
+            let _ = on_progress.send(TransferEvent::Failed {
+                transfer_id,
+                error: "Transfer cancelled".to_string(),
+            });
+            return Err(AppError::TransferCancelled);
+        }
+
+        let mut remote_file = sftp.open(rfile).await.map_err(|e| {
+            let error_msg = format!("Failed to open remote file '{rfile}': {e}");
+            let _ = on_progress.send(TransferEvent::Failed {
+                transfer_id,
+                error: error_msg.clone(),
+            });
+            AppError::Sftp(error_msg)
+        })?;
+
+        let mut local_file = tokio::fs::File::create(lfile).await.map_err(|e| {
+            let _ = on_progress.send(TransferEvent::Failed {
+                transfer_id,
+                error: format!("Failed to create local file '{}': {e}", lfile.display()),
+            });
+            AppError::Io(e)
+        })?;
+
+        loop {
+            tokio::select! {
+                _ = cancel_token.cancelled() => {
+                    let _ = local_file.flush().await;
+                    drop(local_file);
+                    let _ = on_progress.send(TransferEvent::Failed {
+                        transfer_id,
+                        error: "Transfer cancelled".to_string(),
+                    });
+                    return Err(AppError::TransferCancelled);
+                }
+                result = remote_file.read(&mut buf) => {
+                    match result {
+                        Ok(0) => {
+                            local_file.flush().await.map_err(AppError::Io)?;
+                            break;
+                        }
+                        Ok(n) => {
+                            local_file.write_all(&buf[..n]).await.map_err(|e| {
+                                let _ = on_progress.send(TransferEvent::Failed {
+                                    transfer_id,
+                                    error: format!("Failed to write local file: {e}"),
+                                });
+                                AppError::Io(e)
+                            })?;
+                            bytes_transferred += n as u64;
+                            let _ = on_progress.send(TransferEvent::Progress {
+                                transfer_id,
+                                bytes_transferred,
+                                total_bytes,
+                            });
+                        }
+                        Err(e) => {
+                            let error_msg = format!("Failed to read remote file '{rfile}': {e}");
+                            let _ = on_progress.send(TransferEvent::Failed {
+                                transfer_id,
+                                error: error_msg.clone(),
+                            });
+                            return Err(AppError::Sftp(error_msg));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let _ = on_progress.send(TransferEvent::Completed { transfer_id });
+    Ok(transfer_id)
+}
+
 // ─── Tests ──────────────────────────────────────────────
 
 #[cfg(test)]

--- a/src-tauri/src/vault.rs
+++ b/src-tauri/src/vault.rs
@@ -24,6 +24,7 @@ use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
 
 use crate::error::AppError;
+use crate::fs_secure;
 
 /// Vault file name in the app data directory.
 const VAULT_FILE: &str = "vault.json";
@@ -152,6 +153,13 @@ impl Vault {
         // Validate the password by trying to decrypt the first credential
         if let Some((key, _)) = vault.credentials.iter().next() {
             vault.get(key).map_err(|_| AppError::VaultWrongPassword)?;
+        }
+
+        // Idempotent migration: re-apply owner-only access to the existing
+        // vault file in case it was created by an older version of the app
+        // that didn't tighten permissions, or before fs_secure existed.
+        if let Err(e) = fs_secure::harden_existing(&vault.file_path) {
+            tracing::warn!("Failed to harden existing vault file: {e}");
         }
 
         Ok(vault)
@@ -294,7 +302,8 @@ impl Vault {
             .map_err(|e| AppError::VaultError(format!("Invalid UTF-8 in credential: {e}")))
     }
 
-    /// Save vault to disk (atomic write via temp file, 0o600 permissions on Unix).
+    /// Save vault to disk via fs_secure: atomic temp-file write with
+    /// owner-only permissions/ACL applied BEFORE rename.
     fn save_to_disk(&self) -> Result<(), AppError> {
         // Encode credentials to base64
         let mut encoded_creds = HashMap::new();
@@ -318,24 +327,7 @@ impl Vault {
             })?;
         }
 
-        // Write to temp file then rename for atomicity
-        let tmp_path = self.file_path.with_extension("json.tmp");
-        std::fs::write(&tmp_path, &json)
-            .map_err(|e| AppError::VaultError(format!("Failed to write vault: {e}")))?;
-
-        std::fs::rename(&tmp_path, &self.file_path)
-            .map_err(|e| AppError::VaultError(format!("Failed to finalize vault write: {e}")))?;
-
-        // Restrict file permissions to owner-only on Unix (0o600)
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let perms = std::fs::Permissions::from_mode(0o600);
-            std::fs::set_permissions(&self.file_path, perms).map_err(|e| {
-                AppError::VaultError(format!("Failed to set vault file permissions: {e}"))
-            })?;
-        }
-
-        Ok(())
+        fs_secure::secure_write(&self.file_path, json.as_bytes())
+            .map_err(|e| AppError::VaultError(format!("Failed to write vault: {e}")))
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/config.schema.json",
   "productName": "NexTerm",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "com.cognidevai.nexterm",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/features/sftp/FileContextMenu.tsx
+++ b/src/features/sftp/FileContextMenu.tsx
@@ -74,6 +74,11 @@ export function FileContextMenu({
   const isFilelike = (e: FileEntry) =>
     e.fileType === "file" || (e.fileType === "symlink" && e.linkTarget === "file");
 
+  // A directory (or symlink resolving to one) — folder transfers walk recursively
+  const isDirlike = (e: FileEntry) =>
+    e.fileType === "directory" ||
+    (e.fileType === "symlink" && e.linkTarget === "directory");
+
   if (entry) {
     // Open action — for regular files and symlinks to files
     if (isFilelike(entry)) {
@@ -93,7 +98,7 @@ export function FileContextMenu({
     if (source === "local" && isFilelike(entry)) {
       items.push({ label: t("ctx.upload"), action: { type: "upload", entry } });
     }
-    if (source === "remote" && isFilelike(entry)) {
+    if (source === "remote" && (isFilelike(entry) || isDirlike(entry))) {
       items.push({ label: t("ctx.download"), action: { type: "download", entry } });
     }
 

--- a/src/features/sftp/SftpBrowser.tsx
+++ b/src/features/sftp/SftpBrowser.tsx
@@ -566,7 +566,14 @@ export function SftpBrowser({ sessionId }: SftpBrowserProps) {
         case "download": {
           if (!action.entry) return;
           const localDest = sftp.localPane.path + "/" + action.entry.name;
-          void sftp.downloadFile(action.entry.path, localDest);
+          const isDir =
+            action.entry.fileType === "directory" ||
+            (action.entry.fileType === "symlink" && action.entry.linkTarget === "directory");
+          if (isDir) {
+            void sftp.downloadFolder(action.entry.path, localDest);
+          } else {
+            void sftp.downloadFile(action.entry.path, localDest);
+          }
           break;
         }
         case "rename": {
@@ -849,11 +856,20 @@ export function SftpBrowser({ sessionId }: SftpBrowserProps) {
   }, [localSelected, sftp]);
 
   const handleDownload = useCallback(() => {
-    // Download all selected remote files to local
+    // Download all selected remote files and folders to local
     for (const path of remoteSelected) {
       const entry = sftp.remotePane.entries.find((e) => e.path === path);
-      if (entry && (entry.fileType === "file" || (entry.fileType === "symlink" && entry.linkTarget === "file"))) {
-        const localDest = sftp.localPane.path + "/" + entry.name;
+      if (!entry) continue;
+      const localDest = sftp.localPane.path + "/" + entry.name;
+      const isDir =
+        entry.fileType === "directory" ||
+        (entry.fileType === "symlink" && entry.linkTarget === "directory");
+      const isFile =
+        entry.fileType === "file" ||
+        (entry.fileType === "symlink" && entry.linkTarget === "file");
+      if (isDir) {
+        void sftp.downloadFolder(entry.path, localDest);
+      } else if (isFile) {
         void sftp.downloadFile(entry.path, localDest);
       }
     }
@@ -863,10 +879,17 @@ export function SftpBrowser({ sessionId }: SftpBrowserProps) {
 
   const handleLocalDrop = useCallback(
     (entries: FileEntry[]) => {
-      // Dropped from remote → download
+      // Dropped from remote → download (file or folder)
       for (const entry of entries) {
         const localDest = sftp.localPane.path + "/" + entry.name;
-        void sftp.downloadFile(entry.path, localDest);
+        const isDir =
+          entry.fileType === "directory" ||
+          (entry.fileType === "symlink" && entry.linkTarget === "directory");
+        if (isDir) {
+          void sftp.downloadFolder(entry.path, localDest);
+        } else {
+          void sftp.downloadFile(entry.path, localDest);
+        }
       }
     },
     [sftp],

--- a/src/features/sftp/useSftp.ts
+++ b/src/features/sftp/useSftp.ts
@@ -509,6 +509,49 @@ export function useSftp(sessionId: SessionId, options?: UseSftpOptions) {
     [sessionId, addTransfer, updateProgress, completeTransfer, failTransfer, refreshLocal],
   );
 
+  const downloadFolder = useCallback(
+    async (remotePath: string, localPath: string) => {
+      const channel = new Channel<TransferEvent>();
+
+      channel.onmessage = (message) => {
+        switch (message.event) {
+          case "started":
+            addTransfer({
+              id: message.data.transferId,
+              fileName: message.data.fileName,
+              direction: message.data.direction,
+              totalBytes: message.data.totalBytes,
+              bytesTransferred: 0,
+              status: "active",
+            });
+            break;
+          case "progress":
+            updateProgress(
+              message.data.transferId,
+              message.data.bytesTransferred,
+              message.data.totalBytes,
+            );
+            break;
+          case "completed":
+            completeTransfer(message.data.transferId);
+            refreshLocal();
+            break;
+          case "failed":
+            failTransfer(message.data.transferId, message.data.error);
+            break;
+        }
+      };
+
+      await tauriInvoke<void>("sftp_download_folder", {
+        sessionId,
+        remotePath,
+        localPath,
+        onProgress: channel,
+      });
+    },
+    [sessionId, addTransfer, updateProgress, completeTransfer, failTransfer, refreshLocal],
+  );
+
   return {
     // State
     sftpInitialized,
@@ -552,5 +595,6 @@ export function useSftp(sessionId: SessionId, options?: UseSftpOptions) {
     // Transfers
     uploadFile,
     downloadFile,
+    downloadFolder,
   };
 }


### PR DESCRIPTION
## Summary

- **SFTP folder download** (`feat`): adds recursive download with aggregate byte progress. Right-click a remote folder, use the toolbar, or drag-drop — folders now route through a new `sftp_download_folder` Tauri command that walks the tree, mirrors it locally, and emits one transfer entry instead of one per file. Symlinks are skipped to avoid loops.
- **`fs_secure` module** (`feat`, previously committed): owner-only file writes — included in this branch since it was already ahead of `main`.
- **Version bump** to `0.2.1` across `package.json`, `tauri.conf.json`, and `Cargo.toml`.

## Why now
The current installed app's auto-updater couldn't be validated end-to-end because GitHub had `v0.2.0` and the installed app was `v0.2.0` — same semver, no update offered. Cutting `v0.2.1` lets us actually exercise the updater path against a published, signed release.

## Test plan
- [ ] CI release workflow on `v0.2.1` tag completes successfully across all 4 platforms
- [ ] `latest.json` is published with version `0.2.1` and signed `darwin-aarch64`/`darwin-x86_64` entries
- [ ] Installed v0.2.0 client detects the update via in-app "Check for updates"
- [ ] Right-clicking a remote folder shows "Descargar ⬇" and downloads it recursively with one progress entry
- [ ] Drag-drop a remote folder onto the local pane downloads it
- [ ] Cancel button on an in-flight folder transfer aborts cleanly