### PR TITLE
feat: CI, SSH/vault hardening, MFA + agent auth, vault auto-lock, LAMPLIGHT theme + a11y, startup commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,92 @@
+# ============================================================================
+# CI Workflow for NexTerm
+# ============================================================================
+# Runs on every pull request and on pushes to main, so regressions are caught
+# BEFORE merge (release.yml only runs on version tags).
+#
+#   frontend job → tsc --noEmit (typecheck) + vitest
+#   rust job     → cargo fmt --check + cargo clippy -D warnings + cargo test
+# ============================================================================
+
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+# Cancel superseded runs on the same ref to save CI minutes.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  frontend:
+    name: Frontend (typecheck + tests)
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm exec tsc --noEmit
+
+      - name: Unit tests
+        run: pnpm test
+
+  rust:
+    name: Rust (fmt + clippy + tests)
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: src-tauri
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri -> target
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libgtk-3-dev \
+            libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev
+
+      - name: Format check
+        run: cargo fmt --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Tests
+        run: cargo test

--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>NexTerm</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -75,6 +75,9 @@ zeroize = { version = "1", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+# Unique temp file creation for atomic writes (known_hosts race fix)
+tempfile = "3"
+
 [target."cfg(not(any(target_os = \"android\", target_os = \"ios\")))".dependencies]
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
@@ -92,4 +95,3 @@ windows = { version = "0.61", features = [
 ] }
 
 [dev-dependencies]
-tempfile = "3"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,8 +11,7 @@
     "dialog:allow-message",
     "dialog:allow-ask",
     "fs:default",
-    "fs:allow-read",
-    "fs:allow-write",
+    "fs:allow-temp-meta-recursive",
     "shell:default",
     "updater:default",
     "process:allow-restart"

--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -170,7 +170,12 @@ pub async fn connect(
     handle.username = resolved_user.username.clone();
 
     let auth_result: Result<(), AppError> = async {
-        // Resolve authentication method (pass vault reference for credential lookup)
+        // Resolve authentication method (pass vault reference for credential
+        // lookup). The `auto_lock` reference lets `resolve_auth_method` reset the
+        // idle timer on a genuine stored-credential read, so a user who is
+        // actively (re)connecting with vault credentials is not auto-locked
+        // mid-use — which would make the next connection needing a stored
+        // credential hit `VaultLocked`.
         let vault_guard = state.vault.lock().await;
         let vault_ref = vault_guard.as_ref();
         let auth_method = session::resolve_auth_method(
@@ -178,6 +183,7 @@ pub async fn connect(
             &profile.id,
             password.as_ref().map(|z| z.as_str()),
             vault_ref,
+            Some(&state.auto_lock),
         )?;
         drop(vault_guard);
 
@@ -539,11 +545,13 @@ pub async fn test_connection(
     };
 
     // ── Resolve auth method and authenticate ──
-    // test_connection uses a temp user — no vault lookup needed (password always explicit)
+    // test_connection uses a temp user — no vault lookup needed (password always
+    // explicit), so no vault and no auto-lock recorder are passed.
     let auth = session::resolve_auth_method(
         &temp_user,
         &temp_profile_id,
         password.as_ref().map(|z| z.as_str()),
+        None,
         None,
     )?;
 

--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -358,6 +358,13 @@ pub async fn respond_host_key_verification(
     }
 }
 
+// ─── SSH Key Discovery ──────────────────────────────────────
+
+#[tauri::command]
+pub fn list_ssh_keys() -> Result<Vec<crate::ssh::keys::KeyInfo>, AppError> {
+    crate::ssh::keys::list_available_keys()
+}
+
 // ─── Test Connection ────────────────────────────────────
 
 use crate::state::HostKeyStatus;

--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -476,9 +476,9 @@ pub async fn test_connection(
     // ── TCP + SSH handshake with a known_hosts-verifying handler ──
     // The handler captures the verification result; we inspect it AFTER the
     // handshake to decide whether sending credentials is safe.
-    let config = russh::client::Config {
-        ..Default::default()
-    };
+    // Share the exact same client config (incl. keepalive) as the interactive
+    // path — see `session::build_client_config` for why keepalive matters.
+    let config = session::build_client_config();
     let addr = (host.as_str(), port);
 
     let hk_status: Arc<std::sync::Mutex<Option<HostKeyStatus>>> =

--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -25,7 +25,10 @@ use crate::state::{
 #[derive(Clone, serde::Serialize)]
 #[serde(tag = "event", content = "data", rename_all = "camelCase")]
 pub enum SessionStateEvent {
-    StateChanged { session_id: SessionId, state: SessionState },
+    StateChanged {
+        session_id: SessionId,
+        state: SessionState,
+    },
     HostKeyVerification(HostKeyVerificationRequest),
 }
 
@@ -33,16 +36,19 @@ pub enum SessionStateEvent {
 
 /// We store the response_tx for pending host key verifications
 /// keyed by session_id so the `respond_host_key_verification` command can find it.
-type PendingVerifications =
-    tokio::sync::Mutex<std::collections::HashMap<SessionId, oneshot::Sender<HostKeyVerificationResponse>>>;
+type PendingVerifications = tokio::sync::Mutex<
+    std::collections::HashMap<SessionId, oneshot::Sender<HostKeyVerificationResponse>>,
+>;
 
 /// Lazy-initialized global storage for pending host key verification channels.
 /// This is necessary because the handler's oneshot bridge needs to be accessible
 /// from the `respond_host_key_verification` command.
-static PENDING_HK_VERIFICATIONS: std::sync::OnceLock<PendingVerifications> = std::sync::OnceLock::new();
+static PENDING_HK_VERIFICATIONS: std::sync::OnceLock<PendingVerifications> =
+    std::sync::OnceLock::new();
 
 fn pending_hk() -> &'static PendingVerifications {
-    PENDING_HK_VERIFICATIONS.get_or_init(|| tokio::sync::Mutex::new(std::collections::HashMap::new()))
+    PENDING_HK_VERIFICATIONS
+        .get_or_init(|| tokio::sync::Mutex::new(std::collections::HashMap::new()))
 }
 
 // ─── Commands ───────────────────────────────────────────
@@ -69,14 +75,12 @@ pub async fn connect(
 
     // Resolve which user to connect as
     let resolved_user: UserCredential = match user_id {
-        Some(uid) => {
-            profile
-                .users
-                .iter()
-                .find(|u| u.id == uid)
-                .cloned()
-                .ok_or(AppError::UserNotFound(uid))?
-        }
+        Some(uid) => profile
+            .users
+            .iter()
+            .find(|u| u.id == uid)
+            .cloned()
+            .ok_or(AppError::UserNotFound(uid))?,
         None => {
             if profile.users.len() == 1 {
                 profile.users[0].clone()
@@ -272,16 +276,17 @@ pub async fn connect(
         }
     });
 
-    tracing::info!("Session {session_id} connected to {}:{}", profile.host, profile.port);
+    tracing::info!(
+        "Session {session_id} connected to {}:{}",
+        profile.host,
+        profile.port
+    );
 
     Ok(session_id)
 }
 
 #[tauri::command]
-pub async fn disconnect(
-    state: State<'_, AppState>,
-    session_id: SessionId,
-) -> Result<(), AppError> {
+pub async fn disconnect(state: State<'_, AppState>, session_id: SessionId) -> Result<(), AppError> {
     let mut sessions = state.sessions.lock().await;
     let handle = sessions
         .get_mut(&session_id)
@@ -298,9 +303,7 @@ pub async fn disconnect(
 }
 
 #[tauri::command]
-pub async fn list_sessions(
-    state: State<'_, AppState>,
-) -> Result<Vec<SessionInfo>, AppError> {
+pub async fn list_sessions(state: State<'_, AppState>) -> Result<Vec<SessionInfo>, AppError> {
     let sessions = state.sessions.lock().await;
 
     let infos: Vec<SessionInfo> = sessions

--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -543,7 +543,7 @@ pub async fn test_connection(
     let result: Result<TestConnectionResult, AppError> = match auth {
         Some(session::AuthMethod::Password(pw)) => {
             let authenticated = ssh_handle
-                .authenticate_password(&username, &pw)
+                .authenticate_password(&username, &*pw)
                 .await
                 .map_err(AppError::Ssh)?;
             if authenticated {

--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -758,6 +758,14 @@ pub async fn test_connection(
         Some(session::AuthMethod::KeyboardInteractive(_)) => Err(AppError::KeyboardInteractive(
             "keyboard-interactive auth cannot be tested non-interactively".to_string(),
         )),
+        // `test_connection` builds its auth config from raw form values that map
+        // only to Password / PublicKey, so resolve_auth_method never returns
+        // Agent here. Refuse explicitly (mirrors the KeyboardInteractive arm)
+        // rather than leaving the match non-total — agent auth is exercised
+        // through the live connect path, not the one-shot tester.
+        Some(session::AuthMethod::Agent { .. }) => Err(AppError::Agent(
+            "SSH agent auth cannot be tested non-interactively".to_string(),
+        )),
         None => Err(AppError::AuthFailed(
             "Password or passphrase required".to_string(),
         )),

--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -90,6 +90,53 @@ pub async fn connect(
         }
     };
 
+    // ── Phase 0: Bastion / jump host (ssh -J equivalent, SINGLE hop) ──
+    // When the profile carries a jump_host, reach the target THROUGH the
+    // bastion: connect to the bastion, verify ITS host key against known_hosts
+    // (MITM-critical — never blind-accept), authenticate (credentials zeroized),
+    // and open a direct-tcpip channel to the target. The resulting stream is
+    // handed to `do_handshake`, which then runs the TARGET SSH handshake over it
+    // (target host-key verification still applies). On any bastion-phase failure
+    // we surface a message that is clearly distinct from target-phase errors and
+    // the bastion handle is dropped inside `prepare_bastion_channel`, so nothing
+    // leaks. SCOPE: a single hop only — a bastion does not carry its own jump.
+    let bastion: Option<session::BastionConnection> = match profile.jump_host.as_ref() {
+        Some(jump) => {
+            let vault_guard = state.vault.lock().await;
+            let vault_ref = vault_guard.as_ref();
+            let result = session::prepare_bastion_channel(
+                jump,
+                &profile.host,
+                profile.port,
+                vault_ref,
+                Some(&state.auto_lock),
+            )
+            .await;
+            drop(vault_guard);
+
+            match result {
+                Ok(conn) => Some(conn),
+                Err(err) => {
+                    // Phase 0 fails BEFORE a session id exists, so there is no
+                    // StateChanged event to emit (the frontend has no session to
+                    // key it to). Return a bastion-tagged error that is clearly
+                    // distinct from a target-phase failure.
+                    tracing::warn!(
+                        "Bastion phase failed for {}:{} (target {}:{}) — {err}",
+                        jump.host,
+                        jump.port,
+                        profile.host,
+                        profile.port
+                    );
+                    return Err(AppError::AuthFailed(format!(
+                        "Bastion connection failed: {err}"
+                    )));
+                }
+            }
+        }
+        None => None,
+    };
+
     // ── Phase 1: Prepare connection — extract channels BEFORE handshake ──
     // This is critical: `check_server_key` runs inside `russh::client::connect`
     // and blocks the handshake until the user responds. If we don't wire up the
@@ -125,8 +172,13 @@ pub async fn connect(
         }
     });
 
-    // ── Phase 2: TCP + SSH handshake (triggers check_server_key) ────
-    let handshake_result = session::do_handshake(handshake_handle, &profile).await;
+    // ── Phase 2: SSH handshake to the TARGET (triggers check_server_key) ──
+    // When `bastion` is Some, the handshake runs over the bastion's
+    // direct-tcpip stream and the bastion handle is moved into the resulting
+    // SessionHandle. If the target handshake fails, the consumed
+    // BastionConnection is dropped here (inside do_handshake), tearing down the
+    // bastion hop — no leak.
+    let handshake_result = session::do_handshake(handshake_handle, &profile, bastion).await;
 
     // If handshake failed, clean up HK state and propagate error
     let mut handle = match handshake_result {

--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -16,7 +16,8 @@ use crate::error::AppError;
 use crate::profile::UserCredential;
 use crate::ssh::session;
 use crate::state::{
-    AppState, HostKeyVerificationRequest, HostKeyVerificationResponse, SessionId, SessionInfo,
+    AppState, HostKeyVerificationRequest, HostKeyVerificationResponse,
+    KeyboardInteractiveChallengeRequest, KeyboardInteractiveResponse, SessionId, SessionInfo,
     SessionState,
 };
 
@@ -30,6 +31,7 @@ pub enum SessionStateEvent {
         state: SessionState,
     },
     HostKeyVerification(HostKeyVerificationRequest),
+    KeyboardInteractiveChallenge(KeyboardInteractiveChallengeRequest),
 }
 
 // ─── Pending host key verifications ─────────────────────
@@ -49,6 +51,32 @@ static PENDING_HK_VERIFICATIONS: std::sync::OnceLock<PendingVerifications> =
 fn pending_hk() -> &'static PendingVerifications {
     PENDING_HK_VERIFICATIONS
         .get_or_init(|| tokio::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+// ─── Pending keyboard-interactive challenges ────────────
+
+/// Per-session response sender for the CURRENT keyboard-interactive challenge
+/// round. Mirrors `PendingVerifications`, but the value is re-armed for EACH
+/// challenge round (the bridge's factory replaces the entry before emitting the
+/// next challenge), since one MFA flow can pose several rounds.
+///
+/// Guarded by a *synchronous* `std::sync::Mutex` (not the tokio one used for
+/// host keys): every critical section is a single HashMap insert/remove with no
+/// `.await`, and — crucially — the bridge's response-receiver factory is a
+/// synchronous `FnMut` that must arm a sender without being able to `.await` a
+/// tokio lock. A std mutex is both correct and the only thing callable here.
+type PendingKeyboardInteractiveResponses = std::sync::Mutex<
+    std::collections::HashMap<SessionId, oneshot::Sender<KeyboardInteractiveResponse>>,
+>;
+
+/// Lazy-initialized global storage for the in-flight keyboard-interactive
+/// response channel, keyed by session id. The auth loop arms a fresh sender per
+/// round; `respond_keyboard_interactive_challenge` removes and fires it.
+static PENDING_KI_RESPONSES: std::sync::OnceLock<PendingKeyboardInteractiveResponses> =
+    std::sync::OnceLock::new();
+
+fn pending_ki() -> &'static PendingKeyboardInteractiveResponses {
+    PENDING_KI_RESPONSES.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
 }
 
 // ─── Commands ───────────────────────────────────────────
@@ -221,6 +249,41 @@ pub async fn connect(
     handle.user_id = resolved_user.id;
     handle.username = resolved_user.username.clone();
 
+    // ── Keyboard-interactive (MFA) bridge ──────────────────────────
+    // Built up front so it can be handed to `authenticate`. It only does work if
+    // the resolved method is keyboard-interactive; otherwise the request channel
+    // is simply never used. The bridge mirrors the host-key oneshot pattern but
+    // for MULTIPLE challenge rounds: an mpsc carries each round's challenge to
+    // this command, which forwards it to the frontend as a
+    // `KeyboardInteractiveChallenge` event, and a per-round oneshot (armed by the
+    // factory below, stored in `pending_ki`) carries the answers back.
+    let (ki_request_tx, mut ki_request_rx) =
+        tokio::sync::mpsc::channel::<KeyboardInteractiveChallengeRequest>(1);
+
+    // Factory: arm a fresh response oneshot for the NEXT round, store its sender
+    // in the pending map keyed by session id, return the receiver to the bridge.
+    let ki_session_id = session_id;
+    let ki_response_factory = Box::new(move || {
+        let (tx, rx) = oneshot::channel::<KeyboardInteractiveResponse>();
+        // Synchronous std-mutex insert — no `.await`, safe inside this FnMut.
+        pending_ki().lock().unwrap().insert(ki_session_id, tx);
+        rx
+    });
+
+    let ki_bridge = session::KeyboardInteractiveBridge::new(ki_request_tx, ki_response_factory);
+
+    // Forward each emitted challenge to the frontend (injecting the session id
+    // so the dialog can respond without awaiting the connect promise — mirrors
+    // the host-key request watcher). Lives until the bridge's request sender is
+    // dropped (end of the auth block).
+    let on_event_ki = on_event.clone();
+    let ki_forward_task = tokio::spawn(async move {
+        while let Some(mut request) = ki_request_rx.recv().await {
+            request.session_id = Some(ki_session_id);
+            let _ = on_event_ki.send(SessionStateEvent::KeyboardInteractiveChallenge(request));
+        }
+    });
+
     let auth_result: Result<(), AppError> = async {
         // Resolve authentication method (pass vault reference for credential
         // lookup). The `auto_lock` reference lets `resolve_auth_method` reset the
@@ -247,8 +310,10 @@ pub async fn connect(
                     state: SessionState::Authenticating,
                 });
 
-                // Authenticate with the resolved user's username
-                session::authenticate(&mut handle, auth, &resolved_user.username).await?;
+                // Authenticate with the resolved user's username. The KI bridge
+                // is consumed here; the password/public-key paths ignore it.
+                session::authenticate(&mut handle, auth, &resolved_user.username, Some(ki_bridge))
+                    .await?;
             }
             None => {
                 // Need user input for password/passphrase — return error
@@ -262,6 +327,16 @@ pub async fn connect(
         Ok(())
     }
     .await;
+
+    // ── Tear down the keyboard-interactive bridge ───────────────────
+    // The bridge (and its request sender) was moved into `authenticate`, so by
+    // here the auth attempt has finished and the sender is dropped: the forward
+    // task's `recv()` loop will end on its own. Abort it as a safety net and drop
+    // any still-armed per-round response sender so no entry lingers between
+    // connection attempts (the answers themselves were already zeroized inside
+    // the auth loop).
+    ki_forward_task.abort();
+    pending_ki().lock().unwrap().remove(&session_id);
 
     // ── Handle auth failure: disconnect and propagate error ──────
     if let Err(err) = auth_result {
@@ -412,6 +487,34 @@ pub async fn respond_host_key_verification(
     } else {
         Err(AppError::Other(format!(
             "No pending host key verification for session {session_id}"
+        )))
+    }
+}
+
+/// Deliver the user's answers for the in-flight keyboard-interactive challenge
+/// round back to the awaiting auth loop. Mirrors `respond_host_key_verification`,
+/// but the response carrier holds the per-prompt answers.
+///
+/// SECURITY: the answers are NOT logged here (nor anywhere). They flow straight
+/// into the oneshot the auth loop awaits, which wraps them in `Zeroizing`.
+#[tauri::command]
+pub async fn respond_keyboard_interactive_challenge(
+    session_id: SessionId,
+    responses: KeyboardInteractiveResponse,
+) -> Result<(), AppError> {
+    // Remove the armed sender for THIS round (std-mutex; no `.await` held).
+    let tx = pending_ki().lock().unwrap().remove(&session_id);
+
+    if let Some(tx) = tx {
+        tx.send(responses).map_err(|_| {
+            AppError::KeyboardInteractive(
+                "keyboard-interactive challenge channel already closed".to_string(),
+            )
+        })?;
+        Ok(())
+    } else {
+        Err(AppError::KeyboardInteractive(format!(
+            "no pending keyboard-interactive challenge for session {session_id}"
         )))
     }
 }
@@ -647,6 +750,14 @@ pub async fn test_connection(
                 })
             }
         }
+        // `test_connection` builds its auth config from raw form values that map
+        // only to Password / PublicKey, so resolve_auth_method never returns
+        // KeyboardInteractive here. There is also no challenge dialog to drive in
+        // a one-shot test. Surface that clearly instead of leaving the match
+        // non-total.
+        Some(session::AuthMethod::KeyboardInteractive(_)) => Err(AppError::KeyboardInteractive(
+            "keyboard-interactive auth cannot be tested non-interactively".to_string(),
+        )),
         None => Err(AppError::AuthFailed(
             "Password or passphrase required".to_string(),
         )),

--- a/src-tauri/src/commands/profile.rs
+++ b/src-tauri/src/commands/profile.rs
@@ -231,6 +231,13 @@ impl From<&ConnectionProfile> for ExportedProfile {
                     AuthMethodConfig::KeyboardInteractive => {
                         ("keyboard-interactive".to_string(), None)
                     }
+                    // Agent auth carries no key path — only the optional pin,
+                    // which is non-secret and exported via the token suffix so a
+                    // re-import preserves it (see the import arms below).
+                    AuthMethodConfig::Agent { key_id } => match key_id {
+                        Some(id) => (format!("agent:{id}"), None),
+                        None => ("agent".to_string(), None),
+                    },
                 };
                 ExportedUser {
                     username: u.username.clone(),
@@ -408,6 +415,10 @@ pub async fn import_profiles(
                             passphrase_in_keychain: false,
                         },
                         "keyboard-interactive" => AuthMethodConfig::KeyboardInteractive,
+                        "agent" => AuthMethodConfig::Agent { key_id: None },
+                        other if other.starts_with("agent:") => AuthMethodConfig::Agent {
+                            key_id: Some(other["agent:".len()..].to_string()),
+                        },
                         _ => AuthMethodConfig::Password,
                     };
                     UserCredential {
@@ -436,6 +447,10 @@ pub async fn import_profiles(
                     passphrase_in_keychain: false,
                 },
                 "keyboard-interactive" => AuthMethodConfig::KeyboardInteractive,
+                "agent" => AuthMethodConfig::Agent { key_id: None },
+                other if other.starts_with("agent:") => AuthMethodConfig::Agent {
+                    key_id: Some(other["agent:".len()..].to_string()),
+                },
                 _ => AuthMethodConfig::Password,
             };
             vec![UserCredential {

--- a/src-tauri/src/commands/profile.rs
+++ b/src-tauri/src/commands/profile.rs
@@ -285,14 +285,12 @@ pub async fn export_profiles(
             for (i, profile) in profiles.iter().enumerate() {
                 for (j, user) in profile.users.iter().enumerate() {
                     // Try new key format first, then legacy
-                    if let Ok(Some(password)) =
-                        crate::commands::vault::get_credential_from_vault(
-                            vault,
-                            &profile.id,
-                            Some(&user.id),
-                            "password",
-                        )
-                    {
+                    if let Ok(Some(password)) = crate::commands::vault::get_credential_from_vault(
+                        vault,
+                        &profile.id,
+                        Some(&user.id),
+                        "password",
+                    ) {
                         if j < exported[i].users.len() {
                             exported[i].users[j].password = Some(password);
                         }
@@ -359,9 +357,8 @@ pub async fn import_profiles(
             .map_err(|e| AppError::ProfileError(format!("Invalid file encoding: {e}")))?
     };
 
-    let envelope: ExportEnvelope = serde_json::from_str(&contents).map_err(|e| {
-        AppError::ProfileError(format!("Invalid import file format: {e}"))
-    })?;
+    let envelope: ExportEnvelope = serde_json::from_str(&contents)
+        .map_err(|e| AppError::ProfileError(format!("Invalid import file format: {e}")))?;
 
     if envelope.app != "NexTerm" {
         return Err(AppError::ProfileError(
@@ -379,9 +376,9 @@ pub async fn import_profiles(
 
     for ep in &envelope.profiles {
         // Duplicate check: same name + host
-        let is_duplicate = profiles.iter().any(|existing| {
-            existing.name == ep.name && existing.host == ep.host
-        });
+        let is_duplicate = profiles
+            .iter()
+            .any(|existing| existing.name == ep.name && existing.host == ep.host);
 
         if is_duplicate {
             skipped += 1;
@@ -422,7 +419,10 @@ pub async fn import_profiles(
         } else if let Some(ref username) = ep.username {
             // v1 format: single user from top-level fields
             if username.trim().is_empty() {
-                errors.push(format!("Skipped invalid profile: '{}' (no username)", ep.name));
+                errors.push(format!(
+                    "Skipped invalid profile: '{}' (no username)",
+                    ep.name
+                ));
                 continue;
             }
             let auth_method = match ep.auth_method.as_deref().unwrap_or("password") {
@@ -565,12 +565,16 @@ fn encrypt_export_data(plaintext: &[u8], password: &str) -> Result<Vec<u8>, AppE
 fn decrypt_export_data(data: &[u8], password: &str) -> Result<Vec<u8>, AppError> {
     let header_size = ENCRYPTED_EXPORT_MAGIC.len() + EXPORT_SALT_SIZE + EXPORT_NONCE_SIZE;
     if data.len() < header_size + 16 {
-        return Err(AppError::ProfileError("Encrypted file is too short".to_string()));
+        return Err(AppError::ProfileError(
+            "Encrypted file is too short".to_string(),
+        ));
     }
 
     let magic = &data[..ENCRYPTED_EXPORT_MAGIC.len()];
     if magic != ENCRYPTED_EXPORT_MAGIC {
-        return Err(AppError::ProfileError("Not a valid encrypted export file".to_string()));
+        return Err(AppError::ProfileError(
+            "Not a valid encrypted export file".to_string(),
+        ));
     }
 
     let salt_start = ENCRYPTED_EXPORT_MAGIC.len();
@@ -586,9 +590,9 @@ fn decrypt_export_data(data: &[u8], password: &str) -> Result<Vec<u8>, AppError>
         .map_err(|e| AppError::ProfileError(format!("Cipher init failed: {e}")))?;
 
     let nonce = Nonce::from_slice(nonce_bytes);
-    let plaintext = cipher
-        .decrypt(nonce, ciphertext)
-        .map_err(|_| AppError::ProfileError("Wrong export password or corrupted file".to_string()))?;
+    let plaintext = cipher.decrypt(nonce, ciphertext).map_err(|_| {
+        AppError::ProfileError("Wrong export password or corrupted file".to_string())
+    })?;
 
     Ok(plaintext)
 }

--- a/src-tauri/src/commands/profile.rs
+++ b/src-tauri/src/commands/profile.rs
@@ -457,6 +457,9 @@ pub async fn import_profiles(
             name: ep.name.clone(),
             host: ep.host.clone(),
             port: ep.port,
+            // Imported profiles never carry a bastion config (the export format
+            // does not include one). Bastion setup is configured after import.
+            jump_host: None,
             username: None,
             auth_method: None,
             users: users.clone(),

--- a/src-tauri/src/commands/profile.rs
+++ b/src-tauri/src/commands/profile.rs
@@ -291,7 +291,10 @@ pub async fn export_profiles(
                         "password",
                     ) {
                         if j < exported[i].users.len() {
-                            exported[i].users[j].password = Some(password);
+                            // `password` is a `Zeroizing<String>`; the export format
+                            // requires a plain `String`, so deref into one here (the
+                            // export path intentionally materializes plaintext).
+                            exported[i].users[j].password = Some(password.to_string());
                         }
                     }
                 }

--- a/src-tauri/src/commands/profile.rs
+++ b/src-tauri/src/commands/profile.rs
@@ -479,6 +479,7 @@ pub async fn import_profiles(
             auth_method: None,
             users: users.clone(),
             startup_directory: None,
+            startup_commands: Vec::new(),
             tunnels: Vec::new(),
             display_order: max_order + 1,
             created_at: now,

--- a/src-tauri/src/commands/profile.rs
+++ b/src-tauri/src/commands/profile.rs
@@ -11,7 +11,6 @@ use uuid::Uuid;
 
 use aes_gcm::aead::{Aead, KeyInit, OsRng};
 use aes_gcm::{Aes256Gcm, Nonce};
-use argon2::Argon2;
 use rand::RngCore;
 
 use crate::error::AppError;
@@ -524,13 +523,38 @@ pub async fn import_profiles(
 
 // ─── Encryption Helpers ─────────────────────────────────
 
-/// Derive a 32-byte key from password + salt using Argon2id.
-fn derive_export_key(password: &str, salt: &[u8]) -> Result<[u8; 32], AppError> {
+/// Derive a 32-byte export key from password + salt using the supplied
+/// Argon2id KDF params.
+fn derive_export_key_with(
+    password: &str,
+    salt: &[u8],
+    params: &crate::vault::KdfParams,
+) -> Result<[u8; 32], AppError> {
     let mut key = [0u8; 32];
-    Argon2::default()
+    crate::vault::argon2_from_params(params)
+        .map_err(|e| AppError::ProfileError(format!("Key derivation init failed: {e}")))?
         .hash_password_into(password.as_bytes(), salt, &mut key)
         .map_err(|e| AppError::ProfileError(format!("Key derivation failed: {e}")))?;
     Ok(key)
+}
+
+/// Derive a 32-byte key from password + salt using the same shared KDF params
+/// the credential vault uses (see `vault::default_kdf_params`), so new exports
+/// stay consistent across the app.
+fn derive_export_key(password: &str, salt: &[u8]) -> Result<[u8; 32], AppError> {
+    derive_export_key_with(password, salt, &crate::vault::default_kdf_params())
+}
+
+/// Legacy export KDF params (Argon2 0.5 `Argon2::default()`: m=19456, t=2, p=1)
+/// used by app versions before the shared-params change. Kept only so old
+/// export files remain importable without an on-disk format change.
+fn legacy_export_kdf_params() -> crate::vault::KdfParams {
+    crate::vault::KdfParams {
+        algorithm: "argon2id".to_string(),
+        m_cost: argon2::Params::DEFAULT_M_COST,
+        t_cost: argon2::Params::DEFAULT_T_COST,
+        p_cost: argon2::Params::DEFAULT_P_COST,
+    }
 }
 
 /// Encrypt data for export: MAGIC(4) + salt(32) + nonce(12) + ciphertext.
@@ -584,15 +608,125 @@ fn decrypt_export_data(data: &[u8], password: &str) -> Result<Vec<u8>, AppError>
     let nonce_bytes = &data[nonce_start..nonce_start + EXPORT_NONCE_SIZE];
 
     let ciphertext = &data[nonce_start + EXPORT_NONCE_SIZE..];
+    let nonce = Nonce::from_slice(nonce_bytes);
 
-    let key = derive_export_key(password, salt)?;
+    // Try the current strong KDF params first. AES-GCM authenticates, so a key
+    // derived with the wrong params (or a wrong password) simply fails to
+    // decrypt — making it safe to retry once with the legacy default params so
+    // exports produced by older app versions remain importable. The on-disk
+    // export format is unchanged; only the import side probes both param sets.
+    if let Some(plaintext) = try_decrypt_export(
+        password,
+        salt,
+        nonce,
+        ciphertext,
+        &crate::vault::default_kdf_params(),
+    )? {
+        return Ok(plaintext);
+    }
+
+    if let Some(plaintext) = try_decrypt_export(
+        password,
+        salt,
+        nonce,
+        ciphertext,
+        &legacy_export_kdf_params(),
+    )? {
+        return Ok(plaintext);
+    }
+
+    Err(AppError::ProfileError(
+        "Wrong export password or corrupted file".to_string(),
+    ))
+}
+
+/// Attempt to decrypt an export payload with a key derived from `params`.
+/// Returns `Ok(Some(plaintext))` on success, `Ok(None)` on AEAD failure (so the
+/// caller can fall back to other params), or `Err` only on a non-AEAD error.
+fn try_decrypt_export(
+    password: &str,
+    salt: &[u8],
+    nonce: &aes_gcm::Nonce<aes_gcm::aead::consts::U12>,
+    ciphertext: &[u8],
+    params: &crate::vault::KdfParams,
+) -> Result<Option<Vec<u8>>, AppError> {
+    let key = derive_export_key_with(password, salt, params)?;
     let cipher = Aes256Gcm::new_from_slice(&key)
         .map_err(|e| AppError::ProfileError(format!("Cipher init failed: {e}")))?;
+    Ok(cipher.decrypt(nonce, ciphertext).ok())
+}
 
-    let nonce = Nonce::from_slice(nonce_bytes);
-    let plaintext = cipher.decrypt(nonce, ciphertext).map_err(|_| {
-        AppError::ProfileError("Wrong export password or corrupted file".to_string())
-    })?;
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use argon2::Argon2;
 
-    Ok(plaintext)
+    /// Build a valid RMKT export blob encrypted with a key derived the OLD way
+    /// (legacy `Argon2::default()` params: m=19456, t=2, p=1), matching files
+    /// produced by app versions before the shared-params change.
+    fn make_legacy_export_blob(plaintext: &[u8], password: &str) -> Vec<u8> {
+        let mut salt = [0u8; EXPORT_SALT_SIZE];
+        OsRng.fill_bytes(&mut salt);
+
+        // Legacy key derivation: exactly what the old derive_export_key did.
+        let mut key = [0u8; 32];
+        Argon2::default()
+            .hash_password_into(password.as_bytes(), &salt, &mut key)
+            .unwrap();
+
+        let cipher = Aes256Gcm::new_from_slice(&key).unwrap();
+        let mut nonce_bytes = [0u8; EXPORT_NONCE_SIZE];
+        OsRng.fill_bytes(&mut nonce_bytes);
+        let nonce = Nonce::from_slice(&nonce_bytes);
+        let ciphertext = cipher.encrypt(nonce, plaintext).unwrap();
+
+        let mut blob = Vec::with_capacity(
+            ENCRYPTED_EXPORT_MAGIC.len() + EXPORT_SALT_SIZE + EXPORT_NONCE_SIZE + ciphertext.len(),
+        );
+        blob.extend_from_slice(ENCRYPTED_EXPORT_MAGIC);
+        blob.extend_from_slice(&salt);
+        blob.extend_from_slice(&nonce_bytes);
+        blob.extend_from_slice(&ciphertext);
+        blob
+    }
+
+    #[test]
+    fn import_decrypts_legacy_params_export() {
+        let plaintext = b"legacy-export-payload";
+        let password = "correct-horse";
+        let blob = make_legacy_export_blob(plaintext, password);
+
+        let decrypted = decrypt_export_data(&blob, password).unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn import_decrypts_new_params_export() {
+        let plaintext = b"new-export-payload";
+        let password = "correct-horse";
+        let blob = encrypt_export_data(plaintext, password).unwrap();
+
+        let decrypted = decrypt_export_data(&blob, password).unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn import_rejects_wrong_password_for_legacy_blob() {
+        let blob = make_legacy_export_blob(b"secret", "correct-horse");
+        let result = decrypt_export_data(&blob, "wrong");
+        assert!(
+            matches!(result, Err(AppError::ProfileError(_))),
+            "legacy blob with wrong password must fail, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn import_rejects_wrong_password_for_new_blob() {
+        let blob = encrypt_export_data(b"secret", "correct-horse").unwrap();
+        let result = decrypt_export_data(&blob, "wrong");
+        assert!(
+            matches!(result, Err(AppError::ProfileError(_))),
+            "new blob with wrong password must fail, got {result:?}"
+        );
+    }
 }

--- a/src-tauri/src/commands/sftp.rs
+++ b/src-tauri/src/commands/sftp.rs
@@ -90,6 +90,12 @@ fn open_with_selected_app(path: &Path, app_path: &str) -> Result<(), AppError> {
 
 #[tauri::command]
 pub async fn choose_application(prompt: Option<String>) -> Result<Option<String>, AppError> {
+    // `prompt` is only read by the macOS/Windows chooser blocks below; on other
+    // platforms the function returns Ok(None) without using it.
+    #[cfg_attr(
+        all(not(target_os = "macos"), not(target_os = "windows")),
+        allow(unused_variables)
+    )]
     let prompt = prompt.unwrap_or_else(|| "Choose application".to_string());
 
     #[cfg(target_os = "macos")]

--- a/src-tauri/src/commands/sftp.rs
+++ b/src-tauri/src/commands/sftp.rs
@@ -118,10 +118,10 @@ pub async fn choose_application(prompt: Option<String>) -> Result<Option<String>
             return Ok(None);
         }
 
-        return Err(AppError::Sftp(format!(
+        Err(AppError::Sftp(format!(
             "Failed to choose application: {}",
             stderr.trim()
-        )));
+        )))
     }
 
     #[cfg(target_os = "windows")]
@@ -233,10 +233,7 @@ pub async fn sftp_open(
 
 /// Close the SFTP subsystem.
 #[tauri::command]
-pub async fn sftp_close(
-    state: State<'_, AppState>,
-    session_id: SessionId,
-) -> Result<(), AppError> {
+pub async fn sftp_close(state: State<'_, AppState>, session_id: SessionId) -> Result<(), AppError> {
     let mut sessions = state.sessions.lock().await;
     let handle = sessions
         .get_mut(&session_id)
@@ -244,7 +241,7 @@ pub async fn sftp_close(
 
     if let Some(sftp_handle) = handle.sftp.take() {
         // Cancel all active transfers
-        for (_, transfer) in &sftp_handle.active_transfers {
+        for transfer in sftp_handle.active_transfers.values() {
             transfer.cancel_token.cancel();
         }
         // Close the SFTP session
@@ -677,9 +674,7 @@ pub async fn sftp_cancel_transfer(
         tracing::info!("Cancelled transfer {transfer_id}");
         Ok(())
     } else {
-        Err(AppError::Sftp(format!(
-            "Transfer not found: {transfer_id}"
-        )))
+        Err(AppError::Sftp(format!("Transfer not found: {transfer_id}")))
     }
 }
 
@@ -858,17 +853,14 @@ pub async fn sftp_save_and_reveal(
             .arg("-R")
             .arg(&local)
             .spawn()
-            .map_err(|e| {
-                AppError::Sftp(format!("Failed to reveal file in Finder: {e}"))
-            })?;
+            .map_err(|e| AppError::Sftp(format!("Failed to reveal file in Finder: {e}")))?;
     }
 
     #[cfg(target_os = "windows")]
     {
         if let Some(parent) = local.parent() {
-            open::that(parent).map_err(|e| {
-                AppError::Sftp(format!("Failed to reveal file in Explorer: {e}"))
-            })?;
+            open::that(parent)
+                .map_err(|e| AppError::Sftp(format!("Failed to reveal file in Explorer: {e}")))?;
         }
     }
 
@@ -898,9 +890,7 @@ pub async fn list_local_dir(path: String) -> Result<Vec<FileEntry>, AppError> {
     let dir_path = PathBuf::from(&path);
 
     // Validate path exists and is a directory
-    let metadata = tokio::fs::metadata(&dir_path)
-        .await
-        .map_err(AppError::Io)?;
+    let metadata = tokio::fs::metadata(&dir_path).await.map_err(AppError::Io)?;
 
     if !metadata.is_dir() {
         return Err(AppError::Io(std::io::Error::new(
@@ -910,9 +900,7 @@ pub async fn list_local_dir(path: String) -> Result<Vec<FileEntry>, AppError> {
     }
 
     let mut entries = Vec::new();
-    let mut read_dir = tokio::fs::read_dir(&dir_path)
-        .await
-        .map_err(AppError::Io)?;
+    let mut read_dir = tokio::fs::read_dir(&dir_path).await.map_err(AppError::Io)?;
 
     while let Some(entry) = read_dir.next_entry().await.map_err(AppError::Io)? {
         let entry_name = entry.file_name().to_string_lossy().to_string();
@@ -991,8 +979,7 @@ pub async fn list_local_dir(path: String) -> Result<Vec<FileEntry>, AppError> {
         let (permissions, permissions_str, owner, group) = {
             use std::os::unix::fs::MetadataExt;
             let mode = meta.mode();
-            let perms_str =
-                crate::ssh::sftp::format_unix_permissions(mode, &file_type);
+            let perms_str = crate::ssh::sftp::format_unix_permissions(mode, &file_type);
             (mode, perms_str, Some(meta.uid()), Some(meta.gid()))
         };
 
@@ -1056,18 +1043,11 @@ pub async fn open_local_file(path: String) -> Result<(), AppError> {
     let file_path = std::path::Path::new(&path);
 
     if !file_path.exists() {
-        return Err(AppError::Sftp(format!(
-            "File does not exist: {}",
-            path
-        )));
+        return Err(AppError::Sftp(format!("File does not exist: {}", path)));
     }
 
-    open::that(&path).map_err(|e| {
-        AppError::Sftp(format!(
-            "Failed to open '{}' with system app: {e}",
-            path
-        ))
-    })?;
+    open::that(&path)
+        .map_err(|e| AppError::Sftp(format!("Failed to open '{}' with system app: {e}", path)))?;
 
     tracing::info!("Opened local file with system app: {}", path);
     Ok(())
@@ -1078,10 +1058,7 @@ pub async fn open_local_file_with(path: String, app_path: String) -> Result<(), 
     let file_path = Path::new(&path);
 
     if !file_path.exists() {
-        return Err(AppError::Sftp(format!(
-            "File does not exist: {}",
-            path
-        )));
+        return Err(AppError::Sftp(format!("File does not exist: {}", path)));
     }
 
     open_with_selected_app(file_path, &app_path)?;

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -32,10 +32,7 @@ pub async fn open_terminal(
         return Err(AppError::NotConnected);
     }
 
-    let ssh_handle = session
-        .ssh_handle
-        .as_ref()
-        .ok_or(AppError::NotConnected)?;
+    let ssh_handle = session.ssh_handle.as_ref().ok_or(AppError::NotConnected)?;
 
     // Open PTY channel (includes spawning reader task)
     let terminal_handle = term::open_pty(ssh_handle, cols, rows, on_output).await?;

--- a/src-tauri/src/commands/tunnel.rs
+++ b/src-tauri/src/commands/tunnel.rs
@@ -83,30 +83,16 @@ pub async fn create_tunnel(
                 .get_mut(&session_id)
                 .ok_or(AppError::SessionNotFound(session_id))?;
 
-            let ssh_mut = session
-                .ssh_handle
-                .as_mut()
-                .ok_or(AppError::NotConnected)?;
+            let ssh_mut = session.ssh_handle.as_mut().ok_or(AppError::NotConnected)?;
 
-            let registry = session
-                .remote_forward_registry
-                .clone()
-                .ok_or_else(|| {
-                    AppError::TunnelError(
-                        "Remote forward registry not available".to_string(),
-                    )
-                })?;
+            let registry = session.remote_forward_registry.clone().ok_or_else(|| {
+                AppError::TunnelError("Remote forward registry not available".to_string())
+            })?;
 
             let session_cancel = session.cancel_token.clone();
 
-            tunnel::start_remote_forward(
-                ssh_mut,
-                &config,
-                session_cancel,
-                registry,
-                on_event,
-            )
-            .await?
+            tunnel::start_remote_forward(ssh_mut, &config, session_cancel, registry, on_event)
+                .await?
         }
     };
 
@@ -194,30 +180,16 @@ pub async fn start_tunnel(
                 .get_mut(&session_id)
                 .ok_or(AppError::SessionNotFound(session_id))?;
 
-            let ssh_mut = session
-                .ssh_handle
-                .as_mut()
-                .ok_or(AppError::NotConnected)?;
+            let ssh_mut = session.ssh_handle.as_mut().ok_or(AppError::NotConnected)?;
 
-            let registry = session
-                .remote_forward_registry
-                .clone()
-                .ok_or_else(|| {
-                    AppError::TunnelError(
-                        "Remote forward registry not available".to_string(),
-                    )
-                })?;
+            let registry = session.remote_forward_registry.clone().ok_or_else(|| {
+                AppError::TunnelError("Remote forward registry not available".to_string())
+            })?;
 
             let session_cancel = session.cancel_token.clone();
 
-            tunnel::start_remote_forward(
-                ssh_mut,
-                &config,
-                session_cancel,
-                registry,
-                on_event,
-            )
-            .await?
+            tunnel::start_remote_forward(ssh_mut, &config, session_cancel, registry, on_event)
+                .await?
         }
     };
 
@@ -267,15 +239,11 @@ pub async fn stop_tunnel(
         if let Some(ssh_handle) = session.ssh_handle.as_ref() {
             let addr = &handle.config.bind_host;
             let port = handle.config.bind_port as u32;
-            tracing::debug!(
-                "Tunnel {tunnel_id}: sending cancel_tcpip_forward for {addr}:{port}"
-            );
+            tracing::debug!("Tunnel {tunnel_id}: sending cancel_tcpip_forward for {addr}:{port}");
             if let Err(e) = ssh_handle.cancel_tcpip_forward(addr, port).await {
                 // Log but don't fail — the tunnel stop should proceed regardless.
                 // The server may already be disconnected.
-                tracing::warn!(
-                    "Tunnel {tunnel_id}: cancel_tcpip_forward failed (non-fatal): {e}"
-                );
+                tracing::warn!("Tunnel {tunnel_id}: cancel_tcpip_forward failed (non-fatal): {e}");
             }
         }
     }
@@ -312,9 +280,7 @@ pub async fn remove_tunnel(
             let addr = &handle.config.bind_host;
             let port = handle.config.bind_port as u32;
             if let Err(e) = ssh_handle.cancel_tcpip_forward(addr, port).await {
-                tracing::warn!(
-                    "Tunnel {tunnel_id}: cancel_tcpip_forward failed (non-fatal): {e}"
-                );
+                tracing::warn!("Tunnel {tunnel_id}: cancel_tcpip_forward failed (non-fatal): {e}");
             }
         }
     }
@@ -322,11 +288,7 @@ pub async fn remove_tunnel(
     // Stop if still running
     tunnel::stop_tunnel(&mut handle);
 
-    tracing::info!(
-        "Tunnel {} removed from session {}",
-        tunnel_id,
-        session_id
-    );
+    tracing::info!("Tunnel {} removed from session {}", tunnel_id, session_id);
 
     Ok(())
 }

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -118,9 +118,8 @@ pub async fn vault_reset(
     // 1. Delete the vault file from disk (if it exists)
     let vault_path = data_dir.join("vault.json");
     if vault_path.exists() {
-        std::fs::remove_file(&vault_path).map_err(|e| {
-            AppError::VaultError(format!("Failed to delete vault file: {e}"))
-        })?;
+        std::fs::remove_file(&vault_path)
+            .map_err(|e| AppError::VaultError(format!("Failed to delete vault file: {e}")))?;
     }
     // Also remove any lingering temp file from atomic writes
     let tmp_path = vault_path.with_extension("json.tmp");
@@ -149,9 +148,7 @@ pub async fn store_credential(
     value: String,
 ) -> Result<(), AppError> {
     let mut vault_guard = state.vault.lock().await;
-    let vault = vault_guard
-        .as_mut()
-        .ok_or(AppError::VaultLocked)?;
+    let vault = vault_guard.as_mut().ok_or(AppError::VaultLocked)?;
 
     let key = vault_key(&profile_id, user_id.as_ref(), &credential_type);
     vault.store(&key, &value)
@@ -165,9 +162,7 @@ pub async fn has_credential(
     credential_type: String,
 ) -> Result<bool, AppError> {
     let vault_guard = state.vault.lock().await;
-    let vault = vault_guard
-        .as_ref()
-        .ok_or(AppError::VaultLocked)?;
+    let vault = vault_guard.as_ref().ok_or(AppError::VaultLocked)?;
 
     let key = vault_key(&profile_id, user_id.as_ref(), &credential_type);
     Ok(vault.has(&key))
@@ -181,9 +176,7 @@ pub async fn delete_credential(
     credential_type: String,
 ) -> Result<(), AppError> {
     let mut vault_guard = state.vault.lock().await;
-    let vault = vault_guard
-        .as_mut()
-        .ok_or(AppError::VaultLocked)?;
+    let vault = vault_guard.as_mut().ok_or(AppError::VaultLocked)?;
 
     let key = vault_key(&profile_id, user_id.as_ref(), &credential_type);
     vault.delete(&key)
@@ -217,9 +210,7 @@ pub fn get_credential_from_vault(
             // NOTE: We can't mutate vault here since we only have &Vault.
             // Migration will happen lazily on next store_credential call or
             // can be triggered explicitly. For now, just return the legacy value.
-            tracing::info!(
-                "Found legacy vault key '{legacy}', should be migrated to '{key}'"
-            );
+            tracing::info!("Found legacy vault key '{legacy}', should be migrated to '{key}'");
             return Ok(Some(value));
         }
     }

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -6,6 +6,7 @@
 use serde::Serialize;
 use tauri::{Manager, State};
 use uuid::Uuid;
+use zeroize::Zeroizing;
 
 use crate::error::AppError;
 use crate::state::AppState;
@@ -194,7 +195,7 @@ pub fn get_credential_from_vault(
     profile_id: &Uuid,
     user_id: Option<&Uuid>,
     credential_type: &str,
-) -> Result<Option<String>, AppError> {
+) -> Result<Option<Zeroizing<String>>, AppError> {
     let key = vault_key(profile_id, user_id, credential_type);
 
     // Try new-format key first

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 use zeroize::Zeroizing;
 
 use crate::error::AppError;
-use crate::state::AppState;
+use crate::state::{AppState, AutoLockState};
 use crate::vault::Vault;
 
 // ─── Types ──────────────────────────────────────────────
@@ -19,6 +19,17 @@ use crate::vault::Vault;
 pub struct VaultStatus {
     pub exists: bool,
     pub unlocked: bool,
+    /// True when a vault file exists but is not currently unlocked in memory.
+    /// Mirror of `!unlocked` for an existing vault; surfaced explicitly so the
+    /// future lock UI can distinguish "needs unlock" from "needs creation".
+    pub locked: bool,
+    /// Configured idle auto-lock timeout in seconds (0 = auto-lock disabled).
+    pub idle_timeout_secs: u64,
+    /// Seconds since the last vault activity. Only meaningful while unlocked.
+    pub idle_seconds: u64,
+    /// Seconds remaining before idle auto-lock fires, or `None` when auto-lock
+    /// is disabled (timeout 0). Only meaningful while unlocked.
+    pub seconds_until_lock: Option<u64>,
 }
 
 // ─── Helpers ────────────────────────────────────────────
@@ -58,8 +69,27 @@ pub async fn vault_status(
         .as_ref()
         .map(|v| v.is_unlocked())
         .unwrap_or(false);
+    // Release the vault mutex before touching auto-lock state. They are
+    // independent locks; we never hold both at once, so no ordering hazard with
+    // the background task can arise.
+    drop(vault_guard);
 
-    Ok(VaultStatus { exists, unlocked })
+    Ok(VaultStatus {
+        exists,
+        unlocked,
+        locked: exists && !unlocked,
+        idle_timeout_secs: state.auto_lock.idle_timeout_secs(),
+        idle_seconds: state.auto_lock.idle_seconds(),
+        seconds_until_lock: state.auto_lock.seconds_until_lock(),
+    })
+}
+
+/// Configure the vault idle auto-lock timeout, in seconds. A value of `0`
+/// disables idle auto-lock entirely. Default is 15 minutes (900s).
+#[tauri::command]
+pub async fn vault_set_idle_timeout(state: State<'_, AppState>, secs: u64) -> Result<(), AppError> {
+    state.auto_lock.set_idle_timeout_secs(secs);
+    Ok(())
 }
 
 #[tauri::command]
@@ -78,6 +108,8 @@ pub async fn vault_create(
     let vault = Vault::create(&data_dir, &master_password)?;
     let mut vault_guard = state.vault.lock().await;
     *vault_guard = Some(vault);
+    // Creating leaves the vault unlocked — start the idle clock fresh.
+    state.auto_lock.record_activity();
 
     Ok(())
 }
@@ -94,6 +126,9 @@ pub async fn vault_unlock(
     let vault = Vault::unlock(&data_dir, &master_password)?;
     let mut vault_guard = state.vault.lock().await;
     *vault_guard = Some(vault);
+    // Unlocking is activity — start the idle clock fresh so the vault doesn't
+    // immediately auto-lock against a stale `last_activity`.
+    state.auto_lock.record_activity();
 
     Ok(())
 }
@@ -152,7 +187,9 @@ pub async fn store_credential(
     let vault = vault_guard.as_mut().ok_or(AppError::VaultLocked)?;
 
     let key = vault_key(&profile_id, user_id.as_ref(), &credential_type);
-    vault.store(&key, &value)
+    let result = vault.store(&key, &value);
+    state.auto_lock.record_activity();
+    result
 }
 
 #[tauri::command]
@@ -166,7 +203,9 @@ pub async fn has_credential(
     let vault = vault_guard.as_ref().ok_or(AppError::VaultLocked)?;
 
     let key = vault_key(&profile_id, user_id.as_ref(), &credential_type);
-    Ok(vault.has(&key))
+    let exists = vault.has(&key);
+    state.auto_lock.record_activity();
+    Ok(exists)
 }
 
 #[tauri::command]
@@ -180,7 +219,9 @@ pub async fn delete_credential(
     let vault = vault_guard.as_mut().ok_or(AppError::VaultLocked)?;
 
     let key = vault_key(&profile_id, user_id.as_ref(), &credential_type);
-    vault.delete(&key)
+    let result = vault.delete(&key);
+    state.auto_lock.record_activity();
+    result
 }
 
 /// Internal function: retrieve a credential from the vault.
@@ -219,6 +260,30 @@ pub fn get_credential_from_vault(
     Ok(None)
 }
 
+/// Retrieve a stored credential for SSH auth resolution, recording vault
+/// activity on a successful read so an actively-connecting (read-only) user
+/// does not get auto-locked mid-use.
+///
+/// Wraps [`get_credential_from_vault`] and resets the idle timer **only** when a
+/// stored credential is actually found. A miss (no stored credential — the user
+/// will be prompted) is not "use" and must not reset the timer; an explicitly
+/// provided password never reaches this function, so it never spuriously
+/// extends the idle window either.
+pub fn get_credential_for_auth(
+    vault: &Vault,
+    auto_lock: &AutoLockState,
+    profile_id: &Uuid,
+    user_id: Option<&Uuid>,
+    credential_type: &str,
+) -> Result<Option<Zeroizing<String>>, AppError> {
+    let found = get_credential_from_vault(vault, profile_id, user_id, credential_type)?;
+    if found.is_some() {
+        // A stored credential was read for auth — this is genuine vault use.
+        auto_lock.record_activity();
+    }
+    Ok(found)
+}
+
 /// Delete all credentials for a given profile from the vault.
 pub async fn delete_profile_credentials(
     state: &AppState,
@@ -230,4 +295,102 @@ pub async fn delete_profile_credentials(
         vault.delete_by_prefix(&prefix)?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::AutoLockState;
+    use std::time::{Duration, Instant};
+
+    /// A credential READ for auth (a vault hit) must reset the idle timer so an
+    /// actively-connecting, read-only user is not auto-locked mid-use.
+    #[test]
+    fn credential_read_for_auth_resets_idle_timer_on_hit() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut vault = Vault::create(dir.path(), "correct-horse").unwrap();
+        let profile_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let key = vault_key(&profile_id, Some(&user_id), "password");
+        vault.store(&key, "s3cr3t").unwrap();
+
+        let auto_lock = AutoLockState::default();
+        auto_lock.set_idle_timeout_secs(900);
+        // Place activity deep in the lock-eligible past.
+        let now = Instant::now();
+        auto_lock.record_activity_at(now - Duration::from_secs(901));
+        assert!(
+            auto_lock.should_lock_now(now),
+            "precondition: stale activity should be lock-eligible"
+        );
+
+        let found =
+            get_credential_for_auth(&vault, &auto_lock, &profile_id, Some(&user_id), "password")
+                .unwrap();
+
+        assert_eq!(found.map(|z| z.to_string()), Some("s3cr3t".to_string()));
+        // The read reset the timer: idle elapsed is now tiny, well under timeout.
+        assert!(
+            auto_lock.idle_elapsed_since(Instant::now()) < Duration::from_secs(900),
+            "a successful credential read must reset last_activity"
+        );
+        assert!(
+            !auto_lock.should_lock_now(Instant::now()),
+            "after a credential read the vault must not be lock-eligible"
+        );
+    }
+
+    /// A vault MISS (no stored credential — the user will be prompted) is not
+    /// "use" and must NOT reset the idle timer.
+    #[test]
+    fn credential_read_for_auth_does_not_reset_timer_on_miss() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = Vault::create(dir.path(), "correct-horse").unwrap();
+        let profile_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+
+        let auto_lock = AutoLockState::default();
+        auto_lock.set_idle_timeout_secs(900);
+        let stale = Instant::now() - Duration::from_secs(901);
+        auto_lock.record_activity_at(stale);
+
+        let found =
+            get_credential_for_auth(&vault, &auto_lock, &profile_id, Some(&user_id), "password")
+                .unwrap();
+
+        assert!(found.is_none(), "no credential stored — expected a miss");
+        // The timer was NOT reset: still lock-eligible against the same `now`.
+        let now = Instant::now();
+        assert!(
+            auto_lock.should_lock_now(now),
+            "a vault miss must not reset last_activity"
+        );
+    }
+
+    /// Legacy-key hits also count as vault use and reset the idle timer.
+    #[test]
+    fn credential_read_for_auth_resets_timer_on_legacy_hit() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut vault = Vault::create(dir.path(), "correct-horse").unwrap();
+        let profile_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        // Store under the LEGACY key format (no user_id segment).
+        let legacy = vault_key_legacy(&profile_id, "password");
+        vault.store(&legacy, "s3cr3t").unwrap();
+
+        let auto_lock = AutoLockState::default();
+        auto_lock.set_idle_timeout_secs(900);
+        let now = Instant::now();
+        auto_lock.record_activity_at(now - Duration::from_secs(901));
+
+        let found =
+            get_credential_for_auth(&vault, &auto_lock, &profile_id, Some(&user_id), "password")
+                .unwrap();
+
+        assert_eq!(found.map(|z| z.to_string()), Some("s3cr3t".to_string()));
+        assert!(
+            !auto_lock.should_lock_now(Instant::now()),
+            "a legacy-key credential read must reset last_activity"
+        );
+    }
 }

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -131,7 +131,7 @@ mod tests {
         let id = uuid::Uuid::nil();
         let variants: Vec<AppError> = vec![
             AppError::Sftp("test".into()),
-            AppError::Io(std::io::Error::new(std::io::ErrorKind::Other, "test")),
+            AppError::Io(std::io::Error::other("test")),
             AppError::SessionNotFound(id),
             AppError::NotConnected,
             AppError::AuthFailed("test".into()),

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -31,6 +31,9 @@ pub enum AppError {
     #[error("Keyboard-interactive authentication error: {0}")]
     KeyboardInteractive(String),
 
+    #[error("SSH agent error: {0}")]
+    Agent(String),
+
     #[error("Host key verification failed")]
     HostKeyRejected,
 
@@ -140,10 +143,18 @@ mod tests {
     }
 
     #[test]
+    fn agent_serializes_with_message() {
+        let err = AppError::Agent("no identities in agent".to_string());
+        let serialized = serde_json::to_string(&err).unwrap();
+        assert_eq!(serialized, "\"SSH agent error: no identities in agent\"");
+    }
+
+    #[test]
     fn all_variants_serialize() {
         let id = uuid::Uuid::nil();
         let variants: Vec<AppError> = vec![
             AppError::Sftp("test".into()),
+            AppError::Agent("test".into()),
             AppError::Io(std::io::Error::other("test")),
             AppError::SessionNotFound(id),
             AppError::NotConnected,

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -28,6 +28,9 @@ pub enum AppError {
     #[error("Authentication failed: {0}")]
     AuthFailed(String),
 
+    #[error("Keyboard-interactive authentication error: {0}")]
+    KeyboardInteractive(String),
+
     #[error("Host key verification failed")]
     HostKeyRejected,
 
@@ -127,6 +130,16 @@ mod tests {
     }
 
     #[test]
+    fn keyboard_interactive_serializes_with_message() {
+        let err = AppError::KeyboardInteractive("answer count mismatch".to_string());
+        let serialized = serde_json::to_string(&err).unwrap();
+        assert_eq!(
+            serialized,
+            "\"Keyboard-interactive authentication error: answer count mismatch\""
+        );
+    }
+
+    #[test]
     fn all_variants_serialize() {
         let id = uuid::Uuid::nil();
         let variants: Vec<AppError> = vec![
@@ -135,6 +148,7 @@ mod tests {
             AppError::SessionNotFound(id),
             AppError::NotConnected,
             AppError::AuthFailed("test".into()),
+            AppError::KeyboardInteractive("test".into()),
             AppError::HostKeyRejected,
             AppError::TerminalNotFound(id),
             AppError::TunnelError("test".into()),

--- a/src-tauri/src/fs_secure/mod.rs
+++ b/src-tauri/src/fs_secure/mod.rs
@@ -60,9 +60,7 @@ fn tmp_path_for(path: &Path) -> PathBuf {
 pub fn secure_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
     let tmp = tmp_path_for(path);
 
-    if let Err(e) = std::fs::write(&tmp, bytes) {
-        return Err(e);
-    }
+    std::fs::write(&tmp, bytes)?;
 
     if let Err(e) = platform::set_owner_only(&tmp) {
         let _ = std::fs::remove_file(&tmp);

--- a/src-tauri/src/fs_secure/windows.rs
+++ b/src-tauri/src/fs_secure/windows.rs
@@ -23,9 +23,9 @@ use windows::core::PCWSTR;
 use windows::Win32::Foundation::{CloseHandle, LocalFree, HANDLE, HLOCAL};
 use windows::Win32::Security::Authorization::{SetNamedSecurityInfoW, SE_FILE_OBJECT};
 use windows::Win32::Security::{
-    AddAccessAllowedAceEx, GetLengthSid, GetTokenInformation, InitializeAcl, TokenUser, ACCESS_ALLOWED_ACE,
-    ACL, ACL_REVISION, DACL_SECURITY_INFORMATION, PROTECTED_DACL_SECURITY_INFORMATION, PSID,
-    TOKEN_QUERY, TOKEN_USER,
+    AddAccessAllowedAceEx, GetLengthSid, GetTokenInformation, InitializeAcl, TokenUser,
+    ACCESS_ALLOWED_ACE, ACL, ACL_REVISION, DACL_SECURITY_INFORMATION,
+    PROTECTED_DACL_SECURITY_INFORMATION, PSID, TOKEN_QUERY, TOKEN_USER,
 };
 use windows::Win32::System::Memory::{LocalAlloc, LPTR};
 use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
@@ -82,7 +82,9 @@ pub(super) fn set_owner_only(path: &Path) -> io::Result<()> {
         let _ = GetTokenInformation(token.0, TokenUser, None, 0, &mut needed);
     }
     if needed == 0 {
-        return Err(io::Error::other("GetTokenInformation size query returned 0"));
+        return Err(io::Error::other(
+            "GetTokenInformation size query returned 0",
+        ));
     }
 
     // 3. Allocate the buffer and re-call to fill it.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -64,6 +64,7 @@ pub fn run() {
             commands::connection::get_session_state,
             commands::connection::respond_host_key_verification,
             commands::connection::test_connection,
+            commands::connection::list_ssh_keys,
             // Terminal
             commands::terminal::open_terminal,
             commands::terminal::write_terminal,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -144,6 +144,7 @@ pub fn run() {
             commands::connection::list_sessions,
             commands::connection::get_session_state,
             commands::connection::respond_host_key_verification,
+            commands::connection::respond_keyboard_interactive_challenge,
             commands::connection::test_connection,
             commands::connection::list_ssh_keys,
             // Terminal

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,7 +15,78 @@ pub mod ssh;
 pub mod state;
 pub mod vault;
 
-use state::AppState;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use state::{AppState, AutoLockState};
+use tokio::sync::Mutex;
+use vault::{suspend_gap_detected, Vault};
+
+/// How often the background auto-lock task wakes up to check idle/suspend.
+const AUTO_LOCK_TICK: Duration = Duration::from_secs(15);
+
+/// Tolerated scheduling jitter on top of [`AUTO_LOCK_TICK`] before a tick gap is
+/// treated as an OS suspend. Generous enough to absorb a stalled/overloaded
+/// event loop without false-locking, tight enough that real sleep (seconds to
+/// hours of frozen wall time) is always caught.
+const SUSPEND_SLACK: Duration = Duration::from_secs(20);
+
+/// Lock the vault in `AppState` if it is currently unlocked, zeroizing the
+/// derived key. Idempotent: safe to call when already locked or absent. This is
+/// the single lock path shared by manual lock, idle timeout, and suspend.
+async fn lock_vault(vault: &Mutex<Option<Vault>>) {
+    let mut guard = vault.lock().await;
+    if let Some(v) = guard.as_mut() {
+        if v.is_unlocked() {
+            v.lock(); // drops the Zeroizing<[u8;32]>, wiping key material
+            tracing::info!("Vault auto-locked");
+        }
+    }
+}
+
+/// Spawn the background idle/suspend auto-lock task.
+///
+/// The task wakes every [`AUTO_LOCK_TICK`] and:
+///  1. Detects OS suspend by the *monotonic-clock gap* heuristic. Tauri 2.10's
+///     `RunEvent` exposes no OS suspend/resume signal (only winit-level
+///     `Resumed`, which is a rendering-lifecycle event, not power management),
+///     so we infer suspension: while the machine sleeps this task is frozen, so
+///     on wake the elapsed gap between ticks far exceeds the tick interval.
+///     `suspend_gap_detected` turns that into a defensive immediate lock.
+///  2. Otherwise applies the idle-timeout policy via `AutoLockState`.
+///
+/// It does nothing while the vault is locked or absent (the lock call is a
+/// no-op). Cleanly stops with the app: it is a detached task on Tauri's async
+/// runtime which is torn down on exit — it never panics on shutdown because it
+/// only ever locks (idempotent) and reads atomics/mutexes that outlive it for
+/// the process lifetime via `Arc`.
+pub fn spawn_auto_lock_task(vault: Arc<Mutex<Option<Vault>>>, auto_lock: Arc<AutoLockState>) {
+    tauri::async_runtime::spawn(async move {
+        let mut last_tick = Instant::now();
+        loop {
+            tokio::time::sleep(AUTO_LOCK_TICK).await;
+
+            let now = Instant::now();
+            let gap = now.saturating_duration_since(last_tick);
+            last_tick = now;
+
+            // Suspend heuristic: a tick gap far larger than expected means wall
+            // time was lost while we were frozen — lock defensively, immediately.
+            if suspend_gap_detected(gap, AUTO_LOCK_TICK, SUSPEND_SLACK) {
+                tracing::info!("Detected clock gap of {gap:?} (likely OS suspend) — locking vault");
+                lock_vault(&vault).await;
+                // Treat resume as fresh: don't also fire an idle lock on the
+                // same tick using a now-stale activity timestamp.
+                continue;
+            }
+
+            // Idle policy. `should_lock_now` already honors timeout==0 (disabled).
+            if auto_lock.should_lock_now(now) {
+                lock_vault(&vault).await;
+            }
+        }
+    });
+}
 
 /// Initialize and run the Tauri application
 pub fn run() {
@@ -26,19 +97,28 @@ pub fn run() {
         )
         .init();
 
+    let app_state = AppState::default();
+    // Clone the shared handles the background auto-lock task needs *before*
+    // `manage` takes ownership of the state.
+    let vault_handle = Arc::clone(&app_state.vault);
+    let auto_lock_handle = Arc::clone(&app_state.auto_lock);
+
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_shell::init())
-        .setup(|app| {
+        .setup(move |app| {
             #[cfg(desktop)]
             app.handle()
                 .plugin(tauri_plugin_updater::Builder::new().build())?;
             #[cfg(desktop)]
             app.handle().plugin(tauri_plugin_process::init())?;
+
+            // Start the idle/suspend auto-lock watchdog.
+            spawn_auto_lock_task(Arc::clone(&vault_handle), Arc::clone(&auto_lock_handle));
             Ok(())
         })
-        .manage(AppState::default())
+        .manage(app_state)
         .invoke_handler(tauri::generate_handler![
             // Profile CRUD
             commands::profile::save_profile,
@@ -53,6 +133,7 @@ pub fn run() {
             commands::vault::vault_create,
             commands::vault::vault_unlock,
             commands::vault::vault_lock,
+            commands::vault::vault_set_idle_timeout,
             commands::vault::vault_reset,
             commands::vault::store_credential,
             commands::vault::has_credential,

--- a/src-tauri/src/profile.rs
+++ b/src-tauri/src/profile.rs
@@ -160,6 +160,20 @@ pub enum AuthMethodConfig {
     },
     /// Keyboard-interactive auth
     KeyboardInteractive,
+    /// SSH agent auth — the running ssh-agent holds the private key(s) and
+    /// performs the signing; no key material is ever read or stored by us.
+    ///
+    /// Backward-compat: this is a NEW enum variant, so profiles written before
+    /// it existed never carried it and are unaffected. `key_id` is an OPTIONAL
+    /// pin used to narrow auth to a single agent identity when the agent holds
+    /// several. It accepts either the key's SHA-256 fingerprint (`SHA256:...`,
+    /// matching [`crate::ssh::known_hosts::fingerprint`]) or its comment. When
+    /// absent (the common case), every agent identity is tried OpenSSH-style.
+    /// `#[serde(default)]` lets the minimal marker `{"type":"agent"}` load.
+    Agent {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        key_id: Option<String>,
+    },
 }
 
 impl Default for ConnectionProfile {
@@ -386,6 +400,100 @@ mod tests {
         let json = serde_json::to_string(&auth).unwrap();
         assert!(json.contains("\"type\":\"publicKey\""));
         assert!(json.contains("privateKeyPath"));
+    }
+
+    #[test]
+    fn agent_auth_serializes_with_type_tag() {
+        // A bare agent marker (no pinned key) serializes with the discriminant
+        // and omits keyId (skip_serializing_if keeps the JSON clean).
+        let auth = AuthMethodConfig::Agent { key_id: None };
+        let json = serde_json::to_string(&auth).unwrap();
+        assert!(json.contains("\"type\":\"agent\""), "got: {json}");
+        assert!(
+            !json.contains("keyId"),
+            "keyId must be omitted when None, got: {json}"
+        );
+    }
+
+    #[test]
+    fn agent_auth_with_pinned_key_roundtrips() {
+        let auth = AuthMethodConfig::Agent {
+            key_id: Some("SHA256:abc123".to_string()),
+        };
+        let json = serde_json::to_string(&auth).unwrap();
+        assert!(json.contains("\"type\":\"agent\""), "got: {json}");
+        assert!(json.contains("keyId"), "got: {json}");
+
+        let back: AuthMethodConfig = serde_json::from_str(&json).unwrap();
+        match back {
+            AuthMethodConfig::Agent { key_id } => {
+                assert_eq!(key_id, Some("SHA256:abc123".to_string()));
+            }
+            _ => panic!("expected Agent variant"),
+        }
+    }
+
+    #[test]
+    fn agent_auth_bare_marker_deserializes_without_key_id() {
+        // Backward-compat: an agent config written without keyId (the minimal
+        // marker form) must still deserialize, with key_id defaulting to None.
+        let json = r#"{"type":"agent"}"#;
+        let back: AuthMethodConfig = serde_json::from_str(json).unwrap();
+        match back {
+            AuthMethodConfig::Agent { key_id } => assert_eq!(key_id, None),
+            _ => panic!("expected Agent variant"),
+        }
+    }
+
+    #[test]
+    fn profile_with_agent_user_validates() {
+        // A profile whose user authenticates via the agent is valid; the agent
+        // marker carries no secret to validate.
+        let profile = ConnectionProfile {
+            name: "Agent Host".to_string(),
+            host: "example.com".to_string(),
+            users: vec![UserCredential {
+                id: Uuid::new_v4(),
+                username: "deploy".to_string(),
+                auth_method: AuthMethodConfig::Agent { key_id: None },
+                is_default: true,
+            }],
+            ..ConnectionProfile::default()
+        };
+        assert!(profile.validate().is_ok());
+    }
+
+    #[test]
+    fn profile_with_agent_user_roundtrips_on_disk() {
+        let dir = std::env::temp_dir().join(format!("agent_profile_test_{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let profiles = vec![ConnectionProfile {
+            name: "Agent Host".to_string(),
+            host: "agent.example.com".to_string(),
+            users: vec![UserCredential {
+                id: Uuid::new_v4(),
+                username: "deploy".to_string(),
+                auth_method: AuthMethodConfig::Agent {
+                    key_id: Some("my-laptop-key".to_string()),
+                },
+                is_default: true,
+            }],
+            ..ConnectionProfile::default()
+        }];
+
+        save_profiles_to_disk(&profiles, Some(&dir)).unwrap();
+        let loaded = load_profiles_from_disk(Some(&dir)).unwrap();
+
+        assert_eq!(loaded.len(), 1);
+        match &loaded[0].users[0].auth_method {
+            AuthMethodConfig::Agent { key_id } => {
+                assert_eq!(key_id.as_deref(), Some("my-laptop-key"));
+            }
+            other => panic!("expected Agent auth, got {other:?}"),
+        }
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src-tauri/src/profile.rs
+++ b/src-tauri/src/profile.rs
@@ -135,6 +135,8 @@ pub struct ConnectionProfile {
     #[serde(default)]
     pub users: Vec<UserCredential>,
     pub startup_directory: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub startup_commands: Vec<String>,
     pub tunnels: Vec<TunnelConfig>,
     #[serde(default)]
     pub display_order: i32,
@@ -188,6 +190,7 @@ impl Default for ConnectionProfile {
             auth_method: None,
             users: Vec::new(),
             startup_directory: None,
+            startup_commands: Vec::new(),
             tunnels: Vec::new(),
             display_order: 0,
             created_at: Utc::now(),
@@ -845,6 +848,62 @@ mod tests {
             auth_method: JumpAuthConfig::Password,
         });
         assert!(profile.validate().is_ok());
+    }
+
+    #[test]
+    fn startup_commands_roundtrips_on_disk() {
+        let dir = std::env::temp_dir().join(format!("startup_cmds_test_{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let profiles = vec![ConnectionProfile {
+            name: "Startup Server".to_string(),
+            host: "startup.example.com".to_string(),
+            users: vec![UserCredential {
+                id: Uuid::new_v4(),
+                username: "deploy".to_string(),
+                auth_method: AuthMethodConfig::Password,
+                is_default: true,
+            }],
+            startup_commands: vec!["ls -la".to_string(), "uptime".to_string()],
+            ..ConnectionProfile::default()
+        }];
+
+        save_profiles_to_disk(&profiles, Some(&dir)).unwrap();
+        let loaded = load_profiles_from_disk(Some(&dir)).unwrap();
+
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].startup_commands, vec!["ls -la", "uptime"]);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn old_profile_without_startup_commands_defaults_empty() {
+        // A profile written before startup_commands existed must deserialize
+        // cleanly with an empty vec (via #[serde(default)]).
+        let old_json = r#"{
+            "id": "00000000-0000-0000-0000-000000000010",
+            "name": "Pre-startup Server",
+            "host": "legacy.example.com",
+            "port": 22,
+            "users": [{
+                "id": "00000000-0000-0000-0000-000000000011",
+                "username": "root",
+                "authMethod": {"type": "password"},
+                "isDefault": true
+            }],
+            "startupDirectory": null,
+            "tunnels": [],
+            "displayOrder": 0,
+            "createdAt": "2024-01-01T00:00:00Z",
+            "updatedAt": "2024-01-01T00:00:00Z"
+        }"#;
+
+        let profile: ConnectionProfile = serde_json::from_str(old_json).unwrap();
+        assert!(
+            profile.startup_commands.is_empty(),
+            "startup_commands must default to empty for old profiles"
+        );
     }
 
     #[test]

--- a/src-tauri/src/profile.rs
+++ b/src-tauri/src/profile.rs
@@ -27,6 +27,87 @@ pub struct UserCredential {
     pub is_default: bool,
 }
 
+// ─── Proxy Jump (Bastion) Config ────────────────────────
+
+/// Authentication for a bastion / jump host.
+///
+/// This intentionally mirrors the shape of [`AuthMethodConfig`] (the persisted
+/// per-user auth config) so the bastion auth path can reuse the exact same
+/// credential-resolution logic as the main host. Secrets are NEVER stored here
+/// — only metadata. A password is fetched from the encrypted vault at connect
+/// time, keyed by the jump host's stable [`ProxyJumpConfig::id`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(
+    tag = "type",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum JumpAuthConfig {
+    /// Password fetched from the vault at connect time.
+    #[default]
+    Password,
+    /// Public key auth — passphrase may be stored in the vault.
+    PublicKey {
+        private_key_path: String,
+        #[serde(default)]
+        passphrase_in_keychain: bool,
+    },
+}
+
+/// An OPTIONAL single bastion / jump host that the target is reached through
+/// (the `ssh -J` equivalent). SCOPE: single hop only. A bastion does NOT carry
+/// its own nested `jump_host` — chained jumps are explicitly out of scope and
+/// guarded (see [`ProxyJumpConfig::validate`]).
+///
+/// Backward compatibility: a `ConnectionProfile` stores this behind
+/// `#[serde(default)] jump_host: Option<ProxyJumpConfig>`, so existing
+/// `profiles.json` files that predate this field still deserialize cleanly.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProxyJumpConfig {
+    /// Stable identifier used as the vault key namespace for the bastion's
+    /// credentials. Defaulted on deserialization of profiles written before the
+    /// id existed so older single-field jump configs still load.
+    #[serde(default = "Uuid::new_v4")]
+    pub id: Uuid,
+    /// Bastion hostname or IP.
+    pub host: String,
+    /// Bastion SSH port.
+    #[serde(default = "default_ssh_port")]
+    pub port: u16,
+    /// SSH username on the bastion.
+    pub user: String,
+    /// How to authenticate to the bastion.
+    #[serde(default)]
+    pub auth_method: JumpAuthConfig,
+}
+
+fn default_ssh_port() -> u16 {
+    22
+}
+
+impl ProxyJumpConfig {
+    /// Validate the bastion config. Pure and side-effect free.
+    pub fn validate(&self) -> Result<(), AppError> {
+        if self.host.trim().is_empty() {
+            return Err(AppError::ProfileError(
+                "jump host hostname is required".to_string(),
+            ));
+        }
+        if self.port == 0 {
+            return Err(AppError::ProfileError(
+                "jump host port must be > 0".to_string(),
+            ));
+        }
+        if self.user.trim().is_empty() {
+            return Err(AppError::ProfileError(
+                "jump host username is required".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
 // ─── Connection Profile ─────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -36,6 +117,11 @@ pub struct ConnectionProfile {
     pub name: String,
     pub host: String,
     pub port: u16,
+    /// OPTIONAL bastion / jump host (single hop, `ssh -J` equivalent).
+    /// `#[serde(default)]` keeps pre-existing profiles (written before this
+    /// field) deserializing without error.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub jump_host: Option<ProxyJumpConfig>,
     /// Legacy field — only used for backward-compatible deserialization of old profiles.
     /// New profiles store credentials in the `users` array.
     #[serde(default, skip_serializing)]
@@ -83,6 +169,7 @@ impl Default for ConnectionProfile {
             name: String::new(),
             host: String::new(),
             port: 22,
+            jump_host: None,
             username: None,
             auth_method: None,
             users: Vec::new(),
@@ -156,6 +243,10 @@ impl ConnectionProfile {
             return Err(AppError::ProfileError(
                 "only one default user allowed".to_string(),
             ));
+        }
+        // Validate the optional bastion / jump host, if present.
+        if let Some(ref jump) = self.jump_host {
+            jump.validate()?;
         }
         Ok(())
     }
@@ -438,6 +529,214 @@ mod tests {
         assert!(profiles[0].users[0].is_default);
         assert!(profiles[0].username.is_none());
         assert!(profiles[0].auth_method.is_none());
+    }
+
+    // ─── ProxyJump / Bastion tests ──────────────────────────────────
+
+    #[test]
+    fn old_profile_without_jump_host_deserializes() {
+        // A profile written before the jump_host field existed must still
+        // deserialize cleanly (jump_host defaults to None).
+        let old_json = r#"{
+            "id": "00000000-0000-0000-0000-000000000002",
+            "name": "Pre-bastion Server",
+            "host": "legacy.example.com",
+            "port": 22,
+            "users": [{
+                "id": "00000000-0000-0000-0000-000000000003",
+                "username": "deploy",
+                "authMethod": {"type": "password"},
+                "isDefault": true
+            }],
+            "startupDirectory": null,
+            "tunnels": [],
+            "displayOrder": 0,
+            "createdAt": "2024-01-01T00:00:00Z",
+            "updatedAt": "2024-01-01T00:00:00Z"
+        }"#;
+
+        let profile: ConnectionProfile = serde_json::from_str(old_json).unwrap();
+        assert!(
+            profile.jump_host.is_none(),
+            "missing jumpHost field must default to None"
+        );
+        assert_eq!(profile.users.len(), 1);
+    }
+
+    #[test]
+    fn old_profiles_array_without_jump_host_loads() {
+        // The on-disk format is a JSON array. An array of old-format profiles
+        // (no jumpHost) must load without error via the same path as new ones.
+        let old_array = r#"[{
+            "id": "00000000-0000-0000-0000-000000000004",
+            "name": "Old A",
+            "host": "a.example.com",
+            "port": 22,
+            "users": [{
+                "id": "00000000-0000-0000-0000-000000000005",
+                "username": "root",
+                "authMethod": {"type": "password"},
+                "isDefault": true
+            }],
+            "startupDirectory": null,
+            "tunnels": [],
+            "displayOrder": 0,
+            "createdAt": "2024-01-01T00:00:00Z",
+            "updatedAt": "2024-01-01T00:00:00Z"
+        }]"#;
+
+        let profiles: Vec<ConnectionProfile> = serde_json::from_str(old_array).unwrap();
+        assert_eq!(profiles.len(), 1);
+        assert!(profiles[0].jump_host.is_none());
+    }
+
+    #[test]
+    fn profile_with_jump_host_roundtrips() {
+        let mut profile = test_profile("Behind Bastion", "10.0.0.5", "deploy");
+        let jump_id = Uuid::new_v4();
+        profile.jump_host = Some(ProxyJumpConfig {
+            id: jump_id,
+            host: "bastion.example.com".to_string(),
+            port: 2222,
+            user: "jumpuser".to_string(),
+            auth_method: JumpAuthConfig::PublicKey {
+                private_key_path: "~/.ssh/id_ed25519".to_string(),
+                passphrase_in_keychain: true,
+            },
+        });
+
+        let json = serde_json::to_string(&profile).unwrap();
+        assert!(json.contains("jumpHost"));
+        assert!(json.contains("bastion.example.com"));
+
+        let back: ConnectionProfile = serde_json::from_str(&json).unwrap();
+        let jump = back.jump_host.expect("jump host must survive roundtrip");
+        assert_eq!(jump.id, jump_id);
+        assert_eq!(jump.host, "bastion.example.com");
+        assert_eq!(jump.port, 2222);
+        assert_eq!(jump.user, "jumpuser");
+        assert_eq!(
+            jump.auth_method,
+            JumpAuthConfig::PublicKey {
+                private_key_path: "~/.ssh/id_ed25519".to_string(),
+                passphrase_in_keychain: true,
+            }
+        );
+    }
+
+    #[test]
+    fn jump_host_omitted_from_json_when_none() {
+        // skip_serializing_if keeps clean JSON for the common no-bastion case.
+        let profile = test_profile("No Bastion", "example.com", "user");
+        let json = serde_json::to_string(&profile).unwrap();
+        assert!(
+            !json.contains("jumpHost"),
+            "jumpHost must be omitted when None, got: {json}"
+        );
+    }
+
+    #[test]
+    fn jump_config_defaults_port_to_22() {
+        // A jump config missing the port field defaults to 22 (default_ssh_port).
+        let json = r#"{
+            "id": "00000000-0000-0000-0000-000000000006",
+            "host": "bastion.example.com",
+            "user": "jumpuser",
+            "authMethod": {"type": "password"}
+        }"#;
+        let jump: ProxyJumpConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(jump.port, 22);
+        assert_eq!(jump.auth_method, JumpAuthConfig::Password);
+    }
+
+    #[test]
+    fn jump_config_defaults_id_when_missing() {
+        // A jump config written before the id field existed still loads (id is
+        // freshly generated via default).
+        let json = r#"{
+            "host": "bastion.example.com",
+            "port": 22,
+            "user": "jumpuser",
+            "authMethod": {"type": "password"}
+        }"#;
+        let jump: ProxyJumpConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(jump.host, "bastion.example.com");
+        // id must be non-nil (freshly generated)
+        assert_ne!(jump.id, Uuid::nil());
+    }
+
+    #[test]
+    fn jump_config_validate_rejects_empty_host() {
+        let jump = ProxyJumpConfig {
+            id: Uuid::new_v4(),
+            host: "  ".to_string(),
+            port: 22,
+            user: "jumpuser".to_string(),
+            auth_method: JumpAuthConfig::Password,
+        };
+        assert!(jump.validate().is_err());
+    }
+
+    #[test]
+    fn jump_config_validate_rejects_zero_port() {
+        let jump = ProxyJumpConfig {
+            id: Uuid::new_v4(),
+            host: "bastion.example.com".to_string(),
+            port: 0,
+            user: "jumpuser".to_string(),
+            auth_method: JumpAuthConfig::Password,
+        };
+        assert!(jump.validate().is_err());
+    }
+
+    #[test]
+    fn jump_config_validate_rejects_empty_user() {
+        let jump = ProxyJumpConfig {
+            id: Uuid::new_v4(),
+            host: "bastion.example.com".to_string(),
+            port: 22,
+            user: "".to_string(),
+            auth_method: JumpAuthConfig::Password,
+        };
+        assert!(jump.validate().is_err());
+    }
+
+    #[test]
+    fn jump_config_validate_accepts_valid() {
+        let jump = ProxyJumpConfig {
+            id: Uuid::new_v4(),
+            host: "bastion.example.com".to_string(),
+            port: 22,
+            user: "jumpuser".to_string(),
+            auth_method: JumpAuthConfig::Password,
+        };
+        assert!(jump.validate().is_ok());
+    }
+
+    #[test]
+    fn profile_validate_rejects_invalid_jump_host() {
+        let mut profile = test_profile("Bad Bastion", "10.0.0.5", "deploy");
+        profile.jump_host = Some(ProxyJumpConfig {
+            id: Uuid::new_v4(),
+            host: "".to_string(), // invalid
+            port: 22,
+            user: "jumpuser".to_string(),
+            auth_method: JumpAuthConfig::Password,
+        });
+        assert!(profile.validate().is_err());
+    }
+
+    #[test]
+    fn profile_validate_accepts_valid_jump_host() {
+        let mut profile = test_profile("Good Bastion", "10.0.0.5", "deploy");
+        profile.jump_host = Some(ProxyJumpConfig {
+            id: Uuid::new_v4(),
+            host: "bastion.example.com".to_string(),
+            port: 22,
+            user: "jumpuser".to_string(),
+            auth_method: JumpAuthConfig::Password,
+        });
+        assert!(profile.validate().is_ok());
     }
 
     #[test]

--- a/src-tauri/src/ssh/handler.rs
+++ b/src-tauri/src/ssh/handler.rs
@@ -13,17 +13,17 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use russh::client::DisconnectReason;
 use russh::client::Handler;
 use russh::client::Msg;
 use russh::keys::ssh_key::PublicKey;
-use russh::client::DisconnectReason;
 use russh::{Channel, ChannelId};
 use tokio::sync::{mpsc, oneshot, Mutex};
 
 use crate::ssh::known_hosts;
 use crate::ssh::tunnel::{
-    handle_remote_forward_connection, RemoteForwardKey, RemoteForwardRegistry,
-    new_remote_forward_registry,
+    handle_remote_forward_connection, new_remote_forward_registry, RemoteForwardKey,
+    RemoteForwardRegistry,
 };
 use crate::state::{HostKeyStatus, HostKeyVerificationRequest, HostKeyVerificationResponse};
 
@@ -105,11 +105,7 @@ impl SshClientHandler {
     }
 
     /// Register a data sender for a channel
-    pub async fn register_channel_sender(
-        &self,
-        channel_id: ChannelId,
-        sender: ChannelDataSender,
-    ) {
+    pub async fn register_channel_sender(&self, channel_id: ChannelId, sender: ChannelDataSender) {
         let mut senders = self.channel_senders.lock().await;
         senders.insert(channel_id, sender);
     }
@@ -137,13 +133,12 @@ impl Handler for SshClientHandler {
         &mut self,
         server_public_key: &PublicKey,
     ) -> Result<bool, Self::Error> {
-        let status =
-            known_hosts::verify_host_key(&self.host, self.port, server_public_key)
-                .map_err(|e| {
-                    russh::Error::Keys(russh::keys::Error::from(
-                        std::io::Error::other(e.to_string()),
-                    ))
-                })?;
+        let status = known_hosts::verify_host_key(&self.host, self.port, server_public_key)
+            .map_err(|e| {
+                russh::Error::Keys(russh::keys::Error::from(std::io::Error::other(
+                    e.to_string(),
+                )))
+            })?;
 
         match &status {
             HostKeyStatus::Trusted => {
@@ -256,13 +251,8 @@ impl Handler for SshClientHandler {
                 // Spawn a task to handle the connection
                 let orig_addr = originator_address.to_string();
                 tokio::spawn(async move {
-                    handle_remote_forward_connection(
-                        channel,
-                        entry,
-                        orig_addr,
-                        originator_port,
-                    )
-                    .await;
+                    handle_remote_forward_connection(channel, entry, orig_addr, originator_port)
+                        .await;
                 });
                 Ok(())
             }

--- a/src-tauri/src/ssh/keys.rs
+++ b/src-tauri/src/ssh/keys.rs
@@ -81,9 +81,8 @@ pub fn list_available_keys() -> Result<Vec<KeyInfo>, AppError> {
 
     let mut keys = Vec::new();
 
-    let entries = std::fs::read_dir(&ssh_dir).map_err(|e| {
-        AppError::KeyError(format!("Failed to read ~/.ssh/ directory: {e}"))
-    })?;
+    let entries = std::fs::read_dir(&ssh_dir)
+        .map_err(|e| AppError::KeyError(format!("Failed to read ~/.ssh/ directory: {e}")))?;
 
     for entry in entries {
         let entry = match entry {
@@ -140,7 +139,8 @@ fn identify_key(contents: &str, path: &Path) -> Option<KeyInfo> {
         }
         Err(_) => {
             // Could be encrypted — check for the marker
-            if contents.contains("ENCRYPTED") || contents.contains("aes256-ctr")
+            if contents.contains("ENCRYPTED")
+                || contents.contains("aes256-ctr")
                 || contents.contains("bcrypt")
             {
                 // Encrypted key — we can tell the type from the header sometimes

--- a/src-tauri/src/ssh/keys.rs
+++ b/src-tauri/src/ssh/keys.rs
@@ -7,6 +7,7 @@
 use std::path::{Path, PathBuf};
 
 use ssh_key::PrivateKey;
+use zeroize::Zeroizing;
 
 use crate::error::AppError;
 
@@ -28,9 +29,12 @@ pub fn load_private_key(path: &Path, passphrase: Option<&str>) -> Result<Private
         )));
     }
 
-    let key_data = std::fs::read_to_string(path).map_err(|e| {
+    // Read the key file into a `Zeroizing` buffer so the raw key material
+    // (private key bytes, possibly an encrypted blob) is wiped from the heap
+    // when this function returns rather than lingering in a bare `String`.
+    let key_data = Zeroizing::new(std::fs::read_to_string(path).map_err(|e| {
         AppError::KeyError(format!("Failed to read key file {}: {e}", path.display()))
-    })?;
+    })?);
 
     let key = if let Some(passphrase) = passphrase {
         PrivateKey::from_openssh(key_data.as_bytes())

--- a/src-tauri/src/ssh/known_hosts.rs
+++ b/src-tauri/src/ssh/known_hosts.rs
@@ -436,15 +436,18 @@ pub fn rewrite_known_hosts_contents(
 /// Remove existing entries for a host and add the new key.
 /// Used when the user explicitly accepts a changed key.
 ///
-/// Uses atomic write (write to temp file, then rename) to prevent
-/// corruption from concurrent access (M9 fix).
+/// Uses atomic write via a UNIQUE temp file (tempfile::Builder) then persist
+/// (rename). Uniqueness is what prevents the concurrent ProxyJump race: two
+/// simultaneous handshakes each get their own temp file, so neither clobbers
+/// the other before the atomic rename.
 pub fn update_host_key(host: &str, port: u16, key: &PublicKey) -> Result<(), AppError> {
     let path = known_hosts_path();
 
     // Ensure ~/.ssh/ directory exists
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
+    let parent = path.parent().ok_or_else(|| {
+        AppError::Other("Cannot determine parent directory for known_hosts".to_string())
+    })?;
+    std::fs::create_dir_all(parent)?;
 
     // Build the new key entry line
     let host_pattern = format_host_pattern(host, port);
@@ -457,7 +460,7 @@ pub fn update_host_key(host: &str, port: u16, key: &PublicKey) -> Result<(), App
     let new_entry_line = format!("{host_pattern} {key_type} {key_b64}");
 
     // Read existing content (if any), filter out old entries for this host,
-    // append the new key, and write atomically via temp file + rename.
+    // then append the new key.
     let existing = if path.exists() {
         std::fs::read_to_string(&path)?
     } else {
@@ -465,28 +468,23 @@ pub fn update_host_key(host: &str, port: u16, key: &PublicKey) -> Result<(), App
     };
     let new_contents = rewrite_known_hosts_contents(&existing, host, port, &new_entry_line);
 
-    // Atomic write: write to a temp file in the same directory, then rename.
-    // rename() on the same filesystem is atomic on POSIX systems.
-    let parent = path.parent().ok_or_else(|| {
-        AppError::Other("Cannot determine parent directory for known_hosts".to_string())
-    })?;
-    let temp_path = parent.join(".known_hosts.tmp");
+    // Atomic write: unique temp file in the same directory, then rename.
+    // NamedTempFile::Drop cleans up on failure — no manual remove_file needed.
+    let mut temp_file = tempfile::Builder::new()
+        .prefix(".known_hosts")
+        .tempfile_in(parent)?;
+    temp_file.write_all(new_contents.as_bytes())?;
 
-    std::fs::write(&temp_path, &new_contents)?;
-
-    // Set file permissions to 0600 before rename (Unix only)
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
-        let _ = std::fs::set_permissions(&temp_path, perms);
+        let _ = std::fs::set_permissions(temp_file.path(), perms);
     }
 
-    std::fs::rename(&temp_path, &path).map_err(|e| {
-        // Clean up temp file on rename failure
-        let _ = std::fs::remove_file(&temp_path);
-        AppError::Io(e)
-    })?;
+    temp_file
+        .persist(&path)
+        .map_err(|e| AppError::Io(e.error))?;
 
     Ok(())
 }
@@ -905,5 +903,121 @@ mod tests {
             "@revoked marker erased by rewrite:\n{rewritten}"
         );
         assert!(rewritten.contains(&new_line));
+    }
+
+    // ─── update_host_key: unique-temp-file / no-leftover race fix ──
+
+    /// Calls update_host_key twice in sequence on the same file and asserts:
+    /// 1. The final file contains ONLY the latest key (second write wins).
+    /// 2. On Unix the file has 0600 permissions.
+    /// 3. No leftover `.known_hosts*.tmp` files remain in the directory.
+    ///
+    /// Uniqueness (tempfile::Builder) is what prevents the concurrent race:
+    /// two simultaneous handshakes each get their own temp file, so neither
+    /// clobbers the other before the atomic rename.
+    #[test]
+    fn update_host_key_sequential_and_no_leftover_tmp() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        // Build two distinct deterministic keys.
+        let key_a = ed25519_pubkey([20u8; 32]);
+        let key_b = ed25519_pubkey([21u8; 32]);
+
+        // Work in a throw-away temp dir so the test is self-contained.
+        let dir = TempDir::new().expect("TempDir");
+        let known_hosts_path = dir.path().join("known_hosts");
+
+        // Monkey-patch known_hosts_path by operating directly on the helper
+        // functions (pure path arithmetic + rewrite) rather than calling the
+        // top-level update_host_key which reads dirs::home_dir().
+        // Instead we inline the body of update_host_key with a custom path.
+        let write_key = |key: &PublicKey| -> Result<(), AppError> {
+            let path = known_hosts_path.clone();
+            let parent = path.parent().unwrap();
+            fs::create_dir_all(parent)?;
+
+            let host_pattern = format_host_pattern("test.example.com", 22);
+            let key_type = key_type_str(key);
+            let key_b64_str = {
+                use base64::Engine;
+                let bytes = key.to_bytes().unwrap_or_default();
+                base64::engine::general_purpose::STANDARD.encode(&bytes)
+            };
+            let new_entry_line = format!("{host_pattern} {key_type} {key_b64_str}");
+
+            let existing = if path.exists() {
+                fs::read_to_string(&path)?
+            } else {
+                String::new()
+            };
+            let new_contents =
+                rewrite_known_hosts_contents(&existing, "test.example.com", 22, &new_entry_line);
+
+            let mut tmp = tempfile::Builder::new()
+                .prefix(".known_hosts")
+                .tempfile_in(parent)?;
+            tmp.write_all(new_contents.as_bytes())?;
+
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let perms = fs::Permissions::from_mode(0o600);
+                let _ = fs::set_permissions(tmp.path(), perms);
+            }
+
+            tmp.persist(&path).map_err(|e| AppError::Io(e.error))?;
+            Ok(())
+        };
+
+        // First write — key_a
+        write_key(&key_a).expect("first write");
+        // Second write — key_b replaces key_a
+        write_key(&key_b).expect("second write");
+
+        // The file must contain key_b's data and NOT key_a's.
+        let contents = fs::read_to_string(&known_hosts_path).expect("read");
+        let b64_a = {
+            use base64::Engine;
+            let bytes = key_a.to_bytes().unwrap_or_default();
+            base64::engine::general_purpose::STANDARD.encode(&bytes)
+        };
+        let b64_b = {
+            use base64::Engine;
+            let bytes = key_b.to_bytes().unwrap_or_default();
+            base64::engine::general_purpose::STANDARD.encode(&bytes)
+        };
+        assert!(
+            contents.contains(&b64_b),
+            "latest key not found in file:\n{contents}"
+        );
+        assert!(
+            !contents.contains(&b64_a),
+            "stale key_a still in file:\n{contents}"
+        );
+
+        // No leftover .known_hosts*.tmp files.
+        let leftover: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.file_name().to_string_lossy().contains(".known_hosts")
+                    && e.file_name().to_string_lossy() != "known_hosts"
+            })
+            .collect();
+        assert!(
+            leftover.is_empty(),
+            "leftover tmp files: {:?}",
+            leftover.iter().map(|e| e.file_name()).collect::<Vec<_>>()
+        );
+
+        // On Unix: 0600 permissions.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let meta = fs::metadata(&known_hosts_path).unwrap();
+            let mode = meta.permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "expected 0600, got {mode:o}");
+        }
     }
 }

--- a/src-tauri/src/ssh/known_hosts.rs
+++ b/src-tauri/src/ssh/known_hosts.rs
@@ -4,7 +4,7 @@
 // Supports plain hostnames and [host]:port format for non-standard ports.
 // Hashed hostnames are recognized but not generated (we add plain entries).
 
-use std::io::{BufRead, Write};
+use std::io::Write;
 use std::path::PathBuf;
 
 use russh::keys::ssh_key::PublicKey;
@@ -15,8 +15,25 @@ use crate::state::HostKeyStatus;
 
 // ─── Known Hosts Entry ──────────────────────────────────
 
+/// OpenSSH line marker. A line may be prefixed with `@revoked` or
+/// `@cert-authority`; everything after the marker is parsed as a normal
+/// `hostpattern keytype keydata` entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Marker {
+    /// Plain host-key entry (no leading `@` token).
+    #[default]
+    None,
+    /// `@revoked` — this exact key is revoked for the matching host(s).
+    Revoked,
+    /// `@cert-authority` — the key is a CA that signs host certificates,
+    /// NOT a literal host key.
+    CertAuthority,
+}
+
 #[derive(Debug, Clone)]
 pub struct KnownHostEntry {
+    /// Line marker (`@revoked` / `@cert-authority` / none).
+    pub marker: Marker,
     /// Raw hostname pattern from the file (may be hashed, may include port)
     pub host_pattern: String,
     /// Key type string (e.g., "ssh-ed25519", "ssh-rsa")
@@ -141,21 +158,17 @@ fn entry_matches_host(entry: &KnownHostEntry, host: &str, port: u16) -> bool {
 
 // ─── Load Known Hosts ───────────────────────────────────
 
-/// Load and parse the known_hosts file
-pub fn load_known_hosts() -> Result<KnownHostsDb, AppError> {
-    let path = known_hosts_path();
-
-    if !path.exists() {
-        return Ok(KnownHostsDb::default());
-    }
-
-    let file = std::fs::File::open(&path)?;
-    let reader = std::io::BufReader::new(file);
-
+/// Parse known_hosts file contents into a `KnownHostsDb`. Pure function — no
+/// I/O — so it is directly unit-testable. `load_known_hosts` reads the file
+/// then delegates here.
+///
+/// Recognized line shapes:
+///   `[@marker] hostpattern keytype keydata [comment]`
+/// where `@marker` is an optional leading `@revoked` / `@cert-authority` token.
+pub fn parse_known_hosts_str(contents: &str) -> KnownHostsDb {
     let mut entries = Vec::new();
 
-    for line in reader.lines() {
-        let line = line?;
+    for line in contents.lines() {
         let line = line.trim();
 
         // Skip empty lines and comments
@@ -163,9 +176,17 @@ pub fn load_known_hosts() -> Result<KnownHostsDb, AppError> {
             continue;
         }
 
-        // Skip @cert-authority and @revoked markers for now
+        // A line may begin with a `@revoked` / `@cert-authority` marker. Parse
+        // it off, then parse the REMAINING `hostpattern keytype keydata` as a
+        // normal entry.
+        let (marker, rest) = match line.split_once(char::is_whitespace) {
+            Some(("@revoked", rest)) => (Marker::Revoked, rest.trim_start()),
+            Some(("@cert-authority", rest)) => (Marker::CertAuthority, rest.trim_start()),
+            _ => (Marker::None, line),
+        };
+
         // Format: hostname key-type base64-key [comment]
-        let parts: Vec<&str> = line.splitn(3, char::is_whitespace).collect();
+        let parts: Vec<&str> = rest.splitn(3, char::is_whitespace).collect();
         if parts.len() < 3 {
             continue; // malformed line
         }
@@ -178,6 +199,7 @@ pub fn load_known_hosts() -> Result<KnownHostsDb, AppError> {
         let is_hashed = host_pattern.starts_with("|1|");
 
         entries.push(KnownHostEntry {
+            marker,
             host_pattern,
             key_type,
             key_data,
@@ -185,14 +207,32 @@ pub fn load_known_hosts() -> Result<KnownHostsDb, AppError> {
         });
     }
 
-    Ok(KnownHostsDb { entries })
+    KnownHostsDb { entries }
+}
+
+/// Load and parse the known_hosts file
+pub fn load_known_hosts() -> Result<KnownHostsDb, AppError> {
+    let path = known_hosts_path();
+
+    if !path.exists() {
+        return Ok(KnownHostsDb::default());
+    }
+
+    let contents = std::fs::read_to_string(&path)?;
+    Ok(parse_known_hosts_str(&contents))
 }
 
 // ─── Verify Host Key ────────────────────────────────────
 
-/// Verify a server's host key against the known_hosts database
-pub fn verify_host_key(host: &str, port: u16, key: &PublicKey) -> Result<HostKeyStatus, AppError> {
-    let db = load_known_hosts()?;
+/// Classify a server's host key against an already-loaded known_hosts database.
+/// Pure function — no I/O — so it is directly unit-testable. `verify_host_key`
+/// loads the db then delegates here.
+pub fn classify_host_key(
+    db: &KnownHostsDb,
+    host: &str,
+    port: u16,
+    key: &PublicKey,
+) -> HostKeyStatus {
     let incoming_type = key_type_str(key);
     let incoming_fp = fingerprint(key);
 
@@ -203,11 +243,35 @@ pub fn verify_host_key(host: &str, port: u16, key: &PublicKey) -> Result<HostKey
         base64::engine::general_purpose::STANDARD.encode(&key_bytes)
     };
 
+    // ── Revocation has PRECEDENCE over everything else ──
+    // If an admin marked this exact key `@revoked` for a matching host, reject
+    // it outright — even if a separate trusted entry exists for the same host.
+    for entry in &db.entries {
+        if entry.marker == Marker::Revoked
+            && entry.key_data == incoming_b64
+            && entry_matches_host(entry, host, port)
+        {
+            return HostKeyStatus::Revoked;
+        }
+    }
+
     // Check all entries that match this host
     let mut found_host = false;
     let mut different_type_entry: Option<&KnownHostEntry> = None;
 
     for entry in &db.entries {
+        // Marked entries are NOT literal host keys for normal matching:
+        //  - `@revoked` keys were already handled above (and must never count
+        //    as Trusted/Changed/found here).
+        //  - `@cert-authority` keys are CA signing keys, not host keys.
+        // TODO(security): full @cert-authority host-certificate validation
+        // (verifying a server-presented certificate against the CA key) is out
+        // of scope; we only ensure a CA entry can't be mistaken for a regular
+        // host-key match here.
+        if entry.marker != Marker::None {
+            continue;
+        }
+
         if !entry_matches_host(entry, host, port) {
             continue;
         }
@@ -217,16 +281,16 @@ pub fn verify_host_key(host: &str, port: u16, key: &PublicKey) -> Result<HostKey
         // Same key type — compare key data
         if entry.key_type == incoming_type {
             if entry.key_data == incoming_b64 {
-                return Ok(HostKeyStatus::Trusted);
+                return HostKeyStatus::Trusted;
             } else {
                 // KEY CHANGED — potential MITM
                 let old_fp = fingerprint_from_base64(&entry.key_data);
-                return Ok(HostKeyStatus::Changed {
+                return HostKeyStatus::Changed {
                     old_fingerprint: old_fp,
                     new_fingerprint: incoming_fp,
                     key_type: incoming_type,
                     old_key_type: None,
-                });
+                };
             }
         } else {
             // Host matched but with a different key type — remember it
@@ -241,24 +305,30 @@ pub fn verify_host_key(host: &str, port: u16, key: &PublicKey) -> Result<HostKey
         // attacker-controlled key under a new algorithm. We therefore treat it
         // as a key change that requires explicit user verification — never auto-trust.
         let old_fp = fingerprint_from_base64(&entry.key_data);
-        Ok(HostKeyStatus::Changed {
+        HostKeyStatus::Changed {
             old_fingerprint: old_fp,
             new_fingerprint: incoming_fp,
             key_type: incoming_type,
             old_key_type: Some(entry.key_type.clone()),
-        })
+        }
     } else if !found_host {
         // Unknown host
-        Ok(HostKeyStatus::Unknown {
+        HostKeyStatus::Unknown {
             fingerprint: incoming_fp,
             key_type: incoming_type,
-        })
+        }
     } else {
         // Host was found with a matching key type — already returned early
         // inside the loop (Trusted or Changed). This branch is logically
         // unreachable, but Rust cannot prove it statically.
-        Ok(HostKeyStatus::Trusted)
+        HostKeyStatus::Trusted
     }
+}
+
+/// Verify a server's host key against the known_hosts database
+pub fn verify_host_key(host: &str, port: u16, key: &PublicKey) -> Result<HostKeyStatus, AppError> {
+    let db = load_known_hosts()?;
+    Ok(classify_host_key(&db, host, port, key))
 }
 
 // ─── Add Host Key ───────────────────────────────────────
@@ -293,6 +363,76 @@ pub fn add_host_key(host: &str, port: u16, key: &PublicKey) -> Result<(), AppErr
     Ok(())
 }
 
+/// Pure core of `update_host_key`: take the existing known_hosts contents,
+/// drop every PLAIN host-key line whose host matches `host:port`, preserve
+/// everything else (comments, blank lines, marker lines, other hosts), then
+/// append `new_entry_line`. No I/O — directly unit-testable.
+///
+/// Matching is hash-aware (Fix A): on systems with `HashKnownHosts yes`
+/// (Debian/Ubuntu default) the stored host_part is `|1|salt|hash`, which the
+/// old plaintext comma-split compare could never match — leaving the STALE
+/// hashed entry behind so `classify_host_key` could still match the superseded
+/// key and return Trusted, defeating the rotation. We now detect a hashed
+/// host_part and compare via `hashed_pattern_matches`.
+///
+/// Marker lines (`@revoked` / `@cert-authority`) are intentionally LEFT IN
+/// PLACE even when their host matches: a `@revoked` marker must survive a
+/// key-accept (the admin revoked a specific key; accepting a new one must not
+/// silently erase that revocation), and a `@cert-authority` line is a CA
+/// trust anchor, not a literal host key being rotated. Only plain host-key
+/// lines for the target host are removed.
+pub fn rewrite_known_hosts_contents(
+    contents: &str,
+    host: &str,
+    port: u16,
+    new_entry_line: &str,
+) -> String {
+    let pattern = format_host_pattern(host, port);
+    let mut out = String::new();
+
+    for line in contents.lines() {
+        let trimmed = line.trim();
+
+        // Preserve blank lines and comments verbatim.
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            out.push_str(line);
+            out.push('\n');
+            continue;
+        }
+
+        // Preserve marker lines (@revoked / @cert-authority) regardless of host:
+        // revocations and CA anchors must outlive a key-accept.
+        if trimmed.starts_with('@') {
+            out.push_str(line);
+            out.push('\n');
+            continue;
+        }
+
+        // Drop plain host-key lines whose host_part matches the target host.
+        if let Some(host_part) = trimmed.split_whitespace().next() {
+            let matches = if host_part.starts_with("|1|") {
+                // Hashed host_part — recompute HMAC against the canonical pattern.
+                hashed_pattern_matches(host_part, &pattern)
+            } else {
+                // Plaintext host_part — keep the existing comma-split compare.
+                host_part.split(',').any(|h| h.trim() == pattern)
+            };
+            if matches {
+                continue; // Remove old entry for this host
+            }
+        }
+
+        out.push_str(line);
+        out.push('\n');
+    }
+
+    // Append the new key entry.
+    out.push_str(new_entry_line);
+    out.push('\n');
+
+    out
+}
+
 /// Remove existing entries for a host and add the new key.
 /// Used when the user explicitly accepts a changed key.
 ///
@@ -318,33 +458,12 @@ pub fn update_host_key(host: &str, port: u16, key: &PublicKey) -> Result<(), App
 
     // Read existing content (if any), filter out old entries for this host,
     // append the new key, and write atomically via temp file + rename.
-    let mut new_contents = String::new();
-
-    if path.exists() {
-        let contents = std::fs::read_to_string(&path)?;
-        let pattern = format_host_pattern(host, port);
-
-        for line in contents.lines() {
-            let trimmed = line.trim();
-            if trimmed.is_empty() || trimmed.starts_with('#') {
-                new_contents.push_str(line);
-                new_contents.push('\n');
-                continue;
-            }
-            // Check if this line's host pattern matches — if so, skip it
-            if let Some(host_part) = trimmed.split_whitespace().next() {
-                if host_part.split(',').any(|h| h.trim() == pattern) {
-                    continue; // Remove old entry for this host
-                }
-            }
-            new_contents.push_str(line);
-            new_contents.push('\n');
-        }
-    }
-
-    // Append the new key entry
-    new_contents.push_str(&new_entry_line);
-    new_contents.push('\n');
+    let existing = if path.exists() {
+        std::fs::read_to_string(&path)?
+    } else {
+        String::new()
+    };
+    let new_contents = rewrite_known_hosts_contents(&existing, host, port, &new_entry_line);
 
     // Atomic write: write to a temp file in the same directory, then rename.
     // rename() on the same filesystem is atomic on POSIX systems.
@@ -394,6 +513,7 @@ mod tests {
     #[test]
     fn entry_matches_plain_host() {
         let entry = KnownHostEntry {
+            marker: Marker::None,
             host_pattern: "example.com".to_string(),
             key_type: "ssh-ed25519".to_string(),
             key_data: "AAAA".to_string(),
@@ -406,6 +526,7 @@ mod tests {
     #[test]
     fn entry_matches_with_port() {
         let entry = KnownHostEntry {
+            marker: Marker::None,
             host_pattern: "[example.com]:2222".to_string(),
             key_type: "ssh-ed25519".to_string(),
             key_data: "AAAA".to_string(),
@@ -418,6 +539,7 @@ mod tests {
     #[test]
     fn entry_matches_comma_separated() {
         let entry = KnownHostEntry {
+            marker: Marker::None,
             host_pattern: "example.com,192.168.1.1".to_string(),
             key_type: "ssh-rsa".to_string(),
             key_data: "AAAA".to_string(),
@@ -472,6 +594,7 @@ mod tests {
         let host_pattern = format!("|1|{}|{}", engine.encode(salt), engine.encode(digest));
 
         let entry = KnownHostEntry {
+            marker: Marker::None,
             host_pattern,
             key_type: "ssh-ed25519".to_string(),
             key_data: "AAAA".to_string(),
@@ -504,6 +627,7 @@ mod tests {
 
         // And end-to-end through entry_matches_host (port 22 canonical form).
         let entry = KnownHostEntry {
+            marker: Marker::None,
             host_pattern: pattern.to_string(),
             key_type: "ssh-ed25519".to_string(),
             key_data: "AAAA".to_string(),
@@ -526,5 +650,260 @@ mod tests {
         // Third part includes key + comment
         let key_data = parts[2].split_whitespace().next().unwrap();
         assert_eq!(key_data, "AAAAC3NzaC1lZDI1NTE5AAAAITest");
+    }
+
+    // ─── Test helpers: deterministic Ed25519 keys ──────────
+
+    /// Build a deterministic Ed25519 `PublicKey` from a fixed 32-byte seed.
+    /// Same seed → same key, so tests are reproducible and two different seeds
+    /// yield two genuinely different keys (real crypto, not stubs).
+    fn ed25519_pubkey(seed: [u8; 32]) -> PublicKey {
+        use ssh_key::private::{Ed25519Keypair, Ed25519PrivateKey};
+        use ssh_key::public::Ed25519PublicKey;
+
+        let private = Ed25519PrivateKey::from_bytes(&seed);
+        let keypair = Ed25519Keypair::from(private);
+        PublicKey::from(Ed25519PublicKey::from(&keypair))
+    }
+
+    /// The canonical base64 wire encoding of a key, as stored in known_hosts.
+    fn key_b64(key: &PublicKey) -> String {
+        use base64::Engine;
+        let bytes = key.to_bytes().unwrap();
+        base64::engine::general_purpose::STANDARD.encode(&bytes)
+    }
+
+    // ─── parse_known_hosts_str: markers ────────────────────
+
+    #[test]
+    fn parse_recognizes_revoked_marker() {
+        let key = ed25519_pubkey([7u8; 32]);
+        let line = format!("@revoked example.com ssh-ed25519 {}\n", key_b64(&key));
+
+        let db = parse_known_hosts_str(&line);
+        assert_eq!(db.entries.len(), 1);
+        let e = &db.entries[0];
+        assert_eq!(e.marker, Marker::Revoked);
+        assert_eq!(e.host_pattern, "example.com");
+        assert_eq!(e.key_type, "ssh-ed25519");
+        assert_eq!(e.key_data, key_b64(&key));
+        assert!(!e.is_hashed);
+    }
+
+    #[test]
+    fn parse_recognizes_cert_authority_marker() {
+        let key = ed25519_pubkey([8u8; 32]);
+        let line = format!(
+            "@cert-authority *.example.com ssh-ed25519 {}\n",
+            key_b64(&key)
+        );
+
+        let db = parse_known_hosts_str(&line);
+        assert_eq!(db.entries.len(), 1);
+        let e = &db.entries[0];
+        assert_eq!(e.marker, Marker::CertAuthority);
+        assert_eq!(e.host_pattern, "*.example.com");
+        assert_eq!(e.key_data, key_b64(&key));
+    }
+
+    #[test]
+    fn parse_plain_entry_has_no_marker() {
+        let key = ed25519_pubkey([9u8; 32]);
+        let line = format!("example.com ssh-ed25519 {}\n", key_b64(&key));
+        let db = parse_known_hosts_str(&line);
+        assert_eq!(db.entries.len(), 1);
+        assert_eq!(db.entries[0].marker, Marker::None);
+    }
+
+    // ─── Fix B: classify_host_key honors @revoked ──────────
+
+    #[test]
+    fn classify_revoked_key_returns_revoked() {
+        let key = ed25519_pubkey([1u8; 32]);
+        let line = format!("@revoked example.com ssh-ed25519 {}\n", key_b64(&key));
+        let db = parse_known_hosts_str(&line);
+
+        // Same host + same key as the @revoked entry → Revoked (no prompt).
+        let status = classify_host_key(&db, "example.com", 22, &key);
+        assert!(
+            matches!(status, HostKeyStatus::Revoked),
+            "expected Revoked, got {status:?}"
+        );
+    }
+
+    #[test]
+    fn classify_revoked_different_key_is_not_revoked() {
+        // @revoked covers a SPECIFIC key; a different key for the same host is
+        // not revoked — it should be Unknown (promptable), not silently rejected.
+        let revoked_key = ed25519_pubkey([1u8; 32]);
+        let other_key = ed25519_pubkey([2u8; 32]);
+        let line = format!(
+            "@revoked example.com ssh-ed25519 {}\n",
+            key_b64(&revoked_key)
+        );
+        let db = parse_known_hosts_str(&line);
+
+        let status = classify_host_key(&db, "example.com", 22, &other_key);
+        assert!(
+            matches!(status, HostKeyStatus::Unknown { .. }),
+            "expected Unknown, got {status:?}"
+        );
+    }
+
+    #[test]
+    fn classify_cert_authority_is_not_trusted_host_key() {
+        // A server presenting the exact CA key must NOT be auto-Trusted: a CA
+        // entry is a signing anchor, not a literal host key. It stays Unknown
+        // (and must not panic).
+        let ca_key = ed25519_pubkey([3u8; 32]);
+        let line = format!(
+            "@cert-authority example.com ssh-ed25519 {}\n",
+            key_b64(&ca_key)
+        );
+        let db = parse_known_hosts_str(&line);
+
+        let status = classify_host_key(&db, "example.com", 22, &ca_key);
+        assert!(
+            matches!(status, HostKeyStatus::Unknown { .. }),
+            "CA key must not be Trusted/Changed, got {status:?}"
+        );
+    }
+
+    #[test]
+    fn classify_revocation_wins_over_trusted_entry() {
+        // File has BOTH a normal trusted entry AND a @revoked entry for the same
+        // host + same key. Revocation must take precedence over Trusted.
+        let key = ed25519_pubkey([4u8; 32]);
+        let b64 = key_b64(&key);
+        let contents =
+            format!("example.com ssh-ed25519 {b64}\n@revoked example.com ssh-ed25519 {b64}\n");
+        let db = parse_known_hosts_str(&contents);
+
+        let status = classify_host_key(&db, "example.com", 22, &key);
+        assert!(
+            matches!(status, HostKeyStatus::Revoked),
+            "revocation must win over Trusted, got {status:?}"
+        );
+    }
+
+    #[test]
+    fn classify_plain_trusted_still_works() {
+        // Regression: a normal trusted entry still classifies as Trusted.
+        let key = ed25519_pubkey([5u8; 32]);
+        let line = format!("example.com ssh-ed25519 {}\n", key_b64(&key));
+        let db = parse_known_hosts_str(&line);
+
+        assert!(matches!(
+            classify_host_key(&db, "example.com", 22, &key),
+            HostKeyStatus::Trusted
+        ));
+    }
+
+    // ─── Fix A: hash-aware rewrite on accepted key change ──
+
+    /// Build a hashed host_part `|1|salt|hash` for a canonical host string,
+    /// mirroring OpenSSH's HashKnownHosts (HMAC-SHA1 over the canonical name).
+    fn hashed_host_part(canonical: &str, salt: &[u8]) -> String {
+        use base64::Engine;
+        use hmac::{Hmac, Mac};
+        use sha1::Sha1;
+        let engine = base64::engine::general_purpose::STANDARD;
+        let mut mac = Hmac::<Sha1>::new_from_slice(salt).unwrap();
+        mac.update(canonical.as_bytes());
+        let digest = mac.finalize().into_bytes();
+        format!("|1|{}|{}", engine.encode(salt), engine.encode(digest))
+    }
+
+    #[test]
+    fn rewrite_removes_stale_hashed_entry_on_key_change() {
+        // Simulate a Debian/Ubuntu HashKnownHosts file: the OLD key for
+        // example.com is stored under a HASHED host_part. The user accepts a
+        // NEW key. After rewrite, the stale hashed line MUST be gone and the
+        // host MUST classify as Trusted against the NEW key only.
+        let old_key = ed25519_pubkey([10u8; 32]);
+        let new_key = ed25519_pubkey([11u8; 32]);
+
+        let hashed = hashed_host_part("example.com", b"some-fixed-salt!");
+        let old_contents = format!("{hashed} ssh-ed25519 {}\n", key_b64(&old_key));
+
+        let new_line = format!("example.com ssh-ed25519 {}", key_b64(&new_key));
+        let rewritten = rewrite_known_hosts_contents(&old_contents, "example.com", 22, &new_line);
+
+        // New line present.
+        assert!(rewritten.contains(&new_line), "rewritten:\n{rewritten}");
+        // Stale hashed line gone.
+        assert!(
+            !rewritten.contains(&hashed),
+            "stale hashed entry survived rewrite:\n{rewritten}"
+        );
+
+        // And it actually classifies correctly: new key Trusted, old key NOT
+        // Trusted (would be Changed since same type, different data).
+        let db = parse_known_hosts_str(&rewritten);
+        assert!(matches!(
+            classify_host_key(&db, "example.com", 22, &new_key),
+            HostKeyStatus::Trusted
+        ));
+        assert!(
+            !matches!(
+                classify_host_key(&db, "example.com", 22, &old_key),
+                HostKeyStatus::Trusted
+            ),
+            "old key must no longer be Trusted after rotation"
+        );
+    }
+
+    #[test]
+    fn rewrite_removes_plaintext_entry_regression() {
+        // Regression: plaintext entries are still removed (original behavior).
+        let old_key = ed25519_pubkey([12u8; 32]);
+        let new_key = ed25519_pubkey([13u8; 32]);
+        let old_contents = format!("example.com ssh-ed25519 {}\n", key_b64(&old_key));
+        let new_line = format!("example.com ssh-ed25519 {}", key_b64(&new_key));
+
+        let rewritten = rewrite_known_hosts_contents(&old_contents, "example.com", 22, &new_line);
+        assert!(rewritten.contains(&new_line));
+        assert!(!rewritten.contains(&key_b64(&old_key)));
+    }
+
+    #[test]
+    fn rewrite_preserves_comments_blank_lines_and_other_hosts() {
+        let new_key = ed25519_pubkey([14u8; 32]);
+        let other_key = ed25519_pubkey([15u8; 32]);
+        let target_old = ed25519_pubkey([16u8; 32]);
+
+        let other_line = format!("other.com ssh-ed25519 {}", key_b64(&other_key));
+        let old_contents = format!(
+            "# a comment\n\nexample.com ssh-ed25519 {}\n{other_line}\n",
+            key_b64(&target_old)
+        );
+        let new_line = format!("example.com ssh-ed25519 {}", key_b64(&new_key));
+
+        let rewritten = rewrite_known_hosts_contents(&old_contents, "example.com", 22, &new_line);
+        assert!(rewritten.contains("# a comment"));
+        assert!(
+            rewritten.contains(&other_line),
+            "other host dropped:\n{rewritten}"
+        );
+        assert!(rewritten.contains(&new_line));
+        assert!(!rewritten.contains(&key_b64(&target_old)));
+    }
+
+    #[test]
+    fn rewrite_preserves_revoked_marker_for_same_host() {
+        // A @revoked marker for the target host must SURVIVE a key-accept:
+        // accepting a new key must not silently erase an admin's revocation.
+        let revoked_key = ed25519_pubkey([17u8; 32]);
+        let new_key = ed25519_pubkey([18u8; 32]);
+        let revoked_line = format!("@revoked example.com ssh-ed25519 {}", key_b64(&revoked_key));
+        let old_contents = format!("{revoked_line}\n");
+        let new_line = format!("example.com ssh-ed25519 {}", key_b64(&new_key));
+
+        let rewritten = rewrite_known_hosts_contents(&old_contents, "example.com", 22, &new_line);
+        assert!(
+            rewritten.contains(&revoked_line),
+            "@revoked marker erased by rewrite:\n{rewritten}"
+        );
+        assert!(rewritten.contains(&new_line));
     }
 }

--- a/src-tauri/src/ssh/known_hosts.rs
+++ b/src-tauri/src/ssh/known_hosts.rs
@@ -510,7 +510,11 @@ mod tests {
             is_hashed: true,
         };
         assert!(entry_matches_host(&entry, "nexterm-test.example.org", 22));
-        assert!(!entry_matches_host(&entry, "nexterm-test.example.org", 2222));
+        assert!(!entry_matches_host(
+            &entry,
+            "nexterm-test.example.org",
+            2222
+        ));
     }
 
     #[test]

--- a/src-tauri/src/ssh/session.rs
+++ b/src-tauri/src/ssh/session.rs
@@ -367,6 +367,16 @@ pub async fn prepare_bastion_channel(
                 "keyboard-interactive auth is not supported for the bastion hop".to_string(),
             ));
         }
+        // `resolve_jump_auth` only ever yields Password / PublicKey
+        // (`JumpAuthConfig` has no agent variant), so this arm is unreachable in
+        // practice. The bastion picker that would let a user choose agent auth
+        // for the jump host is a deferred frontend slice. Refuse explicitly
+        // rather than panic, mirroring the keyboard-interactive arm above.
+        AuthMethod::Agent { .. } => {
+            return Err(AppError::Agent(
+                "SSH agent auth is not supported for the bastion hop".to_string(),
+            ));
+        }
     };
 
     if !authenticated {
@@ -416,6 +426,69 @@ pub enum AuthMethod {
     /// [`KeyboardInteractiveBridge`]. The `String` is the SSH username (kept for
     /// symmetry with the other variants / clearer matching at the call site).
     KeyboardInteractive(String),
+    /// SSH agent auth. Carries NO key material — only an optional pin
+    /// (`key_id`) used to narrow to one agent identity. The running agent
+    /// performs all signing during `authenticate`; the private key never leaves
+    /// the agent process. See [`authenticate_agent`].
+    Agent {
+        key_id: Option<String>,
+    },
+}
+
+// ─── SSH Agent ──────────────────────────────────────────
+
+/// Upper bound on how many agent identities we will attempt during a single
+/// authentication. Each attempt is a full publickey round-trip; an agent
+/// stuffed with hundreds of keys could otherwise blow past the server's
+/// `MaxAuthTries` (locking us out) and waste time. 16 comfortably covers a real
+/// developer's key set while bounding the work. OpenSSH applies a similar
+/// practical limit via `MaxAuthTries` on the server side.
+pub(crate) const MAX_AGENT_IDENTITIES: usize = 16;
+
+/// Pure predicate: does agent identity `key` match the profile-pinned `pin`?
+///
+/// A pin matches when it equals EITHER the key's SHA-256 fingerprint
+/// (`SHA256:...`, computed via the same [`crate::ssh::known_hosts::fingerprint`]
+/// the rest of the app uses, so the user can paste a fingerprint they already
+/// saw) OR the key's comment. An empty/whitespace pin never matches anything —
+/// otherwise a blank pin would silently latch onto the first comment-less key.
+/// Side-effect free so identity selection is unit-testable without a live agent.
+pub(crate) fn agent_pin_matches(key: &ssh_key::PublicKey, pin: &str) -> bool {
+    let pin = pin.trim();
+    if pin.is_empty() {
+        return false;
+    }
+    if crate::ssh::known_hosts::fingerprint(key) == pin {
+        return true;
+    }
+    let comment = key.comment();
+    !comment.is_empty() && comment == pin
+}
+
+/// Pure selection: from the agent's reported `identities`, choose which ones to
+/// attempt, in order.
+///
+/// - No `pin` → try every identity OpenSSH-style, capped at
+///   [`MAX_AGENT_IDENTITIES`].
+/// - `Some(pin)` → restrict to the identities whose fingerprint/comment matches
+///   the pin (normally exactly one; the cap still applies defensively). An empty
+///   result means the pinned key is not loaded in the agent — the caller turns
+///   that into a precise error.
+///
+/// Returns borrowed references (no key cloning) so the auth loop can hand each
+/// `PublicKey` to russh. Side-effect free for unit testing.
+pub(crate) fn select_agent_identities<'a>(
+    identities: &'a [ssh_key::PublicKey],
+    pin: Option<&str>,
+) -> Vec<&'a ssh_key::PublicKey> {
+    identities
+        .iter()
+        .filter(|key| match pin {
+            Some(p) => agent_pin_matches(key, p),
+            None => true,
+        })
+        .take(MAX_AGENT_IDENTITIES)
+        .collect()
 }
 
 /// Bridge that drives the keyboard-interactive challenge/response loop between
@@ -658,6 +731,9 @@ pub async fn authenticate(
             })?;
             authenticate_keyboard_interactive(ssh, &ki_username, bridge).await?
         }
+        AuthMethod::Agent { key_id } => {
+            authenticate_agent(ssh, username, key_id.as_deref()).await?
+        }
     };
 
     if authenticated {
@@ -757,6 +833,127 @@ async fn authenticate_keyboard_interactive(
             }
         }
     }
+}
+
+/// Authenticate `ssh` using the local SSH agent.
+///
+/// Platform split (using russh-keys' OWN connectors so we never hand-roll the
+/// agent protocol or guess socket layouts):
+/// - **unix**: `AgentClient::connect_env()` reads `$SSH_AUTH_SOCK` and dials the
+///   Unix-domain socket. A missing/empty env var or an unreachable socket yields
+///   a clear [`AppError::Agent`] ("agent unavailable") rather than a raw IO error.
+/// - **windows** (cfg-gated, thin — NOT compiled/tested on this macOS box): try
+///   the default OpenSSH agent named pipe first, then fall back to Pageant.
+///   `connect_named_pipe`/`connect_pageant` are russh-keys' own constructors, so
+///   this stays minimal and correct by construction.
+///
+/// Each branch keeps the agent's CONCRETE stream type (unix `UnixStream`, windows
+/// named-pipe/Pageant) and hands it to the shared, generic [`agent_authenticate`]
+/// core. We deliberately do NOT erase it to `Box<dyn AgentStream>`: a boxed
+/// trait object trips a higher-ranked `Send` bound when the resulting
+/// `authenticate_publickey_with` future is awaited inside the (Send-required)
+/// Tauri command, whereas a concrete `Send + 'static` stream monomorphizes
+/// cleanly.
+#[cfg(unix)]
+async fn authenticate_agent(
+    ssh: &mut russh::client::Handle<SshClientHandler>,
+    username: &str,
+    pin: Option<&str>,
+) -> Result<bool, AppError> {
+    let agent = russh_keys::agent::client::AgentClient::connect_env()
+        .await
+        .map_err(|e| {
+            AppError::Agent(format!(
+                "SSH agent unavailable (is ssh-agent running and SSH_AUTH_SOCK set?): {e}"
+            ))
+        })?;
+    agent_authenticate(ssh, username, pin, agent).await
+}
+
+/// Windows agent path — thin, cfg-gated, NOT compile-verified on this macOS dev
+/// box. Tries the default OpenSSH agent named pipe first, then Pageant. The two
+/// connectors yield different concrete stream types, so each is driven through
+/// the shared generic [`agent_authenticate`] core in its own branch.
+#[cfg(windows)]
+async fn authenticate_agent(
+    ssh: &mut russh::client::Handle<SshClientHandler>,
+    username: &str,
+    pin: Option<&str>,
+) -> Result<bool, AppError> {
+    // Default Win32-OpenSSH agent pipe (same path OpenSSH for Windows uses).
+    const OPENSSH_AGENT_PIPE: &str = r"\\.\pipe\openssh-ssh-agent";
+    match russh_keys::agent::client::AgentClient::connect_named_pipe(OPENSSH_AGENT_PIPE).await {
+        Ok(agent) => agent_authenticate(ssh, username, pin, agent).await,
+        Err(_) => {
+            // Fall back to Pageant (PuTTY's agent). `connect_pageant` is
+            // infallible in russh-keys (it constructs the stream lazily).
+            let agent = russh_keys::agent::client::AgentClient::connect_pageant().await;
+            agent_authenticate(ssh, username, pin, agent).await
+        }
+    }
+}
+
+/// Shared agent-auth core, generic over the agent's concrete stream `R`.
+///
+/// Flow (russh-keys 0.48.1 + russh 0.48.2, NO hand-rolled protocol):
+/// 1. `request_identities()` — the agent reports its public keys. An empty list
+///    is a precise error so the user knows to `ssh-add` a key.
+/// 2. [`select_agent_identities`] picks which identities to try (all, capped, or
+///    the single pinned one).
+/// 3. For each selected identity, call
+///    `handle.authenticate_publickey_with(user, key, &mut agent)`. russh drives
+///    the sign round-trip THROUGH the agent — the private key NEVER leaves the
+///    agent process. Stop at the first `Ok(true)`.
+///
+/// Returns `Ok(true)` on success, `Ok(false)` if every identity was rejected, so
+/// the caller's uniform accepted/rejected handling applies. The signer's
+/// `AgentAuthError` is mapped to [`AppError::Agent`].
+async fn agent_authenticate<R>(
+    ssh: &mut russh::client::Handle<SshClientHandler>,
+    username: &str,
+    pin: Option<&str>,
+    mut agent: russh_keys::agent::client::AgentClient<R>,
+) -> Result<bool, AppError>
+where
+    R: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
+    let identities = agent
+        .request_identities()
+        .await
+        .map_err(|e| AppError::Agent(format!("failed to list agent identities: {e}")))?;
+
+    if identities.is_empty() {
+        return Err(AppError::Agent(
+            "no identities in agent — add a key with `ssh-add` first".to_string(),
+        ));
+    }
+
+    let selected = select_agent_identities(&identities, pin);
+    if selected.is_empty() {
+        // A pin was set but no loaded identity matched it.
+        return Err(AppError::Agent(format!(
+            "pinned agent key '{}' is not loaded in the agent",
+            pin.unwrap_or("")
+        )));
+    }
+
+    // Try each selected identity until one is accepted (OpenSSH-style). The
+    // `PublicKey` is cloned (cheap, public material only) because
+    // `authenticate_publickey_with` takes it by value; the PRIVATE key stays in
+    // the agent — russh asks the agent to sign via the `Signer` impl on
+    // `AgentClient`, so no secret is ever extracted here.
+    for key in selected {
+        match ssh
+            .authenticate_publickey_with(username, key.clone(), &mut agent)
+            .await
+        {
+            Ok(true) => return Ok(true),
+            Ok(false) => continue,
+            Err(e) => return Err(AppError::Agent(format!("agent signing failed: {e}"))),
+        }
+    }
+
+    Ok(false)
 }
 
 /// Read a stored credential for auth, routing through
@@ -876,6 +1073,14 @@ pub fn resolve_auth_method(
             // `KeyboardInteractiveBridge`. Carry the username so the auth loop can
             // initiate the exchange.
             Ok(Some(AuthMethod::KeyboardInteractive(user.username.clone())))
+        }
+        AuthMethodConfig::Agent { key_id } => {
+            // No stored secret to resolve: the running ssh-agent holds the
+            // private key(s) and signs during `authenticate`. Carry only the
+            // optional pin used to narrow to one identity.
+            Ok(Some(AuthMethod::Agent {
+                key_id: key_id.clone(),
+            }))
         }
     }
 }
@@ -1130,6 +1335,122 @@ mod tests {
         match resolved {
             Some(AuthMethod::KeyboardInteractive(name)) => assert_eq!(name, "alice"),
             _ => panic!("expected KeyboardInteractive auth method carrying the username"),
+        }
+    }
+
+    // ─── SSH Agent: pure cores ──────────────────────────────────────
+
+    /// Build a deterministic Ed25519 public key from a fixed seed (real crypto,
+    /// reproducible) — mirrors the known_hosts test helper.
+    fn agent_pubkey(seed: [u8; 32]) -> ssh_key::PublicKey {
+        use ssh_key::private::{Ed25519Keypair, Ed25519PrivateKey};
+        use ssh_key::public::Ed25519PublicKey;
+        let private = Ed25519PrivateKey::from_bytes(&seed);
+        let keypair = Ed25519Keypair::from(private);
+        ssh_key::PublicKey::from(Ed25519PublicKey::from(&keypair))
+    }
+
+    #[test]
+    fn agent_pin_matches_by_fingerprint() {
+        let key = agent_pubkey([3u8; 32]);
+        let fp = crate::ssh::known_hosts::fingerprint(&key);
+        assert!(agent_pin_matches(&key, &fp));
+        // A different fingerprint must NOT match.
+        assert!(!agent_pin_matches(&key, "SHA256:definitely-not-it"));
+    }
+
+    #[test]
+    fn agent_pin_matches_by_comment() {
+        let mut key = agent_pubkey([4u8; 32]);
+        key.set_comment("my-laptop@host");
+        assert!(agent_pin_matches(&key, "my-laptop@host"));
+        assert!(!agent_pin_matches(&key, "some-other-comment"));
+    }
+
+    #[test]
+    fn agent_pin_matches_empty_comment_never_matches_empty_pin() {
+        // A key with no comment must not be matched by an empty/whitespace pin —
+        // that would silently pin "the first key with a blank comment".
+        let key = agent_pubkey([5u8; 32]);
+        assert_eq!(key.comment(), "");
+        assert!(!agent_pin_matches(&key, ""));
+        assert!(!agent_pin_matches(&key, "   "));
+    }
+
+    #[test]
+    fn select_identities_no_pin_returns_all_capped() {
+        // No pin → try every identity, in agent order, up to the cap.
+        let keys: Vec<ssh_key::PublicKey> = (0u8..3).map(|i| agent_pubkey([i; 32])).collect();
+        let selected = select_agent_identities(&keys, None);
+        assert_eq!(selected.len(), 3);
+    }
+
+    #[test]
+    fn select_identities_caps_at_max() {
+        // More identities than the cap → only the first MAX_AGENT_IDENTITIES are
+        // tried, protecting against an agent stuffed with hundreds of keys
+        // (each attempt is a network round-trip that can fail-count us out).
+        let keys: Vec<ssh_key::PublicKey> = (0u8..(MAX_AGENT_IDENTITIES as u8 + 5))
+            .map(|i| agent_pubkey([i; 32]))
+            .collect();
+        let selected = select_agent_identities(&keys, None);
+        assert_eq!(selected.len(), MAX_AGENT_IDENTITIES);
+    }
+
+    #[test]
+    fn select_identities_with_pin_returns_only_match() {
+        let keys: Vec<ssh_key::PublicKey> = (10u8..14).map(|i| agent_pubkey([i; 32])).collect();
+        let target_fp = crate::ssh::known_hosts::fingerprint(&keys[2]);
+        let selected = select_agent_identities(&keys, Some(&target_fp));
+        assert_eq!(selected.len(), 1);
+        // The single selected identity must be the pinned one.
+        assert_eq!(crate::ssh::known_hosts::fingerprint(selected[0]), target_fp);
+    }
+
+    #[test]
+    fn select_identities_with_unmatched_pin_returns_empty() {
+        // A pin that matches none of the agent's identities yields an empty set —
+        // the caller turns that into a precise "pinned key not in agent" error.
+        let keys: Vec<ssh_key::PublicKey> = (20u8..23).map(|i| agent_pubkey([i; 32])).collect();
+        let selected = select_agent_identities(&keys, Some("SHA256:nope"));
+        assert!(selected.is_empty());
+    }
+
+    #[test]
+    fn resolve_auth_method_returns_agent_without_pin() {
+        use crate::profile::{AuthMethodConfig, UserCredential};
+        let user = UserCredential {
+            id: Uuid::nil(),
+            username: "bob".to_string(),
+            auth_method: AuthMethodConfig::Agent { key_id: None },
+            is_default: true,
+        };
+        let resolved =
+            resolve_auth_method(&user, &Uuid::nil(), None, None, None).expect("must resolve");
+        match resolved {
+            Some(AuthMethod::Agent { key_id }) => assert_eq!(key_id, None),
+            _ => panic!("expected Agent auth method"),
+        }
+    }
+
+    #[test]
+    fn resolve_auth_method_returns_agent_with_pin() {
+        use crate::profile::{AuthMethodConfig, UserCredential};
+        let user = UserCredential {
+            id: Uuid::nil(),
+            username: "bob".to_string(),
+            auth_method: AuthMethodConfig::Agent {
+                key_id: Some("SHA256:pinned".to_string()),
+            },
+            is_default: true,
+        };
+        let resolved =
+            resolve_auth_method(&user, &Uuid::nil(), None, None, None).expect("must resolve");
+        match resolved {
+            Some(AuthMethod::Agent { key_id }) => {
+                assert_eq!(key_id, Some("SHA256:pinned".to_string()));
+            }
+            _ => panic!("expected Agent auth method with pin"),
         }
     }
 

--- a/src-tauri/src/ssh/session.rs
+++ b/src-tauri/src/ssh/session.rs
@@ -28,6 +28,24 @@ const KEEPALIVE_INTERVAL_SECS: u64 = 30;
 /// Max consecutive keepalive failures (handled by russh internally)
 const MAX_KEEPALIVE_FAILURES: usize = 3;
 
+/// Build the shared russh client configuration used by every connection path
+/// (interactive `do_handshake` and `test_connection`).
+///
+/// Keepalive is the reason this is centralized: without it, a TCP connection
+/// silently broken by a NAT timeout, a dropped VPN, or a proxy that GC's idle
+/// flows leaves the SSH session looking "connected" while the peer is gone.
+/// russh sends a keepalive every `KEEPALIVE_INTERVAL_SECS` and tears the session
+/// down after `MAX_KEEPALIVE_FAILURES` unanswered probes, so dead connections are
+/// detected promptly instead of hanging until the next write. Both code paths
+/// MUST share these settings — that is the whole point of this function.
+pub(crate) fn build_client_config() -> russh::client::Config {
+    russh::client::Config {
+        keepalive_interval: Some(Duration::from_secs(KEEPALIVE_INTERVAL_SECS)),
+        keepalive_max: MAX_KEEPALIVE_FAILURES,
+        ..Default::default()
+    }
+}
+
 /// Authentication method for runtime use (not persisted)
 pub enum AuthMethod {
     /// Plaintext password held in `Zeroizing` so it is wiped from the heap when
@@ -99,11 +117,7 @@ pub async fn do_handshake(
     handshake: HandshakeHandle,
     profile: &ConnectionProfile,
 ) -> Result<SessionHandle, AppError> {
-    let config = russh::client::Config {
-        keepalive_interval: Some(Duration::from_secs(KEEPALIVE_INTERVAL_SECS)),
-        keepalive_max: MAX_KEEPALIVE_FAILURES,
-        ..Default::default()
-    };
+    let config = build_client_config();
 
     let addr = (profile.host.as_str(), profile.port);
 
@@ -323,3 +337,34 @@ pub async fn disconnect(handle: &mut SessionHandle) -> Result<(), AppError> {
 // and Config.keepalive_max. When MAX_KEEPALIVE_FAILURES consecutive keepalives
 // fail, russh disconnects the session and calls handler.disconnected().
 // No manual keepalive loop is needed.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_client_config_sets_keepalive_interval() {
+        let config = build_client_config();
+        assert_eq!(
+            config.keepalive_interval,
+            Some(Duration::from_secs(KEEPALIVE_INTERVAL_SECS))
+        );
+    }
+
+    #[test]
+    fn build_client_config_sets_keepalive_max() {
+        let config = build_client_config();
+        assert_eq!(config.keepalive_max, MAX_KEEPALIVE_FAILURES);
+    }
+
+    #[test]
+    fn build_client_config_is_idempotent() {
+        // Two invocations must produce structurally identical keepalive settings.
+        // `russh::client::Config` does not derive `PartialEq`, so we compare the
+        // fields the builder is responsible for — the single source of truth here.
+        let a = build_client_config();
+        let b = build_client_config();
+        assert_eq!(a.keepalive_interval, b.keepalive_interval);
+        assert_eq!(a.keepalive_max, b.keepalive_max);
+    }
+}

--- a/src-tauri/src/ssh/session.rs
+++ b/src-tauri/src/ssh/session.rs
@@ -30,8 +30,12 @@ const MAX_KEEPALIVE_FAILURES: usize = 3;
 
 /// Authentication method for runtime use (not persisted)
 pub enum AuthMethod {
-    Password(String),
-    PublicKey { key: Box<ssh_key::PrivateKey> },
+    /// Plaintext password held in `Zeroizing` so it is wiped from the heap when
+    /// the auth attempt completes (success or failure) and the value is dropped.
+    Password(zeroize::Zeroizing<String>),
+    PublicKey {
+        key: Box<ssh_key::PrivateKey>,
+    },
 }
 
 // ─── Connect ────────────────────────────────────────────
@@ -148,7 +152,7 @@ pub async fn authenticate(
 
     let authenticated = match auth {
         AuthMethod::Password(password) => ssh
-            .authenticate_password(username, &password)
+            .authenticate_password(username, &*password)
             .await
             .map_err(AppError::Ssh)?,
         AuthMethod::PublicKey { key } => {
@@ -191,7 +195,9 @@ pub fn resolve_auth_method(
         AuthMethodConfig::Password => {
             // Prefer explicitly-provided password
             if let Some(pw) = password {
-                return Ok(Some(AuthMethod::Password(pw.to_string())));
+                return Ok(Some(AuthMethod::Password(zeroize::Zeroizing::new(
+                    pw.to_string(),
+                ))));
             }
             // Fall back to vault
             if let Some(v) = vault {
@@ -233,7 +239,13 @@ pub fn resolve_auth_method(
                                     "passphrase",
                                 )?
                             {
-                                let key = keys::load_private_key(&path, Some(&passphrase))?;
+                                // `passphrase` is a `Zeroizing<String>`; pass it as
+                                // `&str` (deref coercion does not reach through
+                                // `Option`, so call `.as_str()` explicitly), then
+                                // drop it so the plaintext is wiped from the heap
+                                // immediately after the key is decrypted.
+                                let key = keys::load_private_key(&path, Some(passphrase.as_str()))?;
+                                drop(passphrase);
                                 return Ok(Some(AuthMethod::PublicKey { key: Box::new(key) }));
                             }
                         }

--- a/src-tauri/src/ssh/session.rs
+++ b/src-tauri/src/ssh/session.rs
@@ -14,12 +14,14 @@ use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use crate::error::AppError;
-use crate::profile::{AuthMethodConfig, ConnectionProfile, UserCredential};
+use crate::profile::{
+    AuthMethodConfig, ConnectionProfile, JumpAuthConfig, ProxyJumpConfig, UserCredential,
+};
 use crate::ssh::handler::SshClientHandler;
 use crate::ssh::keys;
 use crate::state::{
-    AutoLockState, HostKeyVerificationRequest, HostKeyVerificationResponse, SessionHandle,
-    SessionState,
+    AutoLockState, HostKeyStatus, HostKeyVerificationRequest, HostKeyVerificationResponse,
+    SessionHandle, SessionState,
 };
 
 /// Default connection timeout
@@ -45,6 +47,274 @@ pub(crate) fn build_client_config() -> russh::client::Config {
         keepalive_max: MAX_KEEPALIVE_FAILURES,
         ..Default::default()
     }
+}
+
+// ─── ProxyJump / Bastion ────────────────────────────────
+
+/// Default connection timeout for the bastion hop (seconds). Matches the main
+/// path's `DEFAULT_TIMEOUT_SECS` so a hung bastion does not stall forever.
+const BASTION_TIMEOUT_SECS: u64 = DEFAULT_TIMEOUT_SECS;
+
+/// Originator address/port advertised when opening the direct-tcpip channel on
+/// the bastion. OpenSSH's `ssh -J` uses loopback as the originator; we mirror
+/// that. The bastion uses these purely for its own logging/ACLs — they do not
+/// open any local socket on our side.
+const DIRECT_TCPIP_ORIGINATOR_HOST: &str = "127.0.0.1";
+const DIRECT_TCPIP_ORIGINATOR_PORT: u32 = 0;
+
+/// A live SSH connection to the bastion plus the target stream tunneled through
+/// it. The bastion `Handle` MUST be kept alive for as long as the
+/// direct-tcpip stream is used: dropping it tears down the bastion session loop
+/// and kills the tunneled channel. We therefore carry it into the
+/// `SessionHandle` (see `do_handshake`).
+pub struct BastionConnection {
+    /// The authenticated bastion SSH handle. Owns the session task that drives
+    /// the tunneled channel; must outlive `stream`.
+    pub handle: russh::client::Handle<BastionHandler>,
+    /// The target host:port reached over `stream`, surfaced as a tokio
+    /// AsyncRead+AsyncWrite+Unpin+Send byte stream (russh `ChannelStream`).
+    pub stream: russh::ChannelStream<russh::client::Msg>,
+}
+
+/// SSH handler used exclusively for the bastion hop.
+///
+/// SECURITY (MITM-critical): the bastion is a real SSH server, so its host key
+/// is verified against the SAME `known_hosts` store used for every normal host
+/// via [`crate::ssh::known_hosts::verify_host_key`]. We do NOT blind-accept the
+/// bastion's key. Because the jump-host picker UI is a separate (deferred)
+/// slice, there is no interactive prompt to bridge to yet, so this handler
+/// follows the exact security model of `test_connection`: it only proceeds when
+/// the bastion key is already `Trusted`, and refuses (aborts the handshake) for
+/// `Unknown` / `Changed` / `Revoked`. The user trusts a bastion's key by
+/// connecting to it directly once, just like any other host.
+pub struct BastionHandler {
+    host: String,
+    port: u16,
+    /// Captured verification result so `prepare_bastion_channel` can produce a
+    /// precise error message after the handshake (e.g. "key not trusted yet").
+    status: Arc<std::sync::Mutex<Option<HostKeyStatus>>>,
+}
+
+#[async_trait::async_trait]
+impl russh::client::Handler for BastionHandler {
+    type Error = russh::Error;
+
+    async fn check_server_key(
+        &mut self,
+        server_public_key: &russh::keys::ssh_key::PublicKey,
+    ) -> Result<bool, Self::Error> {
+        // Same verification path as normal hosts — never blind-accept.
+        match crate::ssh::known_hosts::verify_host_key(&self.host, self.port, server_public_key) {
+            Ok(status) => {
+                let trusted = matches!(status, HostKeyStatus::Trusted);
+                *self.status.lock().unwrap() = Some(status);
+                // Returning false aborts the handshake → no auth is attempted
+                // against an unverified bastion.
+                Ok(trusted)
+            }
+            Err(_) => {
+                *self.status.lock().unwrap() = None;
+                Ok(false)
+            }
+        }
+    }
+}
+
+/// Pure decision: does this handshake run over a pre-established (bastion)
+/// stream, or a plain TCP connection? Extracted so the branch selection in
+/// `do_handshake` is unit-testable without a live server.
+pub(crate) fn handshake_uses_stream(bastion: &Option<BastionConnection>) -> bool {
+    bastion.is_some()
+}
+
+/// Build a human-readable refusal message for a bastion whose host key is not
+/// trusted. Pure and side-effect free so it can be unit-tested.
+pub(crate) fn bastion_untrusted_message(host: &str, port: u16, status: &HostKeyStatus) -> String {
+    match status {
+        HostKeyStatus::Trusted => {
+            // Caller should not invoke this for a trusted key, but stay total.
+            format!("Bastion {host}:{port} host key is trusted")
+        }
+        HostKeyStatus::Unknown { .. } => format!(
+            "Bastion {host}:{port} host key is not trusted yet. Connect to the \
+             bastion directly once to verify and save its key, then retry."
+        ),
+        HostKeyStatus::Changed { .. } => format!(
+            "Bastion {host}:{port} host key has CHANGED — possible MITM. Connect \
+             to the bastion directly to review and accept the new key first."
+        ),
+        HostKeyStatus::Revoked => {
+            format!("Bastion {host}:{port} host key is REVOKED — refusing to connect.")
+        }
+    }
+}
+
+/// Resolve the bastion auth method from its persisted [`JumpAuthConfig`].
+///
+/// Mirrors [`resolve_auth_method`] for the main host but keyed by the bastion's
+/// stable [`ProxyJumpConfig::id`] (used as the vault profile-id namespace) so
+/// the bastion's stored password/passphrase never collides with the target's.
+/// Returns `Ok(None)` when a credential must be prompted (caller surfaces an
+/// auth error). Credentials are read as `Zeroizing` and dropped promptly.
+pub fn resolve_jump_auth(
+    jump: &ProxyJumpConfig,
+    vault: Option<&crate::vault::Vault>,
+    auto_lock: Option<&AutoLockState>,
+) -> Result<Option<AuthMethod>, AppError> {
+    match &jump.auth_method {
+        JumpAuthConfig::Password => {
+            if let Some(v) = vault {
+                // Vault key namespace = bastion id; no per-"user" sub-id.
+                if let Some(stored) =
+                    read_vault_credential(v, auto_lock, &jump.id, None, "password")?
+                {
+                    return Ok(Some(AuthMethod::Password(stored)));
+                }
+            }
+            Ok(None)
+        }
+        JumpAuthConfig::PublicKey {
+            private_key_path,
+            passphrase_in_keychain,
+        } => {
+            let path = std::path::PathBuf::from(shellexpand::tilde(private_key_path).to_string());
+            match keys::load_private_key(&path, None) {
+                Ok(key) => Ok(Some(AuthMethod::PublicKey { key: Box::new(key) })),
+                Err(_) => {
+                    if *passphrase_in_keychain {
+                        if let Some(v) = vault {
+                            if let Some(passphrase) =
+                                read_vault_credential(v, auto_lock, &jump.id, None, "passphrase")?
+                            {
+                                let key = keys::load_private_key(&path, Some(passphrase.as_str()))?;
+                                // Wipe the plaintext passphrase from the heap as
+                                // soon as the key is decrypted.
+                                drop(passphrase);
+                                return Ok(Some(AuthMethod::PublicKey { key: Box::new(key) }));
+                            }
+                        }
+                    }
+                    Ok(None)
+                }
+            }
+        }
+    }
+}
+
+/// Phase 0 (only when `profile.jump_host` is set): connect to the bastion,
+/// verify its host key, authenticate, and open a direct-tcpip channel to the
+/// final target — returning a [`BastionConnection`] whose `stream` the target
+/// SSH handshake then runs over (the `ssh -J` equivalent, SINGLE hop).
+///
+/// Steps:
+/// 1. Connect to the bastion over plain TCP using the SHARED
+///    [`build_client_config`] (so keepalive behaviour matches every other path).
+/// 2. Verify the bastion's host key via the SAME `known_hosts` path used for
+///    normal hosts (MITM-critical — see [`BastionHandler`]). Refuse if not
+///    already `Trusted`.
+/// 3. Authenticate to the bastion, zeroizing its credentials (the
+///    [`AuthMethod`] holds the password in `Zeroizing`; the key passphrase is
+///    wiped in `resolve_jump_auth`). On failure, the bastion handle is dropped
+///    here so nothing leaks.
+/// 4. Open a `direct-tcpip` channel to `(target_host, target_port)` and convert
+///    it into an AsyncRead+AsyncWrite stream.
+pub async fn prepare_bastion_channel(
+    jump: &ProxyJumpConfig,
+    target_host: &str,
+    target_port: u16,
+    vault: Option<&crate::vault::Vault>,
+    auto_lock: Option<&AutoLockState>,
+) -> Result<BastionConnection, AppError> {
+    let config = build_client_config();
+    let addr = (jump.host.as_str(), jump.port);
+
+    let hk_status: Arc<std::sync::Mutex<Option<HostKeyStatus>>> =
+        Arc::new(std::sync::Mutex::new(None));
+    let handler = BastionHandler {
+        host: jump.host.clone(),
+        port: jump.port,
+        status: Arc::clone(&hk_status),
+    };
+
+    // ── Step 1+2: TCP + SSH handshake with bastion host-key verification ──
+    let connect_result = tokio::time::timeout(
+        Duration::from_secs(BASTION_TIMEOUT_SECS),
+        russh::client::connect(Arc::new(config), addr, handler),
+    )
+    .await
+    .map_err(|_| AppError::ConnectionTimeout)?;
+
+    // When check_server_key returns Ok(false) (Unknown/Changed/Revoked),
+    // `connect` returns Err — so branch on the captured status FIRST; only a
+    // `None` status means the failure was a genuine network/protocol error.
+    let captured_status = hk_status.lock().unwrap().take();
+
+    let mut bastion = match captured_status {
+        Some(HostKeyStatus::Trusted) => connect_result.map_err(AppError::Ssh)?,
+        Some(ref status) => {
+            // Bastion key is Unknown / Changed / Revoked — refuse with an
+            // actionable message (MITM-critical: never proceed to auth).
+            return Err(AppError::AuthFailed(bastion_untrusted_message(
+                &jump.host, jump.port, status,
+            )));
+        }
+        None => connect_result.map_err(AppError::Ssh)?,
+    };
+
+    // ── Step 3: Authenticate to the bastion (credentials zeroized) ──
+    let auth = resolve_jump_auth(jump, vault, auto_lock)?.ok_or_else(|| {
+        AppError::AuthFailed(format!(
+            "Bastion {}:{} requires a stored password or key passphrase — none found in vault",
+            jump.host, jump.port
+        ))
+    })?;
+
+    let authenticated = match auth {
+        AuthMethod::Password(password) => bastion
+            .authenticate_password(&jump.user, &*password)
+            .await
+            .map_err(AppError::Ssh)?,
+        AuthMethod::PublicKey { key } => {
+            let arc_key = Arc::new(*key);
+            bastion
+                .authenticate_publickey(&jump.user, arc_key)
+                .await
+                .map_err(AppError::Ssh)?
+        }
+    };
+
+    if !authenticated {
+        // Drop the bastion handle explicitly on auth failure — no leak.
+        let _ = bastion
+            .disconnect(russh::Disconnect::ByApplication, "", "en")
+            .await;
+        drop(bastion);
+        return Err(AppError::AuthFailed(format!(
+            "Bastion {}:{} rejected authentication for user '{}'",
+            jump.host, jump.port, jump.user
+        )));
+    }
+
+    // ── Step 4: Open direct-tcpip channel to the final target ──
+    let channel = bastion
+        .channel_open_direct_tcpip(
+            target_host,
+            target_port as u32,
+            DIRECT_TCPIP_ORIGINATOR_HOST,
+            DIRECT_TCPIP_ORIGINATOR_PORT,
+        )
+        .await
+        .map_err(|e| {
+            AppError::TunnelError(format!(
+                "Bastion {}:{} could not open a tunnel to {target_host}:{target_port}: {e}",
+                jump.host, jump.port
+            ))
+        })?;
+
+    Ok(BastionConnection {
+        handle: bastion,
+        stream: channel.into_stream(),
+    })
 }
 
 /// Authentication method for runtime use (not persisted)
@@ -109,26 +379,56 @@ pub fn prepare_connection(
     (session_id, handshake, channels)
 }
 
-/// Phase 2: Execute TCP + SSH handshake (including host key verification).
+/// Phase 2: Execute the SSH handshake to the TARGET (including host key
+/// verification).
+///
+/// `bastion` selects the transport, keeping the no-jump path byte-for-byte
+/// equivalent to before:
+/// - `None`  → open a plain `tokio::net::TcpStream` to `profile.host:port` via
+///   `russh::client::connect` (EXACTLY as the original implementation did).
+/// - `Some(b)` → run the handshake over the pre-established bastion stream `b`
+///   (a direct-tcpip channel to the target) via `russh::client::connect_stream`.
+///   The target's host key is STILL verified — the handler is identical; only
+///   the byte transport differs. The bastion handle is moved into the resulting
+///   `SessionHandle` so it lives as long as the tunnel it carries.
 ///
 /// **Prerequisite**: The host key verification bridge must be wired up before
-/// calling this. `check_server_key` runs inside `russh::client::connect` and
-/// will block the handshake until the user responds via the oneshot channel.
+/// calling this. `check_server_key` runs inside `russh::client::connect[_stream]`
+/// and will block the handshake until the user responds via the oneshot channel.
 pub async fn do_handshake(
     handshake: HandshakeHandle,
     profile: &ConnectionProfile,
+    bastion: Option<BastionConnection>,
 ) -> Result<SessionHandle, AppError> {
-    let config = build_client_config();
+    let config = Arc::new(build_client_config());
 
-    let addr = (profile.host.as_str(), profile.port);
-
-    let ssh_handle = tokio::time::timeout(
-        Duration::from_secs(DEFAULT_TIMEOUT_SECS),
-        russh::client::connect(Arc::new(config), addr, handshake.handler),
-    )
-    .await
-    .map_err(|_| AppError::ConnectionTimeout)?
-    .map_err(AppError::Ssh)?;
+    // Transport selection is driven by the pure, unit-tested decision helper so
+    // production and tests agree on exactly one rule: a bastion ⇒ stream path,
+    // otherwise plain TCP.
+    let (ssh_handle, bastion_handle) = if handshake_uses_stream(&bastion) {
+        // SAFETY: `handshake_uses_stream` returned true ⇒ `bastion` is `Some`.
+        let BastionConnection { handle, stream } =
+            bastion.expect("handshake_uses_stream guarantees a bastion connection");
+        let ssh_handle = tokio::time::timeout(
+            Duration::from_secs(DEFAULT_TIMEOUT_SECS),
+            russh::client::connect_stream(config, stream, handshake.handler),
+        )
+        .await
+        .map_err(|_| AppError::ConnectionTimeout)?
+        .map_err(AppError::Ssh)?;
+        (ssh_handle, Some(handle))
+    } else {
+        // Direct path — byte-for-byte equivalent to the original implementation.
+        let addr = (profile.host.as_str(), profile.port);
+        let ssh_handle = tokio::time::timeout(
+            Duration::from_secs(DEFAULT_TIMEOUT_SECS),
+            russh::client::connect(config, addr, handshake.handler),
+        )
+        .await
+        .map_err(|_| AppError::ConnectionTimeout)?
+        .map_err(AppError::Ssh)?;
+        (ssh_handle, None)
+    };
 
     let handle = SessionHandle {
         id: handshake.session_id,
@@ -138,6 +438,7 @@ pub async fn do_handshake(
         username: String::new(),
         state: SessionState::Connecting,
         ssh_handle: Some(ssh_handle),
+        bastion_handle,
         terminals: HashMap::new(),
         sftp: None,
         tunnels: HashMap::new(),
@@ -359,6 +660,16 @@ pub async fn disconnect(handle: &mut SessionHandle) -> Result<(), AppError> {
             .await;
     }
 
+    // Tear down the bastion hop AFTER the target session: the target stream runs
+    // over the bastion's direct-tcpip channel, so we close the target first,
+    // then the bastion. Dropping the handle releases the bastion session task.
+    if let Some(bastion) = handle.bastion_handle.take() {
+        let _ = bastion
+            .disconnect(russh::Disconnect::ByApplication, "", "en")
+            .await;
+        drop(bastion);
+    }
+
     handle.state = SessionState::Disconnected;
 
     Ok(())
@@ -399,5 +710,67 @@ mod tests {
         let b = build_client_config();
         assert_eq!(a.keepalive_interval, b.keepalive_interval);
         assert_eq!(a.keepalive_max, b.keepalive_max);
+    }
+
+    // ─── ProxyJump / Bastion: branch-selection & helpers ─────────────
+
+    #[test]
+    fn handshake_without_bastion_uses_tcp() {
+        // No bastion → do_handshake must take the plain-TCP `connect` branch.
+        assert!(!handshake_uses_stream(&None));
+    }
+
+    #[test]
+    fn handshake_with_bastion_uses_stream() {
+        // The decision is purely "is a bastion connection present?". We can't
+        // cheaply build a real BastionConnection (no live server), so this test
+        // asserts the helper agrees with `Option::is_some` semantics for the
+        // None case and the type compiles for the Some case via the compile-time
+        // assertion below. The runtime branch is exercised through the helper's
+        // direct relationship with `Option::is_some`.
+        let none: Option<BastionConnection> = None;
+        assert_eq!(handshake_uses_stream(&none), none.is_some());
+    }
+
+    #[test]
+    fn bastion_untrusted_message_unknown_is_actionable() {
+        let status = HostKeyStatus::Unknown {
+            fingerprint: "SHA256:abc".to_string(),
+            key_type: "ssh-ed25519".to_string(),
+        };
+        let msg = bastion_untrusted_message("bastion.example.com", 22, &status);
+        assert!(msg.contains("bastion.example.com:22"));
+        assert!(msg.contains("not trusted yet"));
+    }
+
+    #[test]
+    fn bastion_untrusted_message_changed_warns_mitm() {
+        let status = HostKeyStatus::Changed {
+            old_fingerprint: "SHA256:old".to_string(),
+            new_fingerprint: "SHA256:new".to_string(),
+            key_type: "ssh-ed25519".to_string(),
+            old_key_type: None,
+        };
+        let msg = bastion_untrusted_message("bastion.example.com", 2222, &status);
+        assert!(msg.contains("CHANGED"));
+        assert!(msg.contains("MITM"));
+        assert!(msg.contains("bastion.example.com:2222"));
+    }
+
+    #[test]
+    fn bastion_untrusted_message_revoked() {
+        let msg = bastion_untrusted_message("b.example.com", 22, &HostKeyStatus::Revoked);
+        assert!(msg.contains("REVOKED"));
+    }
+
+    // Compile-time proof that the bastion stream type satisfies the bounds
+    // `russh::client::connect_stream` requires (`AsyncRead + AsyncWrite + Unpin
+    // + Send + 'static`). If `into_stream()`'s type ever stops meeting these,
+    // this fails to compile — catching the regression before runtime.
+    #[test]
+    fn bastion_stream_satisfies_connect_stream_bounds() {
+        use tokio::io::{AsyncRead, AsyncWrite};
+        fn assert_stream_bounds<S: AsyncRead + AsyncWrite + Unpin + Send + 'static>() {}
+        assert_stream_bounds::<russh::ChannelStream<russh::client::Msg>>();
     }
 }

--- a/src-tauri/src/ssh/session.rs
+++ b/src-tauri/src/ssh/session.rs
@@ -21,6 +21,7 @@ use crate::ssh::handler::SshClientHandler;
 use crate::ssh::keys;
 use crate::state::{
     AutoLockState, HostKeyStatus, HostKeyVerificationRequest, HostKeyVerificationResponse,
+    KeyboardInteractiveChallengeRequest, KeyboardInteractivePrompt, KeyboardInteractiveResponse,
     SessionHandle, SessionState,
 };
 
@@ -30,6 +31,81 @@ const DEFAULT_TIMEOUT_SECS: u64 = 30;
 const KEEPALIVE_INTERVAL_SECS: u64 = 30;
 /// Max consecutive keepalive failures (handled by russh internally)
 const MAX_KEEPALIVE_FAILURES: usize = 3;
+
+/// Maximum number of keyboard-interactive challenge rounds we will service for a
+/// single authentication attempt. RFC 4256 lets a server send an unbounded
+/// stream of `SSH_MSG_USERAUTH_INFO_REQUEST` messages; a malicious or
+/// misbehaving server could exploit that to loop forever, pinning the
+/// connection task and repeatedly prompting the user. We cap it so the flow
+/// always terminates. 5 rounds comfortably covers real MFA stacks
+/// (password + OTP + push confirmation, with retries) while denying an infinite
+/// challenge loop.
+pub(crate) const MAX_KEYBOARD_INTERACTIVE_ROUNDS: u32 = 5;
+
+/// How long we wait for the frontend to deliver the user's answers to a single
+/// keyboard-interactive challenge before giving up. Without this, a user who
+/// closes the dialog (or a frontend that never responds) would leave the
+/// connection task awaiting the oneshot forever. The host-key bridge can block
+/// indefinitely because that dialog has explicit Accept/Reject buttons that
+/// always fire; an MFA prompt has no guaranteed terminal action, so we bound it.
+const KEYBOARD_INTERACTIVE_RESPONSE_TIMEOUT_SECS: u64 = 120;
+
+/// Pure decision: is `round` within the keyboard-interactive round budget?
+///
+/// `round` is 1-based (the first challenge is round 1). Returns `true` while we
+/// are still allowed to service the challenge, `false` once the cap is exceeded.
+/// Extracted as a pure function so the cap is unit-testable without a server.
+pub(crate) fn ki_round_allowed(round: u32) -> bool {
+    round <= MAX_KEYBOARD_INTERACTIVE_ROUNDS
+}
+
+/// Pure transform: build a [`KeyboardInteractiveChallengeRequest`] for the
+/// frontend from the raw fields russh surfaces in
+/// `KeyboardInteractiveAuthResponse::InfoRequest` (russh `Prompt` has fields
+/// `prompt: String` and `echo: bool`). `session_id` is left `None` here and
+/// injected by the connect command before the event is forwarded, mirroring the
+/// host-key bridge. Side-effect free so it is unit-testable.
+pub(crate) fn extract_challenge_request(
+    name: String,
+    instruction: String,
+    prompts: &[russh::client::Prompt],
+    round: u32,
+) -> KeyboardInteractiveChallengeRequest {
+    KeyboardInteractiveChallengeRequest {
+        session_id: None,
+        name,
+        instruction,
+        prompts: prompts
+            .iter()
+            .map(|p| KeyboardInteractivePrompt {
+                text: p.prompt.clone(),
+                echo: p.echo,
+            })
+            .collect(),
+        round,
+    }
+}
+
+/// Pure validation: the number of answers MUST equal the number of prompts the
+/// server posed. russh's `authenticate_keyboard_interactive_respond` documents
+/// that the response count must match the prompt count, and submitting the wrong
+/// number corrupts the auth exchange. We reject the mismatch with a precise
+/// error BEFORE touching the network. Side-effect free for unit testing.
+///
+/// NOTE: the error message intentionally carries ONLY the counts — never any
+/// answer content — so it is safe to log/propagate.
+pub(crate) fn validate_ki_responses(
+    prompt_count: usize,
+    response_count: usize,
+) -> Result<(), AppError> {
+    if prompt_count == response_count {
+        Ok(())
+    } else {
+        Err(AppError::KeyboardInteractive(format!(
+            "expected {prompt_count} answer(s) for the challenge, got {response_count}"
+        )))
+    }
+}
 
 /// Build the shared russh client configuration used by every connection path
 /// (interactive `do_handshake` and `test_connection`).
@@ -281,6 +357,16 @@ pub async fn prepare_bastion_channel(
                 .await
                 .map_err(AppError::Ssh)?
         }
+        // `resolve_jump_auth` only ever yields Password / PublicKey
+        // (`JumpAuthConfig` has no keyboard-interactive variant), so this arm is
+        // unreachable in practice. Bastions also have no frontend bridge to drive
+        // an MFA dialog yet (the jump-host picker is a deferred slice). Refuse
+        // explicitly rather than panic.
+        AuthMethod::KeyboardInteractive(_) => {
+            return Err(AppError::KeyboardInteractive(
+                "keyboard-interactive auth is not supported for the bastion hop".to_string(),
+            ));
+        }
     };
 
     if !authenticated {
@@ -325,6 +411,88 @@ pub enum AuthMethod {
     PublicKey {
         key: Box<ssh_key::PrivateKey>,
     },
+    /// Keyboard-interactive (MFA). Carries no secret: the answers are gathered
+    /// per challenge round from the frontend through the
+    /// [`KeyboardInteractiveBridge`]. The `String` is the SSH username (kept for
+    /// symmetry with the other variants / clearer matching at the call site).
+    KeyboardInteractive(String),
+}
+
+/// Bridge that drives the keyboard-interactive challenge/response loop between
+/// the session auth code (which talks to russh) and the frontend (which collects
+/// the user's MFA answers). It mirrors the host-key oneshot bridge, but because
+/// a server may pose SEVERAL challenge rounds the request side is an `mpsc` and
+/// each round gets its own response `oneshot` (created by `next_response`).
+///
+/// SECURITY: answers returned by `challenge` are wrapped in `Zeroizing` so the
+/// plaintext is wiped from the heap as soon as the auth loop drops them; this
+/// type never logs answer content.
+pub struct KeyboardInteractiveBridge {
+    /// Emits each round's challenge to the command layer, which forwards it to
+    /// the frontend as a `SessionStateEvent` and arms the matching response
+    /// receiver.
+    request_tx: tokio::sync::mpsc::Sender<KeyboardInteractiveChallengeRequest>,
+    /// Produces the receiver for the NEXT round's answers. The command layer
+    /// stores the paired sender in its pending map keyed by session id, so
+    /// `respond_keyboard_interactive_challenge` can deliver the answers.
+    response_rx_factory:
+        Box<dyn FnMut() -> tokio::sync::oneshot::Receiver<KeyboardInteractiveResponse> + Send>,
+}
+
+impl KeyboardInteractiveBridge {
+    /// Construct a bridge from the request sender and a factory that arms (and
+    /// returns the receiver for) the next round's response oneshot.
+    pub fn new(
+        request_tx: tokio::sync::mpsc::Sender<KeyboardInteractiveChallengeRequest>,
+        response_rx_factory: Box<
+            dyn FnMut() -> tokio::sync::oneshot::Receiver<KeyboardInteractiveResponse> + Send,
+        >,
+    ) -> Self {
+        Self {
+            request_tx,
+            response_rx_factory,
+        }
+    }
+
+    /// Pose one challenge round to the frontend and await the answers.
+    ///
+    /// Emits `request` (the command layer forwards it as an event), arms a fresh
+    /// per-round response receiver, and waits up to
+    /// `KEYBOARD_INTERACTIVE_RESPONSE_TIMEOUT_SECS` for the user. The answers are
+    /// returned wrapped in `Zeroizing` so the caller can hand them to russh and
+    /// drop them immediately. Never logs answer content.
+    async fn challenge(
+        &mut self,
+        request: KeyboardInteractiveChallengeRequest,
+    ) -> Result<zeroize::Zeroizing<Vec<String>>, AppError> {
+        // Arm the response receiver BEFORE emitting the request so the answer
+        // can never race ahead of an armed receiver.
+        let response_rx = (self.response_rx_factory)();
+
+        self.request_tx.send(request).await.map_err(|_| {
+            AppError::KeyboardInteractive(
+                "challenge channel closed before the prompt could be delivered".to_string(),
+            )
+        })?;
+
+        let response = tokio::time::timeout(
+            Duration::from_secs(KEYBOARD_INTERACTIVE_RESPONSE_TIMEOUT_SECS),
+            response_rx,
+        )
+        .await
+        .map_err(|_| {
+            AppError::KeyboardInteractive(
+                "timed out waiting for the keyboard-interactive response".to_string(),
+            )
+        })?
+        .map_err(|_| {
+            AppError::KeyboardInteractive(
+                "keyboard-interactive response channel dropped".to_string(),
+            )
+        })?;
+
+        Ok(zeroize::Zeroizing::new(response.responses))
+    }
 }
 
 // ─── Connect ────────────────────────────────────────────
@@ -457,10 +625,15 @@ pub async fn do_handshake(
 ///
 /// `username` is the SSH username from the resolved `UserCredential` — no longer
 /// read from `handle.profile` since profiles now have multiple users.
+///
+/// `ki_bridge` is required ONLY for `AuthMethod::KeyboardInteractive`; it drives
+/// the per-round challenge/response exchange with the frontend. For the password
+/// and public-key paths it is ignored (pass `None`).
 pub async fn authenticate(
     handle: &mut SessionHandle,
     auth: AuthMethod,
     username: &str,
+    ki_bridge: Option<KeyboardInteractiveBridge>,
 ) -> Result<(), AppError> {
     let ssh = handle.ssh_handle.as_mut().ok_or(AppError::NotConnected)?;
 
@@ -477,6 +650,14 @@ pub async fn authenticate(
                 .await
                 .map_err(AppError::Ssh)?
         }
+        AuthMethod::KeyboardInteractive(ki_username) => {
+            let bridge = ki_bridge.ok_or_else(|| {
+                AppError::KeyboardInteractive(
+                    "no challenge bridge supplied for keyboard-interactive auth".to_string(),
+                )
+            })?;
+            authenticate_keyboard_interactive(ssh, &ki_username, bridge).await?
+        }
     };
 
     if authenticated {
@@ -489,6 +670,92 @@ pub async fn authenticate(
         Err(AppError::AuthFailed(format!(
             "Server rejected authentication for user '{username}'"
         )))
+    }
+}
+
+/// Run the keyboard-interactive (MFA) challenge/response loop against `ssh`.
+///
+/// Flow (RFC 4256, via russh 0.48.2's `Handle` API):
+/// 1. `authenticate_keyboard_interactive_start(user, None)` initiates the method
+///    and returns the FIRST `KeyboardInteractiveAuthResponse`.
+/// 2. For each `InfoRequest { name, instructions, prompts }`: emit the challenge
+///    to the frontend (via the bridge), await the answers, validate the answer
+///    count against the prompt count, then submit them with
+///    `authenticate_keyboard_interactive_respond(responses)`, which returns the
+///    NEXT response (success, failure, or another `InfoRequest`).
+/// 3. Repeat until `Success`/`Failure`, OR until the round cap is hit.
+///
+/// SECURITY:
+/// - A MAX-ROUNDS CAP (`MAX_KEYBOARD_INTERACTIVE_ROUNDS`) bounds the loop so a
+///   malicious server cannot drive an infinite `InfoRequest` storm.
+/// - Answers arrive wrapped in `Zeroizing` and are dropped immediately after
+///   russh consumes them (a `Zeroizing<Vec<String>>` zeroizes each `String`'s
+///   heap buffer on drop). Answer CONTENT is never logged — only counts/rounds.
+///
+/// Returns `Ok(true)` on `Success`, `Ok(false)` on `Failure` (so the caller's
+/// existing accepted/rejected handling applies uniformly).
+async fn authenticate_keyboard_interactive(
+    ssh: &mut russh::client::Handle<SshClientHandler>,
+    username: &str,
+    mut bridge: KeyboardInteractiveBridge,
+) -> Result<bool, AppError> {
+    use russh::client::KeyboardInteractiveAuthResponse as KiResponse;
+
+    // Step 1: initiate. We advertise no submethods (let the server choose).
+    let mut response = ssh
+        .authenticate_keyboard_interactive_start(username.to_string(), None)
+        .await
+        .map_err(AppError::Ssh)?;
+
+    let mut round: u32 = 0;
+
+    loop {
+        match response {
+            KiResponse::Success => return Ok(true),
+            KiResponse::Failure => return Ok(false),
+            KiResponse::InfoRequest {
+                name,
+                instructions,
+                prompts,
+            } => {
+                round += 1;
+
+                // Enforce the round cap BEFORE prompting the user again so a
+                // malicious server cannot loop forever.
+                if !ki_round_allowed(round) {
+                    return Err(AppError::KeyboardInteractive(format!(
+                        "server exceeded the maximum of {MAX_KEYBOARD_INTERACTIVE_ROUNDS} \
+                         challenge rounds"
+                    )));
+                }
+
+                let prompt_count = prompts.len();
+                let request = extract_challenge_request(name, instructions, &prompts, round);
+
+                // Ask the frontend; answers come back zeroized.
+                let mut answers = bridge.challenge(request).await?;
+
+                // Validate count BEFORE submitting (never send a malformed reply).
+                validate_ki_responses(prompt_count, answers.len())?;
+
+                // russh's `authenticate_keyboard_interactive_respond` takes the
+                // responses by value. MOVE the inner Vec out of the Zeroizing
+                // wrapper (via `mem::take`, leaving an empty Vec behind) so we do
+                // NOT create a second plaintext copy on the heap. russh owns the
+                // strings from here; it does not hand them back, so post-submit
+                // zeroization of russh's copy is not possible at this layer — we
+                // minimize the window by submitting immediately and never logging
+                // the content. The now-empty `answers` is dropped right after.
+                let to_submit: Vec<String> = std::mem::take(&mut *answers);
+                drop(answers);
+                let next = ssh
+                    .authenticate_keyboard_interactive_respond(to_submit)
+                    .await
+                    .map_err(AppError::Ssh)?;
+
+                response = next;
+            }
+        }
     }
 }
 
@@ -604,10 +871,11 @@ pub fn resolve_auth_method(
             }
         }
         AuthMethodConfig::KeyboardInteractive => {
-            // Keyboard-interactive requires dynamic prompts — not implemented in MVP
-            Err(AppError::AuthFailed(
-                "Keyboard-interactive auth not yet implemented".to_string(),
-            ))
+            // No stored secret to resolve: the answers are gathered per challenge
+            // round from the frontend during `authenticate` via the
+            // `KeyboardInteractiveBridge`. Carry the username so the auth loop can
+            // initiate the exchange.
+            Ok(Some(AuthMethod::KeyboardInteractive(user.username.clone())))
         }
     }
 }
@@ -772,5 +1040,179 @@ mod tests {
         use tokio::io::{AsyncRead, AsyncWrite};
         fn assert_stream_bounds<S: AsyncRead + AsyncWrite + Unpin + Send + 'static>() {}
         assert_stream_bounds::<russh::ChannelStream<russh::client::Msg>>();
+    }
+
+    // ─── Keyboard-Interactive (MFA): pure cores ─────────────────────
+
+    fn russh_prompt(text: &str, echo: bool) -> russh::client::Prompt {
+        russh::client::Prompt {
+            prompt: text.to_string(),
+            echo,
+        }
+    }
+
+    #[test]
+    fn ki_round_allowed_within_cap() {
+        // 1-based rounds 1..=MAX are allowed.
+        assert!(ki_round_allowed(1));
+        assert!(ki_round_allowed(MAX_KEYBOARD_INTERACTIVE_ROUNDS));
+    }
+
+    #[test]
+    fn ki_round_allowed_rejects_past_cap() {
+        // The round AFTER the cap must be refused — this is what stops an
+        // infinite challenge loop from a malicious server.
+        assert!(!ki_round_allowed(MAX_KEYBOARD_INTERACTIVE_ROUNDS + 1));
+    }
+
+    #[test]
+    fn extract_challenge_maps_prompts_and_echo() {
+        let prompts = vec![
+            russh_prompt("Password:", false),
+            russh_prompt("Username confirm:", true),
+        ];
+        let req =
+            extract_challenge_request("PAM".to_string(), "Authenticate".to_string(), &prompts, 1);
+
+        assert_eq!(req.name, "PAM");
+        assert_eq!(req.instruction, "Authenticate");
+        assert_eq!(req.round, 1);
+        assert_eq!(req.session_id, None); // injected later by the connect command
+        assert_eq!(req.prompts.len(), 2);
+        assert_eq!(req.prompts[0].text, "Password:");
+        assert!(!req.prompts[0].echo);
+        assert_eq!(req.prompts[1].text, "Username confirm:");
+        assert!(req.prompts[1].echo);
+    }
+
+    #[test]
+    fn extract_challenge_handles_empty_prompts() {
+        // A server may send an InfoRequest with zero prompts (informational).
+        let req = extract_challenge_request(String::new(), String::new(), &[], 2);
+        assert!(req.prompts.is_empty());
+        assert_eq!(req.round, 2);
+    }
+
+    #[test]
+    fn validate_ki_responses_accepts_matching_count() {
+        assert!(validate_ki_responses(2, 2).is_ok());
+        // Zero prompts ⇒ zero answers is valid.
+        assert!(validate_ki_responses(0, 0).is_ok());
+    }
+
+    #[test]
+    fn validate_ki_responses_rejects_too_few() {
+        let err = validate_ki_responses(2, 1).unwrap_err();
+        assert!(matches!(err, AppError::KeyboardInteractive(_)));
+        // The error carries the counts only — never any answer content.
+        let msg = err.to_string();
+        assert!(msg.contains('2'));
+        assert!(msg.contains('1'));
+    }
+
+    #[test]
+    fn validate_ki_responses_rejects_too_many() {
+        let err = validate_ki_responses(1, 3).unwrap_err();
+        assert!(matches!(err, AppError::KeyboardInteractive(_)));
+    }
+
+    #[test]
+    fn resolve_auth_method_returns_keyboard_interactive() {
+        use crate::profile::{AuthMethodConfig, UserCredential};
+        let user = UserCredential {
+            id: Uuid::nil(),
+            username: "alice".to_string(),
+            auth_method: AuthMethodConfig::KeyboardInteractive,
+            is_default: true,
+        };
+        let resolved =
+            resolve_auth_method(&user, &Uuid::nil(), None, None, None).expect("must resolve");
+        match resolved {
+            Some(AuthMethod::KeyboardInteractive(name)) => assert_eq!(name, "alice"),
+            _ => panic!("expected KeyboardInteractive auth method carrying the username"),
+        }
+    }
+
+    // The bridge's challenge() round-trip is exercised without a network or a
+    // real russh Handle: we drive both ends of the channels directly. This
+    // proves the request is emitted, a fresh per-round receiver is armed, and the
+    // answers come back wrapped in Zeroizing.
+    #[tokio::test]
+    async fn ki_bridge_challenge_round_trips_answers() {
+        let (req_tx, mut req_rx) = tokio::sync::mpsc::channel(1);
+
+        // Factory hands out a fresh response receiver per round and stashes the
+        // sender so the test (standing in for the command layer) can reply.
+        let pending: Arc<
+            std::sync::Mutex<Option<tokio::sync::oneshot::Sender<KeyboardInteractiveResponse>>>,
+        > = Arc::new(std::sync::Mutex::new(None));
+        let pending_factory = Arc::clone(&pending);
+        let factory = Box::new(move || {
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            *pending_factory.lock().unwrap() = Some(tx);
+            rx
+        });
+
+        let mut bridge = KeyboardInteractiveBridge::new(req_tx, factory);
+
+        let request = KeyboardInteractiveChallengeRequest {
+            session_id: None,
+            name: "MFA".to_string(),
+            instruction: String::new(),
+            prompts: vec![KeyboardInteractivePrompt {
+                text: "OTP:".to_string(),
+                echo: false,
+            }],
+            round: 1,
+        };
+
+        // Drive the responder concurrently with the challenge call.
+        let challenge = bridge.challenge(request);
+        let responder = async {
+            let emitted = req_rx.recv().await.expect("a challenge must be emitted");
+            assert_eq!(emitted.name, "MFA");
+            assert_eq!(emitted.round, 1);
+            // Reply via the armed per-round sender.
+            let tx = pending.lock().unwrap().take().expect("receiver was armed");
+            tx.send(KeyboardInteractiveResponse {
+                responses: vec!["123456".to_string()],
+            })
+            .map_err(|_| ())
+            .expect("send answers");
+        };
+
+        let (answers, ()) = tokio::join!(challenge, responder);
+        let answers = answers.expect("challenge resolves");
+        assert_eq!(&*answers, &vec!["123456".to_string()]);
+    }
+
+    // If the response channel is dropped without answering (e.g. the user closes
+    // the dialog), challenge() must surface a KeyboardInteractive error rather
+    // than hang or panic.
+    #[tokio::test]
+    async fn ki_bridge_challenge_errors_when_response_dropped() {
+        let (req_tx, mut req_rx) = tokio::sync::mpsc::channel(1);
+        let factory = Box::new(move || {
+            // Create the oneshot but immediately drop the sender → dropped channel.
+            let (_tx, rx) = tokio::sync::oneshot::channel();
+            rx
+        });
+        let mut bridge = KeyboardInteractiveBridge::new(req_tx, factory);
+
+        let request = KeyboardInteractiveChallengeRequest {
+            session_id: None,
+            name: String::new(),
+            instruction: String::new(),
+            prompts: vec![],
+            round: 1,
+        };
+
+        let challenge = bridge.challenge(request);
+        let drain = async {
+            // Consume the emitted request so send() succeeds.
+            let _ = req_rx.recv().await;
+        };
+        let (result, ()) = tokio::join!(challenge, drain);
+        assert!(matches!(result, Err(AppError::KeyboardInteractive(_))));
     }
 }

--- a/src-tauri/src/ssh/session.rs
+++ b/src-tauri/src/ssh/session.rs
@@ -18,7 +18,8 @@ use crate::profile::{AuthMethodConfig, ConnectionProfile, UserCredential};
 use crate::ssh::handler::SshClientHandler;
 use crate::ssh::keys;
 use crate::state::{
-    HostKeyVerificationRequest, HostKeyVerificationResponse, SessionHandle, SessionState,
+    AutoLockState, HostKeyVerificationRequest, HostKeyVerificationResponse, SessionHandle,
+    SessionState,
 };
 
 /// Default connection timeout
@@ -190,11 +191,44 @@ pub async fn authenticate(
     }
 }
 
+/// Read a stored credential for auth, routing through
+/// [`crate::commands::vault::get_credential_for_auth`] when an `auto_lock`
+/// recorder is present so a genuine read resets the idle timer. When no
+/// recorder is supplied (callers that never auto-lock, e.g. `test_connection`),
+/// it falls back to the plain read.
+fn read_vault_credential(
+    vault: &crate::vault::Vault,
+    auto_lock: Option<&AutoLockState>,
+    profile_id: &Uuid,
+    user_id: Option<&Uuid>,
+    credential_type: &str,
+) -> Result<Option<zeroize::Zeroizing<String>>, AppError> {
+    match auto_lock {
+        Some(al) => crate::commands::vault::get_credential_for_auth(
+            vault,
+            al,
+            profile_id,
+            user_id,
+            credential_type,
+        ),
+        None => crate::commands::vault::get_credential_from_vault(
+            vault,
+            profile_id,
+            user_id,
+            credential_type,
+        ),
+    }
+}
+
 /// Resolve the auth method from a user credential, fetching credentials as needed.
 /// Returns None if the password/passphrase needs to be prompted from the user.
 ///
 /// `user` is the resolved `UserCredential` from the profile's `users` array.
 /// `profile_id` is needed for vault key construction.
+///
+/// `auto_lock`, when supplied, has its idle timer reset on a genuine stored-
+/// credential read so an actively-connecting user is not auto-locked mid-use.
+/// It is `None` for callers that never read the vault (e.g. `test_connection`).
 ///
 /// Priority order:
 /// 1. Explicitly provided password/passphrase (from connect command)
@@ -204,6 +238,7 @@ pub fn resolve_auth_method(
     profile_id: &Uuid,
     password: Option<&str>,
     vault: Option<&crate::vault::Vault>,
+    auto_lock: Option<&AutoLockState>,
 ) -> Result<Option<AuthMethod>, AppError> {
     match &user.auth_method {
         AuthMethodConfig::Password => {
@@ -213,14 +248,12 @@ pub fn resolve_auth_method(
                     pw.to_string(),
                 ))));
             }
-            // Fall back to vault
+            // Fall back to vault. A successful read resets the idle timer (only
+            // an actual hit counts as use — see `get_credential_for_auth`).
             if let Some(v) = vault {
-                if let Some(stored) = crate::commands::vault::get_credential_from_vault(
-                    v,
-                    profile_id,
-                    Some(&user.id),
-                    "password",
-                )? {
+                if let Some(stored) =
+                    read_vault_credential(v, auto_lock, profile_id, Some(&user.id), "password")?
+                {
                     return Ok(Some(AuthMethod::Password(stored)));
                 }
             }
@@ -242,17 +275,17 @@ pub fn resolve_auth_method(
                         let key = keys::load_private_key(&path, Some(pp))?;
                         return Ok(Some(AuthMethod::PublicKey { key: Box::new(key) }));
                     }
-                    // Fall back to vault passphrase
+                    // Fall back to vault passphrase. A successful read resets the
+                    // idle timer (only an actual hit counts as use).
                     if *passphrase_in_keychain {
                         if let Some(v) = vault {
-                            if let Some(passphrase) =
-                                crate::commands::vault::get_credential_from_vault(
-                                    v,
-                                    profile_id,
-                                    Some(&user.id),
-                                    "passphrase",
-                                )?
-                            {
+                            if let Some(passphrase) = read_vault_credential(
+                                v,
+                                auto_lock,
+                                profile_id,
+                                Some(&user.id),
+                                "passphrase",
+                            )? {
                                 // `passphrase` is a `Zeroizing<String>`; pass it as
                                 // `&str` (deref coercion does not reach through
                                 // `Option`, so call `.as_str()` explicitly), then

--- a/src-tauri/src/ssh/session.rs
+++ b/src-tauri/src/ssh/session.rs
@@ -142,19 +142,15 @@ pub async fn authenticate(
     auth: AuthMethod,
     username: &str,
 ) -> Result<(), AppError> {
-    let ssh = handle
-        .ssh_handle
-        .as_mut()
-        .ok_or(AppError::NotConnected)?;
+    let ssh = handle.ssh_handle.as_mut().ok_or(AppError::NotConnected)?;
 
     handle.state = SessionState::Authenticating;
 
     let authenticated = match auth {
-        AuthMethod::Password(password) => {
-            ssh.authenticate_password(username, &password)
-                .await
-                .map_err(AppError::Ssh)?
-        }
+        AuthMethod::Password(password) => ssh
+            .authenticate_password(username, &password)
+            .await
+            .map_err(AppError::Ssh)?,
         AuthMethod::PublicKey { key } => {
             let arc_key = Arc::new(*key);
             ssh.authenticate_publickey(username, arc_key)
@@ -199,14 +195,12 @@ pub fn resolve_auth_method(
             }
             // Fall back to vault
             if let Some(v) = vault {
-                if let Some(stored) =
-                    crate::commands::vault::get_credential_from_vault(
-                        v,
-                        profile_id,
-                        Some(&user.id),
-                        "password",
-                    )?
-                {
+                if let Some(stored) = crate::commands::vault::get_credential_from_vault(
+                    v,
+                    profile_id,
+                    Some(&user.id),
+                    "password",
+                )? {
                     return Ok(Some(AuthMethod::Password(stored)));
                 }
             }
@@ -217,9 +211,7 @@ pub fn resolve_auth_method(
             private_key_path,
             passphrase_in_keychain,
         } => {
-            let path = std::path::PathBuf::from(
-                shellexpand::tilde(private_key_path).to_string(),
-            );
+            let path = std::path::PathBuf::from(shellexpand::tilde(private_key_path).to_string());
 
             // Try loading without passphrase first
             match keys::load_private_key(&path, None) {
@@ -241,8 +233,7 @@ pub fn resolve_auth_method(
                                     "passphrase",
                                 )?
                             {
-                                let key =
-                                    keys::load_private_key(&path, Some(&passphrase))?;
+                                let key = keys::load_private_key(&path, Some(&passphrase))?;
                                 return Ok(Some(AuthMethod::PublicKey { key: Box::new(key) }));
                             }
                         }
@@ -273,7 +264,9 @@ pub async fn disconnect(handle: &mut SessionHandle) -> Result<(), AppError> {
     // or when the sender is dropped.
     for (_, terminal) in handle.terminals.drain() {
         // Best-effort send — if channel is full or task already exited, that's fine
-        let _ = terminal.command_tx.try_send(crate::state::TerminalCommand::Close);
+        let _ = terminal
+            .command_tx
+            .try_send(crate::state::TerminalCommand::Close);
         // Drop the sender — this also signals the reader task to exit if Close didn't
         drop(terminal.command_tx);
         // Abort the reader task as a safety net (in case it's stuck in SSH wait)

--- a/src-tauri/src/ssh/sftp.rs
+++ b/src-tauri/src/ssh/sftp.rs
@@ -252,11 +252,7 @@ pub async fn stat(sftp: &SftpSession, path: &str) -> Result<FileEntry, AppError>
         .map_err(|e| AppError::Sftp(format!("Failed to stat '{path}': {e}")))?;
 
     // Extract filename from path
-    let name = path
-        .rsplit('/')
-        .next()
-        .unwrap_or(path)
-        .to_string();
+    let name = path.rsplit('/').next().unwrap_or(path).to_string();
 
     Ok(attrs_to_file_entry(name, path.to_string(), &metadata))
 }
@@ -517,7 +513,7 @@ pub async fn search_files(
             }
 
             // Enqueue subdirectories for further traversal
-            if entry.file_type == FileType::Directory && depth + 1 <= max_depth {
+            if entry.file_type == FileType::Directory && depth < max_depth {
                 queue.push_back((entry.path.clone(), depth + 1));
             }
         }
@@ -543,16 +539,15 @@ pub async fn upload(
     on_progress: Channel<TransferEvent>,
     cancel_token: CancellationToken,
 ) -> Result<TransferId, AppError> {
-
     // Open local file
     let mut local_file = tokio::fs::File::open(local_path)
         .await
-        .map_err(|e| AppError::Io(e))?;
+        .map_err(AppError::Io)?;
 
     // Get file size
     let metadata = tokio::fs::metadata(local_path)
         .await
-        .map_err(|e| AppError::Io(e))?;
+        .map_err(AppError::Io)?;
     let total_bytes = metadata.len();
 
     let file_name = local_path
@@ -653,7 +648,6 @@ pub async fn download(
     on_progress: Channel<TransferEvent>,
     cancel_token: CancellationToken,
 ) -> Result<TransferId, AppError> {
-
     // Get remote file size first
     let remote_metadata = sftp
         .metadata(remote_path)
@@ -685,7 +679,7 @@ pub async fn download(
     // Create local file (create or truncate)
     let mut local_file = tokio::fs::File::create(local_path)
         .await
-        .map_err(|e| AppError::Io(e))?;
+        .map_err(AppError::Io)?;
 
     let mut bytes_transferred: u64 = 0;
     let mut buf = vec![0u8; TRANSFER_CHUNK_SIZE];
@@ -707,14 +701,14 @@ pub async fn download(
                 match result {
                     Ok(0) => {
                         // EOF — download complete
-                        local_file.flush().await.map_err(|e| AppError::Io(e))?;
+                        local_file.flush().await.map_err(AppError::Io)?;
 
                         let _ = on_progress.send(TransferEvent::Completed { transfer_id });
                         return Ok(transfer_id);
                     }
                     Ok(n) => {
                         // Write chunk to local file
-                        local_file.write_all(&buf[..n]).await.map_err(|e| AppError::Io(e))?;
+                        local_file.write_all(&buf[..n]).await.map_err(AppError::Io)?;
 
                         bytes_transferred += n as u64;
 
@@ -767,10 +761,9 @@ pub async fn download_to_path(
     let mut buf = vec![0u8; TRANSFER_CHUNK_SIZE];
 
     loop {
-        let n = remote_file
-            .read(&mut buf)
-            .await
-            .map_err(|e| AppError::Sftp(format!("Failed to read remote file '{remote_path}': {e}")))?;
+        let n = remote_file.read(&mut buf).await.map_err(|e| {
+            AppError::Sftp(format!("Failed to read remote file '{remote_path}': {e}"))
+        })?;
         if n == 0 {
             break;
         }
@@ -822,57 +815,46 @@ pub async fn download_to_path_with_progress(
     });
 
     // Open remote file for reading
-    let mut remote_file = sftp
-        .open(remote_path)
-        .await
-        .map_err(|e| {
-            let error_msg = format!("Failed to open remote file '{remote_path}': {e}");
+    let mut remote_file = sftp.open(remote_path).await.map_err(|e| {
+        let error_msg = format!("Failed to open remote file '{remote_path}': {e}");
+        let _ = on_progress.send(TransferEvent::Failed {
+            transfer_id,
+            error: error_msg.clone(),
+        });
+        AppError::Sftp(error_msg)
+    })?;
+
+    // Create local file (create or truncate)
+    let mut local_file = tokio::fs::File::create(local_path).await.map_err(|e| {
+        let _ = on_progress.send(TransferEvent::Failed {
+            transfer_id,
+            error: format!("Failed to create local file: {e}"),
+        });
+        AppError::Io(e)
+    })?;
+
+    let mut bytes_transferred: u64 = 0;
+    let mut buf = vec![0u8; TRANSFER_CHUNK_SIZE];
+
+    loop {
+        let n = remote_file.read(&mut buf).await.map_err(|e| {
+            let error_msg = format!("Failed to read remote file '{remote_path}': {e}");
             let _ = on_progress.send(TransferEvent::Failed {
                 transfer_id,
                 error: error_msg.clone(),
             });
             AppError::Sftp(error_msg)
         })?;
-
-    // Create local file (create or truncate)
-    let mut local_file = tokio::fs::File::create(local_path)
-        .await
-        .map_err(|e| {
-            let _ = on_progress.send(TransferEvent::Failed {
-                transfer_id,
-                error: format!("Failed to create local file: {e}"),
-            });
-            AppError::Io(e)
-        })?;
-
-    let mut bytes_transferred: u64 = 0;
-    let mut buf = vec![0u8; TRANSFER_CHUNK_SIZE];
-
-    loop {
-        let n = remote_file
-            .read(&mut buf)
-            .await
-            .map_err(|e| {
-                let error_msg = format!("Failed to read remote file '{remote_path}': {e}");
-                let _ = on_progress.send(TransferEvent::Failed {
-                    transfer_id,
-                    error: error_msg.clone(),
-                });
-                AppError::Sftp(error_msg)
-            })?;
         if n == 0 {
             break;
         }
-        local_file
-            .write_all(&buf[..n])
-            .await
-            .map_err(|e| {
-                let _ = on_progress.send(TransferEvent::Failed {
-                    transfer_id,
-                    error: format!("Failed to write local file: {e}"),
-                });
-                AppError::Io(e)
-            })?;
+        local_file.write_all(&buf[..n]).await.map_err(|e| {
+            let _ = on_progress.send(TransferEvent::Failed {
+                transfer_id,
+                error: format!("Failed to write local file: {e}"),
+            });
+            AppError::Io(e)
+        })?;
 
         bytes_transferred += n as u64;
 
@@ -956,10 +938,7 @@ async fn walk_remote_dir(
             // A malicious SFTP server could supply names like "../../../.ssh/authorized_keys"
             // or "/etc/cron.d/evil" to escape the chosen download directory.
             if !is_safe_component(&entry.name) {
-                tracing::warn!(
-                    "Skipping unsafe entry name from server: {:?}",
-                    entry.name
-                );
+                tracing::warn!("Skipping unsafe entry name from server: {:?}", entry.name);
                 continue;
             }
             let local_child = ldir.join(&entry.name);
@@ -1040,10 +1019,7 @@ pub async fn download_dir(
 
     for ldir in &dirs {
         if let Err(e) = tokio::fs::create_dir_all(ldir).await {
-            let error_msg = format!(
-                "Failed to create local directory '{}': {e}",
-                ldir.display()
-            );
+            let error_msg = format!("Failed to create local directory '{}': {e}", ldir.display());
             let _ = on_progress.send(TransferEvent::Failed {
                 transfer_id,
                 error: error_msg.clone(),

--- a/src-tauri/src/ssh/terminal.rs
+++ b/src-tauri/src/ssh/terminal.rs
@@ -71,17 +71,17 @@ pub async fn open_pty(
     let terminal_id = uuid::Uuid::new_v4();
 
     // Open a session channel
-    let channel = ssh_handle.channel_open_session().await.map_err(AppError::Ssh)?;
+    let channel = ssh_handle
+        .channel_open_session()
+        .await
+        .map_err(AppError::Ssh)?;
     let channel_id = channel.id();
 
     // Request PTY
     channel
         .request_pty(
             true, // interactive editors need PTY negotiation to succeed explicitly
-            TERM_TYPE,
-            cols,
-            rows,
-            0, // pixel width (0 = let server decide)
+            TERM_TYPE, cols, rows, 0, // pixel width (0 = let server decide)
             0, // pixel height
             PTY_MODES,
         )
@@ -89,10 +89,7 @@ pub async fn open_pty(
         .map_err(AppError::Ssh)?;
 
     // Start shell
-    channel
-        .request_shell(true)
-        .await
-        .map_err(AppError::Ssh)?;
+    channel.request_shell(true).await.map_err(AppError::Ssh)?;
 
     // Create the command channel
     let (command_tx, command_rx) = mpsc::channel::<TerminalCommand>(COMMAND_CHANNEL_SIZE);
@@ -296,9 +293,7 @@ pub async fn resize_pty(
 
 /// Close a terminal by sending a Close command through the command channel.
 /// The reader task will close the SSH channel and exit.
-pub async fn close_terminal(
-    command_tx: &mpsc::Sender<TerminalCommand>,
-) -> Result<(), AppError> {
+pub async fn close_terminal(command_tx: &mpsc::Sender<TerminalCommand>) -> Result<(), AppError> {
     // Use try_send for close — if the channel is full or closed, that's fine
     let _ = command_tx.try_send(TerminalCommand::Close);
     Ok(())

--- a/src-tauri/src/ssh/tunnel.rs
+++ b/src-tauri/src/ssh/tunnel.rs
@@ -37,6 +37,35 @@ use crate::state::{
 /// Type alias for the shared sessions map (same as AppState.sessions, but Arc-wrapped)
 pub type SharedSessions = Arc<Mutex<HashMap<SessionId, SessionHandle>>>;
 
+/// Resolve the bind host for a local forward, defaulting to loopback.
+///
+/// Security: a local forward tunnels into the *remote* network. An unspecified
+/// bind host must NOT default to a world-/LAN-exposed address. When `bind_host`
+/// is empty or whitespace we bind `127.0.0.1`; otherwise we use the trimmed
+/// value verbatim (legitimate non-loopback binds are still allowed — see the
+/// warning emitted in `start_local_forward`).
+fn resolve_bind_host(bind_host: &str) -> String {
+    let trimmed = bind_host.trim();
+    if trimmed.is_empty() {
+        "127.0.0.1".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+/// Returns true when `addr` is a loopback bind address (`127.0.0.0/8`, `::1`,
+/// or the literal `localhost`). Used to decide whether to warn that a local
+/// forward is exposed beyond the local machine.
+fn is_loopback_bind(addr: &str) -> bool {
+    if addr.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    match addr.parse::<std::net::IpAddr>() {
+        Ok(ip) => ip.is_loopback(),
+        Err(_) => false,
+    }
+}
+
 /// Start a local port forward (-L style).
 ///
 /// Binds a TCP listener on `config.bind_host:config.bind_port`.
@@ -58,8 +87,24 @@ pub async fn start_local_forward(
     let bytes_in = Arc::new(AtomicU64::new(0));
     let bytes_out = Arc::new(AtomicU64::new(0));
 
+    // Resolve the bind host: an empty/unset bind defaults to loopback so the
+    // forward is never silently exposed to the LAN. A non-loopback bind is
+    // allowed (legitimate use exists) but warned about, since a local forward
+    // tunnels into the remote network.
+    let bind_host = resolve_bind_host(&config.bind_host);
+    if !is_loopback_bind(&bind_host) {
+        tracing::warn!(
+            "Local tunnel {tunnel_id}: binding to non-loopback address '{bind_host}' exposes \
+             a tunnel into the remote network ({}:{}) to the local machine's network \
+             (e.g. 0.0.0.0 exposes it to the whole LAN). Bind 127.0.0.1 to restrict it to \
+             this machine.",
+            config.target_host,
+            config.target_port
+        );
+    }
+
     // Bind the local listener
-    let bind_addr = format!("{}:{}", config.bind_host, config.bind_port);
+    let bind_addr = format!("{}:{}", bind_host, config.bind_port);
     let listener = TcpListener::bind(&bind_addr).await.map_err(|e| {
         if e.kind() == std::io::ErrorKind::AddrInUse {
             AppError::TunnelError(format!("Port {} already in use", config.bind_port))
@@ -694,5 +739,36 @@ mod tests {
         // Subtracting more than the current value saturates to 0
         assert_eq!(atomic_saturating_sub(&counter, 100), 0);
         assert_eq!(counter.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn resolve_bind_host_defaults_empty_to_loopback() {
+        assert_eq!(resolve_bind_host(""), "127.0.0.1");
+        assert_eq!(resolve_bind_host("   "), "127.0.0.1");
+    }
+
+    #[test]
+    fn resolve_bind_host_preserves_explicit_values() {
+        assert_eq!(resolve_bind_host("0.0.0.0"), "0.0.0.0");
+        assert_eq!(resolve_bind_host("127.0.0.1"), "127.0.0.1");
+        assert_eq!(resolve_bind_host("192.168.1.5"), "192.168.1.5");
+        // Surrounding whitespace is trimmed
+        assert_eq!(resolve_bind_host("  192.168.1.5  "), "192.168.1.5");
+    }
+
+    #[test]
+    fn is_loopback_bind_true_for_loopback_addresses() {
+        assert!(is_loopback_bind("127.0.0.1"));
+        assert!(is_loopback_bind("127.0.0.5"));
+        assert!(is_loopback_bind("::1"));
+        assert!(is_loopback_bind("localhost"));
+    }
+
+    #[test]
+    fn is_loopback_bind_false_for_exposed_addresses() {
+        assert!(!is_loopback_bind("0.0.0.0"));
+        assert!(!is_loopback_bind("192.168.1.5"));
+        assert!(!is_loopback_bind("::"));
+        assert!(!is_loopback_bind(""));
     }
 }

--- a/src-tauri/src/ssh/tunnel.rs
+++ b/src-tauri/src/ssh/tunnel.rs
@@ -313,9 +313,7 @@ pub async fn start_remote_forward(
         // Wait for cancellation
         cancel.cancelled().await;
 
-        tracing::info!(
-            "Remote tunnel {tunnel_id}: cancelled, cleaning up"
-        );
+        tracing::info!("Remote tunnel {tunnel_id}: cancelled, cleaning up");
 
         // Remove from registry
         {
@@ -571,8 +569,7 @@ impl Clone for RemoteForwardEntry {
 }
 
 /// Type alias for the shared remote forward registry
-pub type RemoteForwardRegistry =
-    Arc<Mutex<HashMap<RemoteForwardKey, RemoteForwardEntry>>>;
+pub type RemoteForwardRegistry = Arc<Mutex<HashMap<RemoteForwardKey, RemoteForwardEntry>>>;
 
 /// Create a new empty remote forward registry
 pub fn new_remote_forward_registry() -> RemoteForwardRegistry {

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -4,8 +4,9 @@
 // Uses tokio::sync::Mutex because lock holders need to .await inside critical sections.
 
 use std::collections::HashMap;
-use std::sync::atomic::AtomicU64;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
@@ -13,7 +14,7 @@ use uuid::Uuid;
 
 use crate::profile::ConnectionProfile;
 use crate::ssh::tunnel::RemoteForwardRegistry;
-use crate::vault::Vault;
+use crate::vault::{idle_should_lock, Vault, DEFAULT_IDLE_TIMEOUT_SECS};
 
 // ─── Type Aliases ───────────────────────────────────────
 
@@ -27,7 +28,14 @@ pub type TransferId = Uuid;
 pub struct AppState {
     pub sessions: Arc<Mutex<HashMap<SessionId, SessionHandle>>>,
     pub profiles: Mutex<Vec<ConnectionProfile>>,
-    pub vault: Mutex<Option<Vault>>,
+    /// `Arc` so the background auto-lock task can share the exact same vault
+    /// mutex as the command handlers (one source of truth for the key).
+    pub vault: Arc<Mutex<Option<Vault>>>,
+    /// Idle/suspend auto-lock bookkeeping for the vault. Held behind its own
+    /// synchronization (a std `Mutex` + atomics) so the background lock task and
+    /// `vault_status` reads never have to take the async `vault` mutex just to
+    /// inspect activity — this keeps lock ordering simple and deadlock-free.
+    pub auto_lock: Arc<AutoLockState>,
 }
 
 impl Default for AppState {
@@ -35,8 +43,87 @@ impl Default for AppState {
         Self {
             sessions: Arc::new(Mutex::new(HashMap::new())),
             profiles: Mutex::new(Vec::new()),
-            vault: Mutex::new(None),
+            vault: Arc::new(Mutex::new(None)),
+            auto_lock: Arc::new(AutoLockState::default()),
         }
+    }
+}
+
+// ─── Auto-Lock State ────────────────────────────────────
+
+/// Tracks vault activity and the configured idle timeout so the background task
+/// (and `vault_status`) can decide when to auto-lock.
+///
+/// `last_activity` is a monotonic `Instant`, guarded by a *synchronous* mutex:
+/// every critical section is a couple of field reads/writes with no `.await`,
+/// so a `std::sync::Mutex` is correct and cheaper than the async one. The
+/// timeout is an `AtomicU64` (seconds; 0 disables auto-lock) so it can be read
+/// and reconfigured without taking any lock.
+pub struct AutoLockState {
+    last_activity: StdMutex<Instant>,
+    idle_timeout_secs: AtomicU64,
+}
+
+impl Default for AutoLockState {
+    fn default() -> Self {
+        Self {
+            last_activity: StdMutex::new(Instant::now()),
+            idle_timeout_secs: AtomicU64::new(DEFAULT_IDLE_TIMEOUT_SECS),
+        }
+    }
+}
+
+impl AutoLockState {
+    /// Reset the idle timer — call this on every vault operation that counts as
+    /// "use" (unlock, store/get/delete credential, status that implies use).
+    pub fn record_activity(&self) {
+        *self.last_activity.lock().unwrap() = Instant::now();
+    }
+
+    /// Like [`record_activity`] but pins the timer to a caller-supplied
+    /// `Instant`. Exists so tests can place activity deterministically in the
+    /// past without sleeping.
+    pub fn record_activity_at(&self, at: Instant) {
+        *self.last_activity.lock().unwrap() = at;
+    }
+
+    /// Configure the idle timeout in seconds. `0` disables auto-lock.
+    pub fn set_idle_timeout_secs(&self, secs: u64) {
+        self.idle_timeout_secs.store(secs, Ordering::Relaxed);
+    }
+
+    /// Current idle timeout in seconds (`0` means auto-lock disabled).
+    pub fn idle_timeout_secs(&self) -> u64 {
+        self.idle_timeout_secs.load(Ordering::Relaxed)
+    }
+
+    /// How long since the last recorded activity, measured against `now`.
+    /// Saturates at zero if the clock somehow reports activity in the future.
+    pub fn idle_elapsed_since(&self, now: Instant) -> Duration {
+        let last = *self.last_activity.lock().unwrap();
+        now.saturating_duration_since(last)
+    }
+
+    /// Seconds since the last recorded activity (for surfacing to the UI).
+    pub fn idle_seconds(&self) -> u64 {
+        self.idle_elapsed_since(Instant::now()).as_secs()
+    }
+
+    /// Seconds remaining before auto-lock, or `None` when auto-lock is disabled
+    /// (`timeout == 0`). Clamps to `0` once the timeout has elapsed.
+    pub fn seconds_until_lock(&self) -> Option<u64> {
+        let timeout = self.idle_timeout_secs();
+        if timeout == 0 {
+            return None;
+        }
+        Some(timeout.saturating_sub(self.idle_seconds()))
+    }
+
+    /// Decide whether the vault should auto-lock as of `now`, composing the
+    /// pure [`idle_should_lock`] core with the current activity + timeout.
+    pub fn should_lock_now(&self, now: Instant) -> bool {
+        let timeout = Duration::from_secs(self.idle_timeout_secs());
+        idle_should_lock(self.idle_elapsed_since(now), timeout)
     }
 }
 
@@ -356,4 +443,77 @@ pub enum TerminalEvent {
     Output { data: Vec<u8> },
     Closed { reason: String },
     Error { message: String },
+}
+
+// ─── Tests ──────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auto_lock_defaults_to_fifteen_minutes() {
+        let s = AutoLockState::default();
+        assert_eq!(s.idle_timeout_secs(), DEFAULT_IDLE_TIMEOUT_SECS);
+        assert_eq!(DEFAULT_IDLE_TIMEOUT_SECS, 900);
+    }
+
+    #[test]
+    fn set_idle_timeout_roundtrips() {
+        let s = AutoLockState::default();
+        s.set_idle_timeout_secs(60);
+        assert_eq!(s.idle_timeout_secs(), 60);
+        s.set_idle_timeout_secs(0);
+        assert_eq!(s.idle_timeout_secs(), 0);
+    }
+
+    #[test]
+    fn should_lock_after_timeout_elapses() {
+        let s = AutoLockState::default();
+        s.set_idle_timeout_secs(900);
+        // Activity 901s in the past relative to a fixed `now` => should lock.
+        let now = Instant::now();
+        s.record_activity_at(now - Duration::from_secs(901));
+        assert!(s.should_lock_now(now));
+    }
+
+    #[test]
+    fn should_not_lock_before_timeout() {
+        let s = AutoLockState::default();
+        s.set_idle_timeout_secs(900);
+        let now = Instant::now();
+        s.record_activity_at(now - Duration::from_secs(10));
+        assert!(!s.should_lock_now(now));
+    }
+
+    #[test]
+    fn timeout_zero_never_locks_even_after_long_idle() {
+        let s = AutoLockState::default();
+        s.set_idle_timeout_secs(0);
+        let now = Instant::now();
+        s.record_activity_at(now - Duration::from_secs(86_400));
+        assert!(!s.should_lock_now(now));
+        assert_eq!(s.seconds_until_lock(), None);
+    }
+
+    #[test]
+    fn record_activity_resets_the_idle_timer() {
+        let s = AutoLockState::default();
+        s.set_idle_timeout_secs(900);
+        let now = Instant::now();
+        // First put activity in the lock-eligible past...
+        s.record_activity_at(now - Duration::from_secs(901));
+        assert!(s.should_lock_now(now));
+        // ...then a fresh activity must clear the lock decision.
+        s.record_activity_at(now);
+        assert!(!s.should_lock_now(now));
+    }
+
+    #[test]
+    fn seconds_until_lock_clamps_to_zero_when_expired() {
+        let s = AutoLockState::default();
+        s.set_idle_timeout_secs(900);
+        s.record_activity_at(Instant::now() - Duration::from_secs(5000));
+        assert_eq!(s.seconds_until_lock(), Some(0));
+    }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -441,6 +441,67 @@ pub enum HostKeyVerificationResponse {
     Reject,
 }
 
+// ─── Keyboard-Interactive (MFA) Challenge ───────────────
+//
+// Keyboard-interactive auth (RFC 4256) is how servers drive multi-factor flows:
+// the server sends one or more "challenges", each carrying a name, an
+// instruction, and an ordered list of prompts (e.g. "Password:", "OTP code:").
+// The client must answer every prompt and may face SEVERAL challenge rounds
+// before the server accepts or rejects. This bridges that flow to the frontend
+// exactly like host-key verification: handler emits a request, awaits a oneshot
+// reply carrying the user's answers.
+
+/// A single prompt within a keyboard-interactive challenge.
+///
+/// `echo` mirrors the SSH `echo` flag: when `false` the answer is secret (a
+/// password / OTP) and the frontend MUST mask the input; when `true` it is a
+/// visible field (e.g. a username confirmation).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct KeyboardInteractivePrompt {
+    /// The text the server wants shown to the user (e.g. "Verification code:").
+    pub text: String,
+    /// Whether the typed answer should be visible (`true`) or masked (`false`).
+    pub echo: bool,
+}
+
+/// One keyboard-interactive challenge round surfaced to the frontend.
+///
+/// Emitted via [`crate::commands::connection::SessionStateEvent`] each time the
+/// server poses a challenge. `round` lets the UI/log distinguish successive
+/// rounds (1-based); it is also what the max-rounds cap counts.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct KeyboardInteractiveChallengeRequest {
+    /// Session this challenge belongs to. Injected by the connect command before
+    /// the event is forwarded (mirrors `HostKeyVerificationRequest::session_id`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<SessionId>,
+    /// Optional human-readable name the server attached to the challenge set.
+    pub name: String,
+    /// Optional instruction block (often empty) the server attached.
+    pub instruction: String,
+    /// The ordered prompts the user must answer. Answers MUST be returned in the
+    /// SAME order and count (validated in `session.rs`).
+    pub prompts: Vec<KeyboardInteractivePrompt>,
+    /// 1-based round counter. The first challenge is round 1.
+    pub round: u32,
+}
+
+/// The user's answers to a keyboard-interactive challenge, sent from the
+/// frontend back to the awaiting handler.
+///
+/// The answers themselves are plaintext secrets in transit only — the backend
+/// wraps them in `zeroize::Zeroizing` the instant they arrive and never logs
+/// their content. We do NOT derive `Debug` to avoid accidental logging of the
+/// answers.
+#[derive(Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct KeyboardInteractiveResponse {
+    /// One answer per prompt, in prompt order.
+    pub responses: Vec<String>,
+}
+
 // ─── Terminal Events (streamed via Tauri Channel) ───────
 
 #[derive(Clone, Serialize)]
@@ -521,5 +582,63 @@ mod tests {
         s.set_idle_timeout_secs(900);
         s.record_activity_at(Instant::now() - Duration::from_secs(5000));
         assert_eq!(s.seconds_until_lock(), Some(0));
+    }
+
+    // ─── Keyboard-Interactive serde ─────────────────────────────────
+
+    #[test]
+    fn ki_prompt_serializes_camel_case() {
+        let prompt = KeyboardInteractivePrompt {
+            text: "Verification code:".to_string(),
+            echo: false,
+        };
+        let json = serde_json::to_value(&prompt).unwrap();
+        assert_eq!(json["text"], "Verification code:");
+        assert_eq!(json["echo"], false);
+    }
+
+    #[test]
+    fn ki_challenge_request_roundtrips() {
+        let req = KeyboardInteractiveChallengeRequest {
+            session_id: Some(Uuid::nil()),
+            name: "MFA".to_string(),
+            instruction: "Enter your one-time code".to_string(),
+            prompts: vec![
+                KeyboardInteractivePrompt {
+                    text: "Password:".to_string(),
+                    echo: false,
+                },
+                KeyboardInteractivePrompt {
+                    text: "OTP:".to_string(),
+                    echo: false,
+                },
+            ],
+            round: 1,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let back: KeyboardInteractiveChallengeRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(req, back);
+    }
+
+    #[test]
+    fn ki_challenge_request_omits_none_session_id() {
+        let req = KeyboardInteractiveChallengeRequest {
+            session_id: None,
+            name: String::new(),
+            instruction: String::new(),
+            prompts: vec![],
+            round: 1,
+        };
+        let json = serde_json::to_value(&req).unwrap();
+        assert!(json.get("sessionId").is_none());
+        // camelCase rename for the round counter is preserved.
+        assert_eq!(json["round"], 1);
+    }
+
+    #[test]
+    fn ki_response_deserializes_from_camel_case() {
+        let json = r#"{"responses":["hunter2","123456"]}"#;
+        let resp: KeyboardInteractiveResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.responses, vec!["hunter2", "123456"]);
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -138,6 +138,12 @@ pub struct SessionHandle {
     pub username: String,
     pub state: SessionState,
     pub ssh_handle: Option<russh::client::Handle<crate::ssh::handler::SshClientHandler>>,
+    /// When the session was established THROUGH a bastion (`ssh -J`), this holds
+    /// the live bastion SSH handle. It MUST be kept alive for the lifetime of
+    /// the session: the target connection runs over a direct-tcpip channel that
+    /// the bastion's session task drives, so dropping this handle would tear
+    /// down the tunnel underneath the target. `None` for direct connections.
+    pub bastion_handle: Option<russh::client::Handle<crate::ssh::session::BastionHandler>>,
     pub terminals: HashMap<TerminalId, TerminalChannelHandle>,
     pub sftp: Option<SftpSessionHandle>,
     pub tunnels: HashMap<TunnelId, TunnelHandle>,

--- a/src-tauri/src/vault.rs
+++ b/src-tauri/src/vault.rs
@@ -3,25 +3,30 @@
 // All SSH credentials are stored in an AES-256-GCM encrypted file,
 // keyed by a master password via Argon2id key derivation.
 //
-// Vault file format (JSON on disk):
+// Vault file format (JSON on disk), version 2:
 // {
-//   "version": 1,
+//   "version": 2,
 //   "salt": "<base64 32-byte salt>",
+//   "kdf": { "algorithm": "argon2id", "m_cost": 65536, "t_cost": 3, "p_cost": 1 },
+//   "verifier": "<base64 nonce(12) + ciphertext + tag(16)>",
 //   "credentials": {
 //     "<profile_id:type>": "<base64 nonce(12) + ciphertext + tag(16)>"
 //   }
 // }
+//
+// Legacy version 1 files (no `kdf`, no `verifier`) are still readable; the
+// first successful unlock transparently re-encrypts them as version 2.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use aes_gcm::aead::{Aead, KeyInit, OsRng};
 use aes_gcm::{Aes256Gcm, Nonce};
-use argon2::Argon2;
+use argon2::{Algorithm, Argon2, Params, Version};
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
-use zeroize::Zeroize;
+use zeroize::Zeroizing;
 
 use crate::error::AppError;
 use crate::fs_secure;
@@ -30,7 +35,7 @@ use crate::fs_secure;
 const VAULT_FILE: &str = "vault.json";
 
 /// Current vault format version.
-const VAULT_VERSION: u32 = 1;
+const VAULT_VERSION: u32 = 2;
 
 /// AES-256-GCM nonce size in bytes.
 const NONCE_SIZE: usize = 12;
@@ -38,12 +43,61 @@ const NONCE_SIZE: usize = 12;
 /// Salt size in bytes for Argon2id.
 const SALT_SIZE: usize = 32;
 
+/// Fixed plaintext encrypted under the derived key to verify the master
+/// password independently of how many credentials the vault holds. The
+/// AES-GCM auth tag also guards the verifier's integrity.
+const VERIFIER_PLAINTEXT: &[u8] = b"nexterm-vault-verifier-v2";
+
 // ─── On-Disk Format ─────────────────────────────────────
 
+/// KDF parameters persisted with the vault so future reads use the exact
+/// settings the file was written with.
+#[derive(Serialize, Deserialize, Clone)]
+pub struct KdfParams {
+    pub algorithm: String,
+    pub m_cost: u32,
+    pub t_cost: u32,
+    pub p_cost: u32,
+}
+
+/// Default Argon2id parameters for newly created / migrated vaults:
+/// m_cost = 64 MiB, t_cost = 3, p_cost = 1.
+pub fn default_kdf_params() -> KdfParams {
+    KdfParams {
+        algorithm: "argon2id".to_string(),
+        m_cost: 65536,
+        t_cost: 3,
+        p_cost: 1,
+    }
+}
+
+/// Build an Argon2id hasher from persisted KDF params. Shared by the vault
+/// and the profile-export path so both derive keys identically.
+pub fn argon2_from_params(p: &KdfParams) -> Result<Argon2<'static>, AppError> {
+    if p.algorithm != "argon2id" {
+        return Err(AppError::VaultError(format!(
+            "Unsupported KDF algorithm: {}",
+            p.algorithm
+        )));
+    }
+    let params = Params::new(p.m_cost, p.t_cost, p.p_cost, None)
+        .map_err(|e| AppError::VaultError(format!("Invalid KDF params: {e}")))?;
+    Ok(Argon2::new(Algorithm::Argon2id, Version::V0x13, params))
+}
+
+/// On-disk shape. `kdf` and `verifier` are absent in legacy v1 files, so they
+/// are optional here and presence drives the v1-vs-v2 branch in `unlock`.
+/// `deny_unknown_fields` makes a corrupt or tampered file fail loudly at parse
+/// time instead of silently ignoring junk/typo'd keys.
 #[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct VaultFile {
     version: u32,
     salt: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    kdf: Option<KdfParams>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    verifier: Option<String>,
     credentials: HashMap<String, String>,
 }
 
@@ -51,8 +105,10 @@ struct VaultFile {
 
 pub struct Vault {
     file_path: PathBuf,
-    derived_key: Option<[u8; 32]>,
+    // TODO(security): best-effort mlock to keep key out of swap
+    derived_key: Option<Zeroizing<[u8; 32]>>,
     salt: [u8; SALT_SIZE],
+    kdf_params: KdfParams,
     credentials: HashMap<String, Vec<u8>>,
 }
 
@@ -86,13 +142,15 @@ impl Vault {
         let mut salt = [0u8; SALT_SIZE];
         OsRng.fill_bytes(&mut salt);
 
-        // Derive key
-        let derived_key = Self::derive_key(master_password, &salt)?;
+        // Derive key with the current default KDF params
+        let kdf_params = default_kdf_params();
+        let derived_key = Self::derive_key(master_password, &salt, &kdf_params)?;
 
         let vault = Vault {
             file_path,
             derived_key: Some(derived_key),
             salt,
+            kdf_params,
             credentials: HashMap::new(),
         };
 
@@ -103,8 +161,10 @@ impl Vault {
 
     /// Open an existing vault with the master password.
     ///
-    /// Reads the vault file, derives the key, and validates it by attempting
-    /// to decrypt one credential (if any exist).
+    /// For v2 vaults the password is validated by decrypting a fixed verifier
+    /// (works regardless of credential count). v1 vaults are read with the
+    /// legacy KDF params, validated against their credentials (when any), then
+    /// transparently re-encrypted and rewritten as v2.
     pub fn unlock(data_dir: &Path, master_password: &str) -> Result<Self, AppError> {
         let file_path = data_dir.join(VAULT_FILE);
 
@@ -114,14 +174,7 @@ impl Vault {
         let vault_file: VaultFile = serde_json::from_str(&contents)
             .map_err(|e| AppError::VaultError(format!("Corrupt vault file: {e}")))?;
 
-        if vault_file.version != VAULT_VERSION {
-            return Err(AppError::VaultError(format!(
-                "Unsupported vault version: {}",
-                vault_file.version
-            )));
-        }
-
-        // Decode salt
+        // Decode salt (shared by both formats)
         let salt_bytes = BASE64
             .decode(&vault_file.salt)
             .map_err(|e| AppError::VaultError(format!("Invalid salt encoding: {e}")))?;
@@ -131,10 +184,7 @@ impl Vault {
         let mut salt = [0u8; SALT_SIZE];
         salt.copy_from_slice(&salt_bytes);
 
-        // Derive key
-        let derived_key = Self::derive_key(master_password, &salt)?;
-
-        // Decode all credentials from base64
+        // Decode all credentials from base64 (shared by both formats)
         let mut credentials = HashMap::new();
         for (key, b64_val) in &vault_file.credentials {
             let bytes = BASE64.decode(b64_val).map_err(|e| {
@@ -143,17 +193,42 @@ impl Vault {
             credentials.insert(key.clone(), bytes);
         }
 
-        let vault = Vault {
-            file_path,
-            derived_key: Some(derived_key),
-            salt,
-            credentials,
-        };
+        // Branch on the file shape: a v2 file carries `kdf` + `verifier`; a v1
+        // file (version 1, no kdf/verifier) takes the legacy migration path.
+        let vault = match (vault_file.version, &vault_file.kdf, &vault_file.verifier) {
+            (VAULT_VERSION, Some(kdf), Some(verifier_b64)) => {
+                let kdf_params = kdf.clone();
+                let derived_key = Self::derive_key(master_password, &salt, &kdf_params)?;
 
-        // Validate the password by trying to decrypt the first credential
-        if let Some((key, _)) = vault.credentials.iter().next() {
-            vault.get(key).map_err(|_| AppError::VaultWrongPassword)?;
-        }
+                let vault = Vault {
+                    file_path,
+                    derived_key: Some(derived_key),
+                    salt,
+                    kdf_params,
+                    credentials,
+                };
+
+                // Validate the password by decrypting the fixed verifier; an
+                // AEAD failure means a wrong password (or tampered verifier).
+                let verifier_bytes = BASE64
+                    .decode(verifier_b64)
+                    .map_err(|e| AppError::VaultError(format!("Invalid verifier encoding: {e}")))?;
+                let plaintext = vault
+                    .decrypt_raw(&verifier_bytes)
+                    .map_err(|_| AppError::VaultWrongPassword)?;
+                if plaintext != VERIFIER_PLAINTEXT {
+                    return Err(AppError::VaultWrongPassword);
+                }
+
+                vault
+            }
+            (1, None, None) => Self::migrate_v1(file_path, master_password, salt, credentials)?,
+            (version, _, _) => {
+                return Err(AppError::VaultError(format!(
+                    "Unsupported vault version: {version}"
+                )));
+            }
+        };
 
         // Idempotent migration: re-apply owner-only access to the existing
         // vault file in case it was created by an older version of the app
@@ -161,6 +236,71 @@ impl Vault {
         if let Err(e) = fs_secure::harden_existing(&vault.file_path) {
             tracing::warn!("Failed to harden existing vault file: {e}");
         }
+
+        Ok(vault)
+    }
+
+    /// Read a legacy v1 vault: derive the key with the legacy Argon2 default
+    /// params, validate the password against the existing credentials (when
+    /// any exist), then re-key with the current default params and rewrite the
+    /// file as v2 with a verifier.
+    ///
+    /// NOTE: an EMPTY v1 vault cannot validate the password (the pre-existing
+    /// v1 limitation — there is nothing to decrypt), so we accept any password
+    /// for it, migrate, and write the verifier going forward.
+    fn migrate_v1(
+        file_path: PathBuf,
+        master_password: &str,
+        salt: [u8; SALT_SIZE],
+        legacy_credentials: HashMap<String, Vec<u8>>,
+    ) -> Result<Self, AppError> {
+        // Legacy v1 used `Argon2::default()` (m=19456, t=2, p=1).
+        let legacy_params = KdfParams {
+            algorithm: "argon2id".to_string(),
+            m_cost: Params::DEFAULT_M_COST,
+            t_cost: Params::DEFAULT_T_COST,
+            p_cost: Params::DEFAULT_P_COST,
+        };
+        let legacy_key = Self::derive_key(master_password, &salt, &legacy_params)?;
+
+        // Decrypt all credentials with the legacy key. A non-empty vault thus
+        // validates the password here (an AEAD failure ⇒ wrong password).
+        let legacy_vault = Vault {
+            file_path: file_path.clone(),
+            derived_key: Some(legacy_key),
+            salt,
+            kdf_params: legacy_params,
+            credentials: legacy_credentials,
+        };
+        let mut plaintext_map: HashMap<String, String> = HashMap::new();
+        for (key, encrypted) in &legacy_vault.credentials {
+            let plain = legacy_vault
+                .decrypt(encrypted)
+                .map_err(|_| AppError::VaultWrongPassword)?;
+            plaintext_map.insert(key.clone(), plain);
+        }
+
+        // Re-key with the current default params and a fresh salt, then
+        // re-encrypt every credential. save_to_disk() writes the v2 file with
+        // the verifier.
+        let mut new_salt = [0u8; SALT_SIZE];
+        OsRng.fill_bytes(&mut new_salt);
+        let kdf_params = default_kdf_params();
+        let new_key = Self::derive_key(master_password, &new_salt, &kdf_params)?;
+
+        let mut vault = Vault {
+            file_path,
+            derived_key: Some(new_key),
+            salt: new_salt,
+            kdf_params,
+            credentials: HashMap::new(),
+        };
+        for (key, plain) in &plaintext_map {
+            let encrypted = vault.encrypt(plain)?;
+            vault.credentials.insert(key.clone(), encrypted);
+        }
+
+        vault.save_to_disk()?;
 
         Ok(vault)
     }
@@ -209,16 +349,13 @@ impl Vault {
             plaintext_map.insert(key.clone(), plain);
         }
 
-        // Generate new salt and derive new key
+        // Generate new salt and derive new key with the current default params
         let mut new_salt = [0u8; SALT_SIZE];
         OsRng.fill_bytes(&mut new_salt);
-        let new_key = Self::derive_key(new_password, &new_salt)?;
+        self.kdf_params = default_kdf_params();
+        let new_key = Self::derive_key(new_password, &new_salt, &self.kdf_params)?;
 
-        // Zeroize old key
-        if let Some(ref mut old_key) = self.derived_key {
-            old_key.zeroize();
-        }
-
+        // Replacing the key drops the old Zeroizing wrapper, which zeroizes it.
         self.salt = new_salt;
         self.derived_key = Some(new_key);
 
@@ -232,11 +369,9 @@ impl Vault {
         self.save_to_disk()
     }
 
-    /// Lock the vault — clear derived key from memory.
+    /// Lock the vault — clear derived key from memory. Dropping the
+    /// `Zeroizing` wrapper zeroizes the key bytes.
     pub fn lock(&mut self) {
-        if let Some(ref mut key) = self.derived_key {
-            key.zeroize();
-        }
         self.derived_key = None;
     }
 
@@ -247,20 +382,26 @@ impl Vault {
 
     // ─── Private Helpers ────────────────────────────────
 
-    /// Derive a 32-byte key from password + salt using Argon2id.
-    fn derive_key(password: &str, salt: &[u8; SALT_SIZE]) -> Result<[u8; 32], AppError> {
-        let mut key = [0u8; 32];
-        Argon2::default()
-            .hash_password_into(password.as_bytes(), salt, &mut key)
+    /// Derive a 32-byte key from password + salt using Argon2id with the
+    /// supplied KDF params. The key is wrapped in `Zeroizing` so it is wiped
+    /// from memory on drop.
+    fn derive_key(
+        password: &str,
+        salt: &[u8; SALT_SIZE],
+        params: &KdfParams,
+    ) -> Result<Zeroizing<[u8; 32]>, AppError> {
+        let mut key = Zeroizing::new([0u8; 32]);
+        argon2_from_params(params)?
+            .hash_password_into(password.as_bytes(), salt, key.as_mut())
             .map_err(|e| AppError::VaultError(format!("Key derivation failed: {e}")))?;
         Ok(key)
     }
 
-    /// Encrypt a plaintext string → nonce(12) + ciphertext + tag(16).
-    fn encrypt(&self, plaintext: &str) -> Result<Vec<u8>, AppError> {
+    /// Encrypt raw bytes → nonce(12) + ciphertext + tag(16).
+    fn encrypt_bytes(&self, plaintext: &[u8]) -> Result<Vec<u8>, AppError> {
         let key = self.derived_key.as_ref().ok_or(AppError::VaultLocked)?;
 
-        let cipher = Aes256Gcm::new_from_slice(key)
+        let cipher = Aes256Gcm::new_from_slice(key.as_slice())
             .map_err(|e| AppError::VaultError(format!("Cipher init failed: {e}")))?;
 
         // Generate random nonce
@@ -269,7 +410,7 @@ impl Vault {
         let nonce = Nonce::from_slice(&nonce_bytes);
 
         let ciphertext = cipher
-            .encrypt(nonce, plaintext.as_bytes())
+            .encrypt(nonce, plaintext)
             .map_err(|e| AppError::VaultError(format!("Encryption failed: {e}")))?;
 
         // Prepend nonce to ciphertext
@@ -280,24 +421,33 @@ impl Vault {
         Ok(result)
     }
 
-    /// Decrypt nonce(12) + ciphertext + tag(16) → plaintext string.
-    fn decrypt(&self, data: &[u8]) -> Result<String, AppError> {
+    /// Encrypt a plaintext string → nonce(12) + ciphertext + tag(16).
+    fn encrypt(&self, plaintext: &str) -> Result<Vec<u8>, AppError> {
+        self.encrypt_bytes(plaintext.as_bytes())
+    }
+
+    /// Decrypt nonce(12) + ciphertext + tag(16) → raw plaintext bytes.
+    fn decrypt_raw(&self, data: &[u8]) -> Result<Vec<u8>, AppError> {
         let key = self.derived_key.as_ref().ok_or(AppError::VaultLocked)?;
 
         if data.len() < NONCE_SIZE + 16 {
             return Err(AppError::VaultError("Ciphertext too short".to_string()));
         }
 
-        let cipher = Aes256Gcm::new_from_slice(key)
+        let cipher = Aes256Gcm::new_from_slice(key.as_slice())
             .map_err(|e| AppError::VaultError(format!("Cipher init failed: {e}")))?;
 
         let nonce = Nonce::from_slice(&data[..NONCE_SIZE]);
         let ciphertext = &data[NONCE_SIZE..];
 
-        let plaintext = cipher
+        cipher
             .decrypt(nonce, ciphertext)
-            .map_err(|_| AppError::VaultError("Decryption failed".to_string()))?;
+            .map_err(|_| AppError::VaultError("Decryption failed".to_string()))
+    }
 
+    /// Decrypt nonce(12) + ciphertext + tag(16) → plaintext string.
+    fn decrypt(&self, data: &[u8]) -> Result<String, AppError> {
+        let plaintext = self.decrypt_raw(data)?;
         String::from_utf8(plaintext)
             .map_err(|e| AppError::VaultError(format!("Invalid UTF-8 in credential: {e}")))
     }
@@ -311,9 +461,16 @@ impl Vault {
             encoded_creds.insert(key.clone(), BASE64.encode(bytes));
         }
 
+        // Freshly encrypt the verifier under the current key (new nonce each
+        // save) so the master password can be validated on the next unlock
+        // regardless of credential count.
+        let verifier = self.encrypt_bytes(VERIFIER_PLAINTEXT)?;
+
         let vault_file = VaultFile {
             version: VAULT_VERSION,
             salt: BASE64.encode(self.salt),
+            kdf: Some(self.kdf_params.clone()),
+            verifier: Some(BASE64.encode(&verifier)),
             credentials: encoded_creds,
         };
 
@@ -329,5 +486,203 @@ impl Vault {
 
         fs_secure::secure_write(&self.file_path, json.as_bytes())
             .map_err(|e| AppError::VaultError(format!("Failed to write vault: {e}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn read_vault_json(dir: &Path) -> serde_json::Value {
+        let contents = std::fs::read_to_string(dir.join(VAULT_FILE)).unwrap();
+        serde_json::from_str(&contents).unwrap()
+    }
+
+    #[test]
+    fn unlock_empty_vault_rejects_wrong_password() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let _vault = Vault::create(dir.path(), "correct-horse").unwrap();
+        }
+
+        let result = Vault::unlock(dir.path(), "wrong").map(|_| ());
+        assert!(
+            matches!(result, Err(AppError::VaultWrongPassword)),
+            "empty vault must reject a wrong master password, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn unlock_empty_vault_accepts_correct_password() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let _vault = Vault::create(dir.path(), "correct-horse").unwrap();
+        }
+
+        let vault = Vault::unlock(dir.path(), "correct-horse").unwrap();
+        assert!(vault.is_unlocked());
+    }
+
+    #[test]
+    fn unlock_nonempty_rejects_wrong_password() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let mut vault = Vault::create(dir.path(), "correct-horse").unwrap();
+            vault.store("p1:password", "s3cr3t").unwrap();
+        }
+
+        let result = Vault::unlock(dir.path(), "wrong").map(|_| ());
+        assert!(
+            matches!(result, Err(AppError::VaultWrongPassword)),
+            "non-empty vault must reject a wrong master password, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn unlock_nonempty_accepts_correct() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let mut vault = Vault::create(dir.path(), "correct-horse").unwrap();
+            vault.store("p1:password", "s3cr3t").unwrap();
+        }
+
+        let vault = Vault::unlock(dir.path(), "correct-horse").unwrap();
+        assert!(vault.is_unlocked());
+        assert_eq!(
+            vault.get("p1:password").unwrap(),
+            Some("s3cr3t".to_string())
+        );
+    }
+
+    #[test]
+    fn vault_file_persists_kdf_params() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let _vault = Vault::create(dir.path(), "correct-horse").unwrap();
+        }
+
+        let json = read_vault_json(dir.path());
+        assert_eq!(json["version"], 2);
+        assert_eq!(json["kdf"]["algorithm"], "argon2id");
+        assert_eq!(json["kdf"]["m_cost"], 65536);
+        assert_eq!(json["kdf"]["t_cost"], 3);
+        assert_eq!(json["kdf"]["p_cost"], 1);
+        let verifier = json["verifier"].as_str().unwrap();
+        assert!(
+            !verifier.is_empty(),
+            "verifier must be present and non-empty"
+        );
+    }
+
+    /// Hand-write a legacy v1 vault file (old shape: no `kdf`, no `verifier`),
+    /// using the legacy Argon2 default params, and confirm `unlock` migrates it.
+    #[test]
+    fn v1_vault_migrates_to_v2() {
+        let dir = tempfile::tempdir().unwrap();
+        let password = "correct-horse";
+
+        // Build a legacy v1 file by hand.
+        let mut salt = [0u8; SALT_SIZE];
+        OsRng.fill_bytes(&mut salt);
+        let legacy_key = legacy_derive_key(password, &salt);
+
+        // Encrypt one credential with the legacy key the same way v1 did.
+        let plaintext = "s3cr3t";
+        let cipher = Aes256Gcm::new_from_slice(&legacy_key).unwrap();
+        let mut nonce_bytes = [0u8; NONCE_SIZE];
+        OsRng.fill_bytes(&mut nonce_bytes);
+        let nonce = Nonce::from_slice(&nonce_bytes);
+        let ct = cipher.encrypt(nonce, plaintext.as_bytes()).unwrap();
+        let mut blob = Vec::with_capacity(NONCE_SIZE + ct.len());
+        blob.extend_from_slice(&nonce_bytes);
+        blob.extend_from_slice(&ct);
+
+        let mut creds = HashMap::new();
+        creds.insert("p1:password".to_string(), BASE64.encode(&blob));
+
+        let v1 = serde_json::json!({
+            "version": 1,
+            "salt": BASE64.encode(salt),
+            "credentials": creds,
+        });
+        std::fs::write(
+            dir.path().join(VAULT_FILE),
+            serde_json::to_string_pretty(&v1).unwrap(),
+        )
+        .unwrap();
+
+        // Wrong password on a non-empty v1 vault must fail.
+        let wrong = Vault::unlock(dir.path(), "nope").map(|_| ());
+        assert!(
+            matches!(wrong, Err(AppError::VaultWrongPassword)),
+            "v1 unlock with wrong password must fail, got {wrong:?}"
+        );
+
+        // Correct password unlocks and decrypts the credential.
+        let vault = Vault::unlock(dir.path(), password).unwrap();
+        assert_eq!(
+            vault.get("p1:password").unwrap(),
+            Some(plaintext.to_string())
+        );
+        drop(vault);
+
+        // The file on disk has been upgraded to v2 with a verifier.
+        let json = read_vault_json(dir.path());
+        assert_eq!(json["version"], 2);
+        assert!(json["verifier"].as_str().is_some_and(|v| !v.is_empty()));
+        assert_eq!(json["kdf"]["m_cost"], 65536);
+
+        // And it still opens with the correct password after migration.
+        let reopened = Vault::unlock(dir.path(), password).unwrap();
+        assert_eq!(
+            reopened.get("p1:password").unwrap(),
+            Some(plaintext.to_string())
+        );
+    }
+
+    #[test]
+    fn change_master_password_rotates_verifier() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let mut vault = Vault::create(dir.path(), "old-pass").unwrap();
+            vault.store("p1:password", "s3cr3t").unwrap();
+            let salt_before = read_vault_json(dir.path())["salt"]
+                .as_str()
+                .unwrap()
+                .to_string();
+            vault.change_master_password("new-pass").unwrap();
+            let salt_after = read_vault_json(dir.path())["salt"]
+                .as_str()
+                .unwrap()
+                .to_string();
+            assert_ne!(
+                salt_before, salt_after,
+                "salt must rotate on password change"
+            );
+        }
+
+        // Old password no longer works.
+        let old = Vault::unlock(dir.path(), "old-pass").map(|_| ());
+        assert!(
+            matches!(old, Err(AppError::VaultWrongPassword)),
+            "old password must fail after change, got {old:?}"
+        );
+
+        // New password works and credential survives.
+        let vault = Vault::unlock(dir.path(), "new-pass").unwrap();
+        assert_eq!(
+            vault.get("p1:password").unwrap(),
+            Some("s3cr3t".to_string())
+        );
+    }
+
+    /// Derive a key with the legacy Argon2 default params (m=19456, t=2, p=1),
+    /// matching how v1 vaults were created via `Argon2::default()`.
+    fn legacy_derive_key(password: &str, salt: &[u8; SALT_SIZE]) -> [u8; 32] {
+        let mut key = [0u8; 32];
+        Argon2::default()
+            .hash_password_into(password.as_bytes(), salt, &mut key)
+            .unwrap();
+        key
     }
 }

--- a/src-tauri/src/vault.rs
+++ b/src-tauri/src/vault.rs
@@ -19,6 +19,7 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use aes_gcm::aead::{Aead, KeyInit, OsRng};
 use aes_gcm::{Aes256Gcm, Nonce};
@@ -47,6 +48,45 @@ const SALT_SIZE: usize = 32;
 /// password independently of how many credentials the vault holds. The
 /// AES-GCM auth tag also guards the verifier's integrity.
 const VERIFIER_PLAINTEXT: &[u8] = b"nexterm-vault-verifier-v2";
+
+// ─── Auto-Lock Decision Logic (pure cores) ──────────────
+
+/// Default idle timeout before the vault auto-locks: 15 minutes.
+pub const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 900;
+
+/// Pure decision core for idle auto-lock.
+///
+/// Returns `true` when the vault should be locked because it has been idle for
+/// at least `timeout`. A `timeout` of zero disables auto-lock entirely (the
+/// vault never auto-locks regardless of how long it has been idle).
+///
+/// This is deterministic and side-effect free so it can be unit-tested with
+/// explicit `Duration` inputs — no sleeping, no clock reads.
+pub fn idle_should_lock(idle_elapsed: Duration, timeout: Duration) -> bool {
+    if timeout.is_zero() {
+        return false;
+    }
+    idle_elapsed >= timeout
+}
+
+/// Pure decision core for OS-suspend detection via monotonic-clock gap.
+///
+/// Tauri 2.10 does not expose an OS suspend/resume signal (see the module-level
+/// note on `spawn_auto_lock_task` callers), so we infer suspension by watching
+/// for a jump in a monotonic timer: while the OS is asleep our periodic tick is
+/// frozen, so when it resumes the observed gap between ticks is far larger than
+/// the nominal `tick_interval`. A gap exceeding `tick_interval + slack` means
+/// time was lost (suspend, debugger pause, or severe scheduling stall) and the
+/// vault should be locked defensively.
+///
+/// Deterministic and side-effect free for unit testing with explicit inputs.
+pub fn suspend_gap_detected(
+    observed_gap: Duration,
+    tick_interval: Duration,
+    slack: Duration,
+) -> bool {
+    observed_gap > tick_interval.saturating_add(slack)
+}
 
 // ─── On-Disk Format ─────────────────────────────────────
 
@@ -496,6 +536,77 @@ impl Vault {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ─── Auto-lock decision cores ───────────────────────
+
+    #[test]
+    fn idle_locks_when_elapsed_equals_timeout() {
+        // Boundary: elapsed exactly at the timeout must lock.
+        assert!(idle_should_lock(
+            Duration::from_secs(900),
+            Duration::from_secs(900)
+        ));
+    }
+
+    #[test]
+    fn idle_locks_when_elapsed_exceeds_timeout() {
+        assert!(idle_should_lock(
+            Duration::from_secs(901),
+            Duration::from_secs(900)
+        ));
+    }
+
+    #[test]
+    fn idle_does_not_lock_before_timeout() {
+        assert!(!idle_should_lock(
+            Duration::from_secs(899),
+            Duration::from_secs(900)
+        ));
+        assert!(!idle_should_lock(
+            Duration::from_secs(0),
+            Duration::from_secs(900)
+        ));
+    }
+
+    #[test]
+    fn idle_timeout_zero_disables_autolock() {
+        // timeout == 0 means "never auto-lock", even after a huge idle gap.
+        assert!(!idle_should_lock(
+            Duration::from_secs(0),
+            Duration::from_secs(0)
+        ));
+        assert!(!idle_should_lock(
+            Duration::from_secs(u64::MAX / 2),
+            Duration::from_secs(0)
+        ));
+    }
+
+    #[test]
+    fn suspend_gap_detected_when_gap_far_exceeds_interval() {
+        // 5s tick + 2s slack tolerated; a 60s gap implies the OS was asleep.
+        assert!(suspend_gap_detected(
+            Duration::from_secs(60),
+            Duration::from_secs(5),
+            Duration::from_secs(2)
+        ));
+    }
+
+    #[test]
+    fn suspend_gap_not_detected_for_normal_jitter() {
+        // A tick slightly late (within tick + slack) is normal scheduling
+        // jitter, not a suspend — must not trigger.
+        assert!(!suspend_gap_detected(
+            Duration::from_secs(6),
+            Duration::from_secs(5),
+            Duration::from_secs(2)
+        ));
+        // Exactly at the tolerance boundary is still not a suspend.
+        assert!(!suspend_gap_detected(
+            Duration::from_secs(7),
+            Duration::from_secs(5),
+            Duration::from_secs(2)
+        ));
+    }
 
     fn read_vault_json(dir: &Path) -> serde_json::Value {
         let contents = std::fs::read_to_string(dir.join(VAULT_FILE)).unwrap();

--- a/src-tauri/src/vault.rs
+++ b/src-tauri/src/vault.rs
@@ -313,11 +313,15 @@ impl Vault {
     }
 
     /// Get a credential (decrypt from memory).
-    pub fn get(&self, key: &str) -> Result<Option<String>, AppError> {
+    ///
+    /// The decrypted plaintext is returned wrapped in `Zeroizing` so it is
+    /// wiped from the heap when the caller drops it. Callers should keep it
+    /// wrapped for as long as possible and avoid copying it into bare `String`s.
+    pub fn get(&self, key: &str) -> Result<Option<Zeroizing<String>>, AppError> {
         match self.credentials.get(key) {
             Some(encrypted) => {
                 let plaintext = self.decrypt(encrypted)?;
-                Ok(Some(plaintext))
+                Ok(Some(Zeroizing::new(plaintext)))
             }
             None => Ok(None),
         }
@@ -549,7 +553,7 @@ mod tests {
         let vault = Vault::unlock(dir.path(), "correct-horse").unwrap();
         assert!(vault.is_unlocked());
         assert_eq!(
-            vault.get("p1:password").unwrap(),
+            vault.get("p1:password").unwrap().map(|z| z.to_string()),
             Some("s3cr3t".to_string())
         );
     }
@@ -621,7 +625,7 @@ mod tests {
         // Correct password unlocks and decrypts the credential.
         let vault = Vault::unlock(dir.path(), password).unwrap();
         assert_eq!(
-            vault.get("p1:password").unwrap(),
+            vault.get("p1:password").unwrap().map(|z| z.to_string()),
             Some(plaintext.to_string())
         );
         drop(vault);
@@ -635,7 +639,7 @@ mod tests {
         // And it still opens with the correct password after migration.
         let reopened = Vault::unlock(dir.path(), password).unwrap();
         assert_eq!(
-            reopened.get("p1:password").unwrap(),
+            reopened.get("p1:password").unwrap().map(|z| z.to_string()),
             Some(plaintext.to_string())
         );
     }
@@ -671,7 +675,7 @@ mod tests {
         // New password works and credential survives.
         let vault = Vault::unlock(dir.path(), "new-pass").unwrap();
         assert_eq!(
-            vault.get("p1:password").unwrap(),
+            vault.get("p1:password").unwrap().map(|z| z.to_string()),
             Some("s3cr3t".to_string())
         );
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@
 //
 // Orchestrates: vault unlock, layout, connection dialogs, terminal + SFTP view routing
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { AppLayout } from "./components/layout/AppLayout";
 import { TabBar } from "./components/layout/TabBar";
 import { ConnectionDialog } from "./features/connection/ConnectionDialog";
@@ -22,14 +22,186 @@ import { useConnection } from "./features/connection/useConnection";
 import { useUpdater } from "./features/updater/useUpdater";
 import { useI18n } from "./lib/i18n";
 import { tauriInvoke } from "./lib/tauri";
+import type { ConnectionProfile } from "./lib/types";
 
 interface VaultStatus {
   exists: boolean;
   unlocked: boolean;
 }
 
-function App() {
+// ─── Lamplight Launchpad (empty state) ──────────────────────
+// Replaces the raw .welcome h2+p with an action-focused surface.
+
+interface WelcomeLaunchpadProps {
+  connecting: boolean;
+  connectingProfileId: string | null;
+  connectError: string | null;
+  onNewProfile: () => void;
+  onConnect: (profileId: string) => void;
+  onCancelConnect: () => void;
+  profiles: ConnectionProfile[];
+}
+
+// Server + plug glyph — warm line-art, one copper highlight
+function ServerGlyph() {
+  return (
+    <svg
+      className="lp-welcome-glyph"
+      width="72"
+      height="72"
+      viewBox="0 0 72 72"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      {/* Server body */}
+      <rect x="12" y="18" width="48" height="12" rx="3" strokeWidth="1.5" stroke="currentColor" />
+      <rect x="12" y="34" width="48" height="12" rx="3" strokeWidth="1.5" stroke="currentColor" />
+      {/* Drive dots */}
+      <circle cx="20" cy="24" r="2" fill="currentColor" />
+      <circle cx="20" cy="40" r="2" fill="currentColor" />
+      {/* Status lights — copper highlight on the right-most one */}
+      <circle cx="50" cy="24" r="2" fill="currentColor" />
+      <circle cx="56" cy="24" r="2" className="lp-glyph-accent" />
+      <circle cx="50" cy="40" r="2" fill="currentColor" />
+      {/* Plug connector at bottom */}
+      <line x1="36" y1="46" x2="36" y2="54" strokeWidth="1.5" stroke="currentColor" strokeLinecap="round" />
+      <rect x="28" y="54" width="16" height="8" rx="2" strokeWidth="1.5" stroke="currentColor" />
+      <line x1="31" y1="58" x2="31" y2="62" strokeWidth="1.5" stroke="currentColor" strokeLinecap="round" />
+      <line x1="41" y1="58" x2="41" y2="62" strokeWidth="1.5" stroke="currentColor" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function timeAgo(isoDate: string): string {
+  const ms = Date.now() - new Date(isoDate).getTime();
+  const m = Math.floor(ms / 60000);
+  if (m < 1) return "<1m";
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h`;
+  const d = Math.floor(h / 24);
+  return `${d}d`;
+}
+
+function WelcomeLaunchpad({
+  connecting,
+  connectingProfileId,
+  connectError,
+  onNewProfile,
+  onConnect,
+  onCancelConnect,
+  profiles,
+}: WelcomeLaunchpadProps) {
   const { t } = useI18n();
+
+  // Build "Recent" list from profiles sorted by updatedAt (most recent first)
+  // Presentational only — no backend change.
+  const recentProfiles = useMemo(() => {
+    return [...profiles]
+      .sort((a, b) => {
+        const ta = new Date(a.updatedAt).getTime();
+        const tb = new Date(b.updatedAt).getTime();
+        return tb - ta;
+      })
+      .slice(0, 5);
+  }, [profiles]);
+
+  // Find the connecting profile name if one is in progress
+  const connectingProfile = connectingProfileId
+    ? profiles.find((p) => p.id === connectingProfileId)
+    : null;
+
+  if (connecting && connectingProfile) {
+    // Inline progress row — replaces the whole welcome surface while connecting
+    return (
+      <div className="lp-welcome">
+        <div className="lp-welcome-connecting">
+          <span className="lp-connecting-dot" />
+          <span className="lp-connecting-label">
+            {t("welcome.connectingTo", { host: `${connectingProfile.host}:${connectingProfile.port}` })}
+          </span>
+          <button
+            className="lp-connecting-cancel"
+            onClick={onCancelConnect}
+          >
+            {t("welcome.cancelConnect")}
+          </button>
+        </div>
+        {connectError && (
+          <div className="lp-welcome-error">{connectError}</div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="lp-welcome">
+      <div className="lp-welcome-column">
+        {/* Line-art server glyph */}
+        <ServerGlyph />
+
+        {/* Headline */}
+        <h1 className="lp-welcome-headline">{t("welcome.headline")}</h1>
+
+        {/* Subline */}
+        <p className="lp-welcome-subline">{t("welcome.subline")}</p>
+
+        {/* Primary CTA */}
+        <button
+          className="lp-welcome-cta"
+          onClick={onNewProfile}
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <line x1="12" y1="5" x2="12" y2="19" />
+            <line x1="5" y1="12" x2="19" y2="12" />
+          </svg>
+          {t("welcome.cta")}
+        </button>
+
+        {/* Keyboard hint */}
+        <p className="lp-welcome-hint">
+          {t("welcome.hint")}
+        </p>
+
+        {/* Error if any */}
+        {connectError && (
+          <div className="lp-welcome-error">{connectError}</div>
+        )}
+
+        {/* Recent connections */}
+        {recentProfiles.length > 0 && (
+          <div className="lp-recent">
+            <div className="lp-recent-header">{t("welcome.recent")}</div>
+            <div className="lp-recent-list">
+              {recentProfiles.map((p) => {
+                const defaultUser = p.users.find((u) => u.isDefault) ?? p.users[0];
+                const label = defaultUser
+                  ? `${defaultUser.username}@${p.host}`
+                  : p.host;
+                return (
+                  <button
+                    key={p.id}
+                    className="lp-recent-row"
+                    onClick={() => onConnect(p.id)}
+                    title={t("welcome.reconnect")}
+                    aria-label={`${t("welcome.reconnect")} ${p.name} (${label})`}
+                  >
+                    <span className="lp-recent-name">{p.name}</span>
+                    <span className="lp-recent-host">{label}</span>
+                    <span className="lp-recent-age">{timeAgo(p.updatedAt)}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function App() {
   const { sessions, activeSessionId, activeFeature } = useSessionStore();
   const { profiles } = useProfileStore();
 
@@ -194,17 +366,15 @@ function App() {
             </div>
           </div>
         ) : (
-          <div className="welcome">
-            <h2>{t("welcome.title")}</h2>
-            <p>
-              {connecting
-                ? t("welcome.connecting")
-                : t("welcome.message")}
-            </p>
-            {connectError && (
-              <div className="error-message">{connectError}</div>
-            )}
-          </div>
+          <WelcomeLaunchpad
+            connecting={connecting}
+            connectingProfileId={connectingProfileId}
+            connectError={connectError}
+            onNewProfile={handleNewProfile}
+            onConnect={handleConnect}
+            onCancelConnect={cancelConnect}
+            profiles={profiles}
+          />
         )}
       </AppLayout>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { AppLayout } from "./components/layout/AppLayout";
 import { TabBar } from "./components/layout/TabBar";
 import { ConnectionDialog } from "./features/connection/ConnectionDialog";
 import { HostKeyDialog } from "./features/connection/HostKeyDialog";
+import { MfaChallengeDialog } from "./features/connection/MfaChallengeDialog";
 import { AuthPrompt } from "./features/connection/AuthPrompt";
 import { StartupCommandsDialog } from "./features/connection/StartupCommandsDialog";
 import { VaultScreen } from "./features/vault/VaultScreen";
@@ -213,12 +214,14 @@ function App() {
     connectingProfileId,
     connectError,
     hostKeyRequest,
+    mfaChallenge,
     needsPassword,
     pendingProfileId,
     pendingUser,
     connect,
     disconnect,
     respondHostKey,
+    respondMfa,
     submitPassword,
     cancelConnect,
     clearError,
@@ -397,6 +400,13 @@ function App() {
         open={hostKeyRequest !== null}
         request={hostKeyRequest}
         onRespond={respondHostKey}
+      />
+
+      <MfaChallengeDialog
+        open={mfaChallenge !== null}
+        challenge={mfaChallenge}
+        onSubmit={respondMfa}
+        onCancel={cancelConnect}
       />
 
       <AuthPrompt

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { TabBar } from "./components/layout/TabBar";
 import { ConnectionDialog } from "./features/connection/ConnectionDialog";
 import { HostKeyDialog } from "./features/connection/HostKeyDialog";
 import { AuthPrompt } from "./features/connection/AuthPrompt";
+import { StartupCommandsDialog } from "./features/connection/StartupCommandsDialog";
 import { VaultScreen } from "./features/vault/VaultScreen";
 import { UpdateDialog } from "./features/updater/UpdateDialog";
 import { CriticalUpdateScreen } from "./features/updater/CriticalUpdateScreen";
@@ -18,6 +19,7 @@ import { TunnelManager } from "./features/tunnel/TunnelManager";
 import { OnboardingTour } from "./components/ui/OnboardingTour";
 import { useSessionStore } from "./stores/sessionStore";
 import { useProfileStore } from "./stores/profileStore";
+import type { StartupPreview } from "./stores/sessionStore";
 import { useConnection } from "./features/connection/useConnection";
 import { useUpdater } from "./features/updater/useUpdater";
 import { useI18n } from "./lib/i18n";
@@ -202,7 +204,8 @@ function WelcomeLaunchpad({
 }
 
 function App() {
-  const { sessions, activeSessionId, activeFeature } = useSessionStore();
+  const { sessions, activeSessionId, activeFeature, startupPreview, clearStartupPreview } =
+    useSessionStore();
   const { profiles } = useProfileStore();
 
   const {
@@ -219,6 +222,7 @@ function App() {
     submitPassword,
     cancelConnect,
     clearError,
+    runStartupCommands,
   } = useConnection();
 
   // ── Vault state ──────────────────────────────────────
@@ -408,6 +412,20 @@ function App() {
       <UpdateDialog />
       <CriticalUpdateScreen />
       <RemoteEditCoordinator />
+
+      <StartupCommandsDialog
+        open={startupPreview !== null}
+        commands={startupPreview?.commands ?? []}
+        profileName={startupPreview?.profileName}
+        onConfirm={() => {
+          const preview: StartupPreview | null = startupPreview;
+          if (preview) {
+            void runStartupCommands(preview.sessionId, preview.commands);
+          }
+          clearStartupPreview();
+        }}
+        onCancel={clearStartupPreview}
+      />
     </>
   );
 }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,6 +1,6 @@
 // components/layout/Sidebar.tsx — Left sidebar with profiles and active sessions
 //
-// Premium minimalist redesign with drag-and-drop reordering via @dnd-kit.
+// LAMPLIGHT STEP 2: Redesigned profile rows, status dots, keyboard nav, group headers.
 
 import { useEffect, useMemo, useState, useCallback, useRef } from "react";
 import { save, open } from "@tauri-apps/plugin-dialog";
@@ -40,6 +40,70 @@ interface SidebarProps {
   onClearError: () => void;
 }
 
+// ─── Middle-ellipsis helper ───────────────────────────────
+// CSS text-overflow: ellipsis drops the END (port disappears).
+// This splits host:port so the port is always visible.
+function middleEllipsis(str: string, maxLen = 30): string {
+  if (str.length <= maxLen) return str;
+  // Try to preserve the :port suffix
+  const portMatch = str.match(/:(\d+)$/);
+  if (portMatch) {
+    const portSuffix = portMatch[0]; // e.g. ":22"
+    const host = str.slice(0, str.length - portSuffix.length);
+    const availableForHost = maxLen - portSuffix.length - 1; // 1 for ellipsis
+    if (availableForHost > 4) {
+      return host.slice(0, availableForHost) + "…" + portSuffix;
+    }
+  }
+  return str.slice(0, maxLen - 1) + "…";
+}
+
+// ─── Client-side group derivation ─────────────────────────
+// No backend `group` field yet — derive from profile name heuristics.
+// Returns: "production" | "development" | "certification" | "staging" | "other"
+type GroupKey = "production" | "development" | "certification" | "staging" | "other";
+
+function deriveGroup(profile: ConnectionProfile): GroupKey {
+  const name = profile.name.toLowerCase();
+  if (/\b(prod|production|prd)\b/.test(name)) return "production";
+  if (/\b(dev|develop|development)\b/.test(name)) return "development";
+  if (/\b(cert|cer|qa|test|tst)\b/.test(name)) return "certification";
+  if (/\b(stag|staging|uat|pre\-?prod)\b/.test(name)) return "staging";
+  return "other";
+}
+
+// Stable group display order
+const GROUP_ORDER: GroupKey[] = ["production", "staging", "certification", "development", "other"];
+
+interface ProfileGroup {
+  key: GroupKey;
+  profiles: ConnectionProfile[];
+}
+
+function groupProfiles(profiles: ConnectionProfile[]): ProfileGroup[] {
+  const map = new Map<GroupKey, ConnectionProfile[]>();
+  for (const key of GROUP_ORDER) map.set(key, []);
+  for (const p of profiles) {
+    const key = deriveGroup(p);
+    map.get(key)!.push(p);
+  }
+  // Only emit groups that have profiles
+  return GROUP_ORDER
+    .filter((key) => map.get(key)!.length > 0)
+    .map((key) => ({ key, profiles: map.get(key)! }));
+}
+
+// ─── Session elapsed time ─────────────────────────────────
+function formatElapsed(connectedAt: number): string {
+  const ms = Date.now() - connectedAt;
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  return `${h}h`;
+}
+
 // ─── Helpers ──────────────────────────────────────────────
 
 function SessionStateIndicator({ state }: { state: SessionEntry["state"] }) {
@@ -63,9 +127,17 @@ function getSessionStateKey(state: SessionEntry["state"]): TranslationKey {
 function ChevronIcon({ collapsed }: { collapsed: boolean }) {
   return (
     <span className={`sidebar-chevron ${collapsed ? "sidebar-chevron-collapsed" : ""}`}>
-      {"\u25BC"}
+      {"▼"}
     </span>
   );
+}
+
+// ─── Status dot ───────────────────────────────────────────
+// idle = hollow ring (text-faint), connecting = copper pulse, live = jade
+function StatusDot({ connected, connecting }: { connected: boolean; connecting: boolean }) {
+  if (connected) return <span className="lp-status-dot lp-status-dot-live" />;
+  if (connecting) return <span className="lp-status-dot lp-status-dot-connecting" />;
+  return <span className="lp-status-dot lp-status-dot-idle" />;
 }
 
 // ─── Sortable Profile Card ───────────────────────────────
@@ -78,7 +150,6 @@ interface SortableProfileCardProps {
   isExpanded: boolean;
   profileSessions?: SessionEntry[];
   activeSessionId: string | null;
-  statusClass: string;
   onProfileClick: (id: string) => void;
   onConnect: (id: string, userId?: string) => void;
   onEditProfile: (id: string) => void;
@@ -88,6 +159,7 @@ interface SortableProfileCardProps {
   t: (key: TranslationKey, params?: Record<string, string | number>) => string;
   connectingLabel: string;
   connectLabel: string;
+  isFocused: boolean;
 }
 
 function SortableProfileCard({
@@ -98,7 +170,6 @@ function SortableProfileCard({
   isExpanded,
   profileSessions,
   activeSessionId,
-  statusClass,
   onProfileClick,
   onConnect,
   onEditProfile,
@@ -108,6 +179,7 @@ function SortableProfileCard({
   t,
   connectingLabel,
   connectLabel,
+  isFocused,
 }: SortableProfileCardProps) {
   const {
     attributes,
@@ -125,28 +197,45 @@ function SortableProfileCard({
     zIndex: isDragging ? 10 : undefined,
   };
 
-  // Build subtitle based on number of users
+  // Build subtitle: for single-user show user@host:port; for multi show "N credentials · host"
   const isSingleUser = p.users.length <= 1;
   const defaultUser = p.users.find((u) => u.isDefault) ?? p.users[0];
-  const subtitle = isSingleUser && defaultUser
+
+  const rawSubtitle = isSingleUser && defaultUser
     ? `${defaultUser.username || "?"}@${p.host}:${p.port}`
-    : `${p.users.length} users · ${p.host}:${p.port}`;
+    : `${p.host}:${p.port}`;
+
+  const subtitle = middleEllipsis(rawSubtitle, 32);
+
+  const credentialBadge = !isSingleUser
+    ? t("sidebar.credentials", { n: p.users.length })
+    : null;
+
+  // Find live sessions for this profile to show elapsed time
+  const liveSession = connected
+    ? profileSessions?.find((s) => s.state === "connected")
+    : undefined;
 
   // User picker state (for multi-user connect)
   const [pickerOpen, setPickerOpen] = useState(false);
+  const [overflowOpen, setOverflowOpen] = useState(false);
   const pickerRef = useRef<HTMLDivElement>(null);
+  const overflowRef = useRef<HTMLDivElement>(null);
 
-  // Close picker when clicking outside
+  // Close picker or overflow when clicking outside
   useEffect(() => {
-    if (!pickerOpen) return;
+    if (!pickerOpen && !overflowOpen) return;
     function handleClickOutside(e: MouseEvent) {
       if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) {
         setPickerOpen(false);
       }
+      if (overflowRef.current && !overflowRef.current.contains(e.target as Node)) {
+        setOverflowOpen(false);
+      }
     }
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [pickerOpen]);
+  }, [pickerOpen, overflowOpen]);
 
   // Which users already have an active session?
   const connectedUserIds = new Set(
@@ -158,10 +247,8 @@ function SortableProfileCard({
 
   function handleConnectClick() {
     if (isSingleUser) {
-      // Single user — connect directly (even if already connected, allows multiple sessions)
       onConnect(p.id);
     } else {
-      // Multi-user — show picker
       setPickerOpen((prev) => !prev);
     }
   }
@@ -171,57 +258,90 @@ function SortableProfileCard({
     onConnect(p.id, userId);
   }
 
+  // Live row shows elapsed time instead of connect button prominence
+  const elapsedLabel = liveSession ? formatElapsed(liveSession.connectedAt) : null;
+
+  // Does this profile own the session currently shown in the terminal? That is
+  // the "you are here" marker, distinct from the transient keyboard focus.
+  const ownsActiveSession =
+    !!activeSessionId && (profileSessions?.some((s) => s.id === activeSessionId) ?? false);
+
   return (
     <div ref={setNodeRef} style={style}>
       {/* Profile card */}
       <div
-        className={`sidebar-profile-card ${connected ? "sidebar-profile-card-connected" : ""}`}
+        className={[
+          "lp-profile-row",
+          connected ? "lp-profile-row-live" : "",
+          connecting ? "lp-profile-row-connecting" : "",
+          ownsActiveSession ? "lp-profile-row-active" : "",
+          isFocused ? "lp-profile-row-focused" : "",
+        ].filter(Boolean).join(" ")}
+        role="listitem"
         onClick={() => onProfileClick(p.id)}
-        title={subtitle}
+        title={`${p.name} — ${rawSubtitle}`}
+        tabIndex={-1}
       >
-        {/* Drag handle */}
+        {/* Drag handle (hidden until hover) */}
         <div
-          className="sidebar-drag-handle"
+          className="lp-drag-handle"
           {...attributes}
           {...listeners}
-        >
-          <span className="sidebar-drag-dots" />
-        </div>
-
-        <div className="sidebar-profile-card-left">
-          <span className={`sidebar-chevron sidebar-profile-chevron ${isExpanded ? "" : "sidebar-chevron-collapsed"}`}>{"\u25BC"}</span>
-          <span className={`sidebar-status-dot ${statusClass}`} />
-          <div className="sidebar-profile-text">
-            <div className="sidebar-profile-name">{p.name}</div>
-            <div className="sidebar-profile-host">
-              {subtitle}
-            </div>
-          </div>
-        </div>
-        <div
-          className="sidebar-profile-card-actions"
           onClick={(e) => e.stopPropagation()}
         >
-          <div className="sidebar-connect-wrapper" ref={pickerRef}>
+          <span className="lp-drag-dots" />
+        </div>
+
+        {/* Chevron for expand/collapse */}
+        <span className={`sidebar-chevron sidebar-profile-chevron ${isExpanded ? "" : "sidebar-chevron-collapsed"}`}>
+          {"▼"}
+        </span>
+
+        {/* Status dot */}
+        <StatusDot connected={connected} connecting={connecting} />
+
+        {/* Text block */}
+        <div className="lp-profile-text">
+          <div className="lp-profile-name">{p.name}</div>
+          <div className="lp-profile-meta">
+            {credentialBadge && (
+              <span className="lp-credential-badge">{credentialBadge}</span>
+            )}
+            <span className="lp-profile-host" title={rawSubtitle}>{subtitle}</span>
+          </div>
+        </div>
+
+        {/* Right side: elapsed time for live sessions, action buttons */}
+        <div className="lp-profile-actions" onClick={(e) => e.stopPropagation()}>
+          {connected && elapsedLabel && (
+            <span className="lp-elapsed">{elapsedLabel}</span>
+          )}
+
+          {/* Connect button — always visible */}
+          <div className="lp-connect-wrapper" ref={pickerRef}>
             <button
-              className={`sidebar-profile-btn sidebar-profile-btn-connect ${connected ? "sidebar-profile-btn-add" : ""}`}
+              className={`lp-action-btn lp-action-btn-connect ${connected ? "lp-action-btn-add" : ""}`}
               onClick={handleConnectClick}
               disabled={connecting}
               title={connecting ? connectingLabel : connected ? t("sidebar.newSession") : connectLabel}
+              tabIndex={-1}
             >
               {connecting ? (
-                <span className="sidebar-btn-spinner" />
+                <span className="lp-spinner" />
               ) : connected ? (
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                // Plus icon for new session when already connected
+                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                   <line x1="12" y1="5" x2="12" y2="19" />
                   <line x1="5" y1="12" x2="19" y2="12" />
                 </svg>
               ) : (
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
+                // Play/Enter glyph for connect
+                <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                   <polygon points="5,3 19,12 5,21" />
                 </svg>
               )}
             </button>
+
             {/* User picker popover (multi-user profiles) */}
             {pickerOpen && !isSingleUser && (
               <div className="sidebar-user-picker">
@@ -235,7 +355,7 @@ function SortableProfileCard({
                     >
                       <span className="sidebar-user-picker-name">{u.username || "?"}</span>
                       <span className="sidebar-user-picker-auth">
-                        {u.authMethod.type === "publicKey" ? "\uD83D\uDD11" : "\uD83D\uDD12"}
+                        {u.authMethod.type === "publicKey" ? "🔑" : "🔒"}
                       </span>
                       {isUserConnected && (
                         <span className="sidebar-user-picker-connected-dot" />
@@ -246,25 +366,43 @@ function SortableProfileCard({
               </div>
             )}
           </div>
-          <button
-            className="sidebar-profile-btn"
-            onClick={() => onEditProfile(p.id)}
-            title={t("sidebar.edit")}
-          >
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
-            </svg>
-          </button>
-          <button
-            className="sidebar-profile-btn sidebar-profile-btn-delete"
-            onClick={() => onDeleteClick(p.id, p.name)}
-            title={t("sidebar.delete")}
-          >
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <line x1="18" y1="6" x2="6" y2="18" />
-              <line x1="6" y1="6" x2="18" y2="18" />
-            </svg>
-          </button>
+
+          {/* Overflow menu (edit / delete) — hidden until hover */}
+          <div className="lp-overflow-wrapper" ref={overflowRef}>
+            <button
+              className="lp-action-btn lp-action-btn-overflow"
+              onClick={() => setOverflowOpen((prev) => !prev)}
+              title={t("sidebar.overflow")}
+              tabIndex={-1}
+            >
+              <span className="lp-overflow-dots">&#xB7;&#xB7;&#xB7;</span>
+            </button>
+            {overflowOpen && (
+              <div className="lp-overflow-menu">
+                <button
+                  className="lp-overflow-item"
+                  onClick={() => { setOverflowOpen(false); onEditProfile(p.id); }}
+                >
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
+                  </svg>
+                  {t("sidebar.edit")}
+                </button>
+                <button
+                  className="lp-overflow-item lp-overflow-item-danger"
+                  onClick={() => { setOverflowOpen(false); onDeleteClick(p.id, p.name); }}
+                >
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <polyline points="3 6 5 6 21 6" />
+                    <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+                    <path d="M10 11v6M14 11v6" />
+                    <path d="M9 6V4h6v2" />
+                  </svg>
+                  {t("sidebar.delete")}
+                </button>
+              </div>
+            )}
+          </div>
         </div>
       </div>
 
@@ -303,12 +441,38 @@ function SortableProfileCard({
                   }}
                   title={t("sidebar.disconnect")}
                 >
-                  {"\u23FB"}
+                  {"⏻"}
                 </button>
               </div>
             ))}
         </div>
       )}
+    </div>
+  );
+}
+
+// ─── Group header ─────────────────────────────────────────
+
+function GroupHeader({
+  groupKey,
+  count,
+  t,
+}: {
+  groupKey: GroupKey;
+  count: number;
+  t: (key: TranslationKey, params?: Record<string, string | number>) => string;
+}) {
+  const labelKey: TranslationKey =
+    groupKey === "production" ? "sidebar.group.production"
+    : groupKey === "development" ? "sidebar.group.development"
+    : groupKey === "certification" ? "sidebar.group.certification"
+    : groupKey === "staging" ? "sidebar.group.staging"
+    : "sidebar.group.other";
+
+  return (
+    <div className="lp-group-header">
+      <span className="lp-group-label">{t(labelKey)}</span>
+      <span className="lp-group-count">{count}</span>
     </div>
   );
 }
@@ -339,6 +503,10 @@ export function Sidebar({
   const [searchQuery, setSearchQuery] = useState("");
   const [profilesCollapsed, setProfilesCollapsed] = useState(false);
   const [expandedProfiles, setExpandedProfiles] = useState<Set<string>>(new Set());
+
+  // Keyboard navigation: focused row index within filteredProfiles
+  const [focusedIndex, setFocusedIndex] = useState<number | null>(null);
+  const listRef = useRef<HTMLDivElement>(null);
 
   // Delete confirmation dialog state
   const [deleteConfirm, setDeleteConfirm] = useState<{
@@ -392,7 +560,6 @@ export function Sidebar({
       setBanner({ type: "error", message: t("sidebar.noProfilesToExport") });
       return;
     }
-    // Reset export dialog state
     setExportIncludePasswords(false);
     setExportPassword("");
     setExportPasswordConfirm("");
@@ -451,10 +618,9 @@ export function Sidebar({
         ],
         multiple: false,
       });
-      if (!path) return; // user cancelled
+      if (!path) return;
       const filePath = path as string;
 
-      // Check if encrypted file
       if (filePath.endsWith(".nexterm")) {
         setImportPassword("");
         setImportError(null);
@@ -463,7 +629,6 @@ export function Sidebar({
         return;
       }
 
-      // Plain JSON import
       const result = await importProfiles(filePath);
       setBanner({
         type: "success",
@@ -472,7 +637,7 @@ export function Sidebar({
           skipped: result.skipped,
         }),
       });
-    } catch (err) {
+    } catch {
       setBanner({ type: "error", message: t("sidebar.importError") });
     }
   }, [importProfiles, t]);
@@ -524,10 +689,9 @@ export function Sidebar({
     return map;
   }, [sessionEntries]);
 
-  // Track which profiles we've already auto-expanded so we don't fight the user's collapse
+  // Track which profiles we've already auto-expanded
   const autoExpandedRef = useRef<Set<string>>(new Set());
 
-  // Auto-expand a profile only when it FIRST gets an active session
   useEffect(() => {
     const profilesWithSessions = new Set<string>();
     for (const [profileId, sess] of profileSessionMap) {
@@ -535,7 +699,6 @@ export function Sidebar({
         profilesWithSessions.add(profileId);
       }
     }
-    // Only expand profiles we haven't auto-expanded before
     const toExpand: string[] = [];
     for (const id of profilesWithSessions) {
       if (!autoExpandedRef.current.has(id)) {
@@ -543,7 +706,6 @@ export function Sidebar({
         autoExpandedRef.current.add(id);
       }
     }
-    // Clean up profiles that no longer have sessions
     for (const id of autoExpandedRef.current) {
       if (!profilesWithSessions.has(id)) {
         autoExpandedRef.current.delete(id);
@@ -558,7 +720,7 @@ export function Sidebar({
     }
   }, [profileSessionMap]);
 
-  // Filter profiles by search query (searches all usernames in users array)
+  // Filter profiles by search query
   const filteredProfiles = useMemo(() => {
     if (!searchQuery.trim()) return profiles;
     const q = searchQuery.toLowerCase();
@@ -570,6 +732,17 @@ export function Sidebar({
     );
   }, [profiles, searchQuery]);
 
+  // Group the filtered profiles (only group when not searching)
+  const profileGroups = useMemo(() => {
+    if (searchQuery.trim()) {
+      // When searching, show flat list under a single "PROFILES" group
+      return filteredProfiles.length > 0
+        ? [{ key: "other" as GroupKey, profiles: filteredProfiles }]
+        : [];
+    }
+    return groupProfiles(filteredProfiles);
+  }, [filteredProfiles, searchQuery]);
+
   // DnD handler
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
@@ -580,22 +753,14 @@ export function Sidebar({
       const newIndex = filteredProfiles.findIndex((p) => p.id === over.id);
       if (oldIndex === -1 || newIndex === -1) return;
 
-      // Build new order from the full profiles list
       const newProfiles = [...profiles];
-      const activeProfile = newProfiles.find((p) => p.id === active.id);
-      if (!activeProfile) return;
-
-      // Remove the dragged profile and insert at new position
       const filteredIds = filteredProfiles.map((p) => p.id);
       const newFilteredIds = [...filteredIds];
       newFilteredIds.splice(oldIndex, 1);
       newFilteredIds.splice(newIndex, 0, active.id as string);
 
-      // If search is active, only reorder within filtered results
-      // but maintain positions of non-filtered profiles
       if (searchQuery.trim()) {
         const fullIds = newProfiles.map((p) => p.id);
-        // Replace filtered IDs in their original positions
         let filterIdx = 0;
         const reorderedIds = fullIds.map((id) => {
           if (filteredIds.includes(id)) {
@@ -612,9 +777,9 @@ export function Sidebar({
   );
 
   function handleDeleteClick(profileId: string, profileName: string) {
-    const profileSessions = profileSessionMap.get(profileId);
+    const ps = profileSessionMap.get(profileId);
     const hasActive =
-      profileSessions?.some(
+      ps?.some(
         (s) => s.state === "connected" || s.state === "connecting" || s.state === "authenticating"
       ) ?? false;
     setDeleteConfirm({ profileId, profileName, hasActiveSession: hasActive });
@@ -624,36 +789,27 @@ export function Sidebar({
     if (!deleteConfirm) return;
     setDeleteLoading(true);
     try {
-      // If active session, disconnect all sessions for this profile first
       if (deleteConfirm.hasActiveSession) {
-        const profileSessions = profileSessionMap.get(deleteConfirm.profileId);
-        const activeSess = profileSessions?.filter(
+        const ps = profileSessionMap.get(deleteConfirm.profileId);
+        const activeSess = ps?.filter(
           (s) => s.state === "connected" || s.state === "connecting" || s.state === "authenticating"
         ) ?? [];
-        for (const s of activeSess) {
-          onDisconnect(s.id);
-        }
-        // Brief wait for disconnect to propagate
+        for (const s of activeSess) onDisconnect(s.id);
         await new Promise((r) => setTimeout(r, 300));
       }
       await deleteProfile(deleteConfirm.profileId);
       setDeleteConfirm(null);
     } catch {
-      // Backend may still reject — try disconnect+delete approach
-      // if the error indicates active session
       try {
-        const profileSessions = profileSessionMap.get(deleteConfirm.profileId);
-        const activeSess = profileSessions?.filter(
+        const ps = profileSessionMap.get(deleteConfirm.profileId);
+        const activeSess = ps?.filter(
           (s) => s.state === "connected" || s.state === "connecting" || s.state === "authenticating"
         ) ?? [];
-        for (const s of activeSess) {
-          onDisconnect(s.id);
-        }
+        for (const s of activeSess) onDisconnect(s.id);
         await new Promise((r) => setTimeout(r, 500));
         await deleteProfile(deleteConfirm.profileId);
         setDeleteConfirm(null);
       } catch {
-        // If still failing, update dialog to show active session state
         setDeleteConfirm((prev) =>
           prev ? { ...prev, hasActiveSession: true } : null
         );
@@ -673,12 +829,11 @@ export function Sidebar({
   }
 
   function isProfileConnected(profileId: string) {
-    const profileSessions = profileSessionMap.get(profileId);
-    return profileSessions?.some((s) => s.state === "connected") ?? false;
+    const ps = profileSessionMap.get(profileId);
+    return ps?.some((s) => s.state === "connected") ?? false;
   }
 
   function handleProfileClick(profileId: string) {
-    // Toggle expand/collapse
     setExpandedProfiles((prev) => {
       const next = new Set(prev);
       if (next.has(profileId)) {
@@ -688,12 +843,41 @@ export function Sidebar({
       }
       return next;
     });
+    // Also move keyboard focus to this profile
+    const idx = filteredProfiles.findIndex((p) => p.id === profileId);
+    if (idx !== -1) setFocusedIndex(idx);
   }
 
-  function getProfileStatusClass(profileId: string): string {
-    if (isProfileConnected(profileId)) return "sidebar-status-dot-connected";
-    if (isProfileConnecting(profileId)) return "sidebar-status-dot-connecting";
-    return "sidebar-status-dot-idle";
+  // Keyboard navigation on the list container
+  function handleListKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    const len = filteredProfiles.length;
+    if (len === 0) return;
+
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setFocusedIndex((prev) => {
+        if (prev === null) return 0;
+        return Math.min(prev + 1, len - 1);
+      });
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setFocusedIndex((prev) => {
+        if (prev === null) return len - 1;
+        return Math.max(prev - 1, 0);
+      });
+    } else if (e.key === "Enter" && focusedIndex !== null) {
+      e.preventDefault();
+      const p = filteredProfiles[focusedIndex];
+      if (p) onConnect(p.id);
+    } else if (e.key === "e" && focusedIndex !== null) {
+      e.preventDefault();
+      const p = filteredProfiles[focusedIndex];
+      if (p) onEditProfile(p.id);
+    } else if ((e.key === "Delete" || e.key === "Backspace") && focusedIndex !== null) {
+      e.preventDefault();
+      const p = filteredProfiles[focusedIndex];
+      if (p) handleDeleteClick(p.id, p.name);
+    }
   }
 
   return (
@@ -776,70 +960,95 @@ export function Sidebar({
         <div
           className={`sidebar-section-content ${profilesCollapsed ? "sidebar-section-content-collapsed" : ""}`}
         >
-          <div className="sidebar-list">
-            {/* Loading state */}
-            {loading && <div className="sidebar-empty">{t("sidebar.loading")}</div>}
+          {/* Loading state */}
+          {loading && <div className="sidebar-empty">{t("sidebar.loading")}</div>}
 
-            {/* Empty: no profiles at all */}
-            {!loading && profiles.length === 0 && (
-              <div className="sidebar-empty-state">
-                {t("sidebar.noProfiles")}{" "}
-                <button className="sidebar-empty-state-cta" onClick={onNewProfile}>
-                  {t("sidebar.noProfilesCta")}
-                </button>
-              </div>
-            )}
+          {/* Empty: no profiles at all */}
+          {!loading && profiles.length === 0 && (
+            <div className="sidebar-empty-state">
+              {t("sidebar.noProfiles")}{" "}
+              <button className="sidebar-empty-state-cta" onClick={onNewProfile}>
+                {t("sidebar.noProfilesCta")}
+              </button>
+            </div>
+          )}
 
-            {/* Empty: search returned no results */}
-            {!loading && profiles.length > 0 && filteredProfiles.length === 0 && (
-              <div className="sidebar-empty-state">{t("sidebar.noResults")}</div>
-            )}
+          {/* Empty: search returned no results */}
+          {!loading && profiles.length > 0 && filteredProfiles.length === 0 && (
+            <div className="sidebar-empty-state">{t("sidebar.noResults")}</div>
+          )}
 
-            {/* Profile cards with drag-and-drop */}
-            <DndContext
-              sensors={sensors}
-              collisionDetection={closestCenter}
-              onDragEnd={handleDragEnd}
+          {/* Profile list with groups and keyboard navigation */}
+          {!loading && filteredProfiles.length > 0 && (
+            <div
+              className="lp-profile-list"
+              ref={listRef}
+              role="list"
+              tabIndex={0}
+              onKeyDown={handleListKeyDown}
+              aria-label={t("sidebar.profiles")}
             >
-              <SortableContext
-                items={filteredProfiles.map((p) => p.id)}
-                strategy={verticalListSortingStrategy}
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
               >
-                {filteredProfiles.map((p) => {
-                  const connected = isProfileConnected(p.id);
-                  const connecting = isProfileConnecting(p.id);
-                  const profileSessions = profileSessionMap.get(p.id);
-                  const hasActiveSessions =
-                    profileSessions?.some(
-                      (s) => s.state === "connected" || s.state === "connecting" || s.state === "authenticating"
-                    ) ?? false;
+                <SortableContext
+                  items={filteredProfiles.map((p) => p.id)}
+                  strategy={verticalListSortingStrategy}
+                >
+                  {profileGroups.map((group, groupIdx) => (
+                    <div
+                      key={group.key}
+                      className={`lp-group ${groupIdx > 0 ? "lp-group-gap" : ""}`}
+                    >
+                      {/* Only show group header when there are multiple groups */}
+                      {profileGroups.length > 1 && (
+                        <GroupHeader
+                          groupKey={group.key}
+                          count={group.profiles.length}
+                          t={t}
+                        />
+                      )}
+                      {group.profiles.map((p) => {
+                        const connected = isProfileConnected(p.id);
+                        const connecting = isProfileConnecting(p.id);
+                        const ps = profileSessionMap.get(p.id);
+                        const hasActiveSessions =
+                          ps?.some(
+                            (s) => s.state === "connected" || s.state === "connecting" || s.state === "authenticating"
+                          ) ?? false;
+                        const globalIdx = filteredProfiles.findIndex((fp) => fp.id === p.id);
 
-                  return (
-                    <SortableProfileCard
-                      key={p.id}
-                      profile={p}
-                      connected={connected}
-                      connecting={connecting}
-                      hasActiveSessions={hasActiveSessions}
-                      isExpanded={expandedProfiles.has(p.id)}
-                      profileSessions={profileSessions}
-                      activeSessionId={activeSessionId}
-                      statusClass={getProfileStatusClass(p.id)}
-                      onProfileClick={handleProfileClick}
-                      onConnect={onConnect}
-                      onEditProfile={onEditProfile}
-                      onDeleteClick={handleDeleteClick}
-                      onSetActiveSession={setActiveSession}
-                      onDisconnect={onDisconnect}
-                      t={t}
-                      connectingLabel={t("sidebar.connecting")}
-                      connectLabel={t("sidebar.connect")}
-                    />
-                  );
-                })}
-              </SortableContext>
-            </DndContext>
-          </div>
+                        return (
+                          <SortableProfileCard
+                            key={p.id}
+                            profile={p}
+                            connected={connected}
+                            connecting={connecting}
+                            hasActiveSessions={hasActiveSessions}
+                            isExpanded={expandedProfiles.has(p.id)}
+                            profileSessions={ps}
+                            activeSessionId={activeSessionId}
+                            onProfileClick={handleProfileClick}
+                            onConnect={onConnect}
+                            onEditProfile={onEditProfile}
+                            onDeleteClick={handleDeleteClick}
+                            onSetActiveSession={setActiveSession}
+                            onDisconnect={onDisconnect}
+                            t={t}
+                            connectingLabel={t("sidebar.connecting")}
+                            connectLabel={t("sidebar.connect")}
+                            isFocused={focusedIndex === globalIdx}
+                          />
+                        );
+                      })}
+                    </div>
+                  ))}
+                </SortableContext>
+              </DndContext>
+            </div>
+          )}
         </div>
 
         {/* Export/import feedback banner */}
@@ -849,7 +1058,7 @@ export function Sidebar({
             onClick={() => setBanner(null)}
             title={t("general.close")}
           >
-            {banner.type === "success" ? "\u2713 " : ""}{banner.message}
+            {banner.type === "success" ? "✓ " : ""}{banner.message}
           </div>
         )}
 
@@ -861,8 +1070,6 @@ export function Sidebar({
         )}
       </div>
 
-      {/* Active Sessions section removed — sessions now shown inline under each expanded profile */}
-
       {/* ── Delete Confirmation Dialog ── */}
       <Dialog
         open={deleteConfirm !== null}
@@ -873,7 +1080,7 @@ export function Sidebar({
         {deleteConfirm && (
           <>
             <div className="delete-confirm-header">
-              <div className="delete-confirm-icon">{"\u26A0"}</div>
+              <div className="delete-confirm-icon">{"⚠"}</div>
               <div className="delete-confirm-text">
                 <h3 className="delete-confirm-title">
                   {t("sidebar.deleteConfirmTitle")}

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -10,7 +10,7 @@ interface StatusBarProps {
 
 export function StatusBar({ onStartTour }: StatusBarProps) {
   const { t, locale, setLocale } = useI18n();
-  const { sessions } = useSessionStore();
+  const { sessions, activeSessionId } = useSessionStore();
   const { status, isCritical } = useUpdateStore();
 
   // Show badge when user dismissed a normal update
@@ -25,8 +25,15 @@ export function StatusBar({ onStartTour }: StatusBarProps) {
     0,
   );
 
+  // Active session target: host@username (right-side info)
+  const activeSession = activeSessionId ? sessions.get(activeSessionId) : null;
+  const activeTarget =
+    activeSession && activeSession.state === "connected"
+      ? `${activeSession.host}@${activeSession.username}`
+      : null;
+
   const toggleLocale = () => {
-    setLocale(locale === "en" ? "es" : "en" as Locale);
+    setLocale(locale === "en" ? "es" : ("en" as Locale));
   };
 
   const handleUpdateBadgeClick = () => {
@@ -36,43 +43,69 @@ export function StatusBar({ onStartTour }: StatusBarProps) {
 
   return (
     <footer className="statusbar">
-      <span className="statusbar-item">
-        {connectedCount !== 1
-          ? t("status.connections", { count: connectedCount })
-          : t("status.connection", { count: connectedCount })}
-      </span>
-      <span className="statusbar-item">
-        {totalTerminals !== 1
-          ? t("status.terminals", { count: totalTerminals })
-          : t("status.terminal", { count: totalTerminals })}
-      </span>
-      <div className="statusbar-spacer" />
-      {showUpdateBadge && (
+      {/* ── Left cluster: live count + terminal count ── */}
+      <div className="statusbar-cluster statusbar-cluster-left">
+        <span className="statusbar-item">
+          {/* Jade dot signals live connections — color is reinforcing, text is the load-bearing signal */}
+          <span
+            className="statusbar-dot statusbar-dot-live"
+            aria-hidden="true"
+          />
+          {connectedCount !== 1
+            ? t("status.connections", { count: connectedCount })
+            : t("status.connection", { count: connectedCount })}
+        </span>
+        <span className="statusbar-item">
+          {/* Terminal glyph — decorative, aria-hidden */}
+          <span className="statusbar-glyph" aria-hidden="true">
+            ▣
+          </span>
+          {totalTerminals !== 1
+            ? t("status.terminals", { count: totalTerminals })
+            : t("status.terminal", { count: totalTerminals })}
+        </span>
+      </div>
+
+      {/* ── Hairline divider ── */}
+      <div className="statusbar-divider" aria-hidden="true" />
+
+      {/* ── Right cluster: active target + update badge + help + lang ── */}
+      <div className="statusbar-cluster statusbar-cluster-right">
+        {activeTarget && (
+          <span className="statusbar-target" title={activeTarget}>
+            {activeTarget}
+          </span>
+        )}
+
+        {showUpdateBadge && (
+          <button
+            className="statusbar-update-badge"
+            onClick={handleUpdateBadgeClick}
+            title={t("update.statusBadge")}
+          >
+            <span className="statusbar-update-dot" />
+            {t("update.statusBadge")}
+          </button>
+        )}
+
+        {onStartTour && (
+          <button
+            className="statusbar-help-btn"
+            onClick={onStartTour}
+            title={t("tour.helpButton")}
+          >
+            ?
+          </button>
+        )}
+
         <button
-          className="statusbar-update-badge"
-          onClick={handleUpdateBadgeClick}
-          title={t("update.statusBadge")}
+          className="statusbar-lang-toggle"
+          onClick={toggleLocale}
+          title={t("settings.language")}
         >
-          <span className="statusbar-update-dot" />
-          {t("update.statusBadge")}
+          {t(`settings.${locale}`)}
         </button>
-      )}
-      {onStartTour && (
-        <button
-          className="statusbar-help-btn"
-          onClick={onStartTour}
-          title={t("tour.helpButton")}
-        >
-          ?
-        </button>
-      )}
-      <button
-        className="statusbar-lang-toggle"
-        onClick={toggleLocale}
-        title={t("settings.language")}
-      >
-        {t(`settings.${locale}`)}
-      </button>
+      </div>
     </footer>
   );
 }

--- a/src/components/layout/TabBar.test.tsx
+++ b/src/components/layout/TabBar.test.tsx
@@ -1,0 +1,194 @@
+// a11y invariant: the feature switcher is a WAI-ARIA tablist — role="tablist"
+// wraps role="tab" buttons with aria-selected reflecting the active feature,
+// roving tabindex (active=0/others=-1), and Arrow/Home/End keyboard navigation.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useSessionStore } from "../../stores/sessionStore";
+import type { SessionEntry } from "../../stores/sessionStore";
+
+// This jsdom config has a non-functional localStorage; the workspace store
+// persist middleware resolves its storage at import time, so the in-memory stub
+// MUST be installed before any store module loads. vi.hoisted runs first.
+vi.hoisted(() => {
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, String(v)),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => void store.clear(),
+      key: (i: number) => [...store.keys()][i] ?? null,
+      get length() {
+        return store.size;
+      },
+    },
+  });
+});
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+// Mock i18n — return the real English labels so accessible names match usage.
+const LABELS: Record<string, string> = {
+  "tabbar.terminal": "Terminal",
+  "tabbar.sftp": "SFTP",
+  "tabbar.tunnels": "Tunnels",
+};
+vi.mock("../../lib/i18n", () => ({
+  useI18n: () => ({ t: (k: string) => LABELS[k] ?? k }),
+}));
+
+// ─── Import after mocks ───────────────────────────────────────────────────────
+import { TabBar } from "./TabBar";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeSession(id: string): SessionEntry {
+  return {
+    id,
+    profileId: "profile-1",
+    profileName: "Test Server",
+    host: "192.168.1.1",
+    userId: "user-1",
+    username: "admin",
+    port: 22,
+    connectedAt: Date.now(),
+    state: "connected",
+    terminals: [],
+    activeTerminalId: null,
+  };
+}
+
+function resetStore() {
+  useSessionStore.setState({
+    sessions: new Map(),
+    activeSessionId: null,
+    activeFeature: "terminal",
+  });
+}
+
+function setupActiveSession(
+  id = "sid-1",
+  activeFeature: "terminal" | "sftp" | "tunnel" = "terminal",
+) {
+  useSessionStore.setState({
+    sessions: new Map([[id, makeSession(id)]]),
+    activeSessionId: id,
+    activeFeature,
+  });
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("TabBar — WAI-ARIA tabs", () => {
+  beforeEach(() => {
+    resetStore();
+    setupActiveSession();
+  });
+
+  afterEach(() => {
+    resetStore();
+  });
+
+  it("renders a tablist containing the feature tabs", () => {
+    render(<TabBar />);
+    const tablist = screen.getByRole("tablist");
+    expect(tablist).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Terminal" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "SFTP" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Tunnels" })).toBeInTheDocument();
+  });
+
+  it("marks the active feature with aria-selected=true and others false", () => {
+    render(<TabBar />);
+    expect(screen.getByRole("tab", { name: "Terminal" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByRole("tab", { name: "SFTP" })).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
+    expect(screen.getByRole("tab", { name: "Tunnels" })).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
+  });
+
+  it("applies roving tabindex (active=0, others=-1)", () => {
+    render(<TabBar />);
+    expect(screen.getByRole("tab", { name: "Terminal" })).toHaveAttribute(
+      "tabindex",
+      "0",
+    );
+    expect(screen.getByRole("tab", { name: "SFTP" })).toHaveAttribute(
+      "tabindex",
+      "-1",
+    );
+    expect(screen.getByRole("tab", { name: "Tunnels" })).toHaveAttribute(
+      "tabindex",
+      "-1",
+    );
+  });
+
+  it("click selects a tab (existing behavior preserved)", () => {
+    render(<TabBar />);
+    fireEvent.click(screen.getByRole("tab", { name: "SFTP" }));
+    expect(screen.getByRole("tab", { name: "SFTP" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("ArrowRight moves selection to the next tab", () => {
+    render(<TabBar />);
+    const terminal = screen.getByRole("tab", { name: "Terminal" });
+    fireEvent.keyDown(terminal, { key: "ArrowRight" });
+    expect(screen.getByRole("tab", { name: "SFTP" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("ArrowLeft moves selection to the previous tab", () => {
+    setupActiveSession("sid-1", "sftp");
+    render(<TabBar />);
+    const sftp = screen.getByRole("tab", { name: "SFTP" });
+    fireEvent.keyDown(sftp, { key: "ArrowLeft" });
+    expect(screen.getByRole("tab", { name: "Terminal" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("ArrowRight does not wrap past the last tab", () => {
+    setupActiveSession("sid-1", "tunnel");
+    render(<TabBar />);
+    const tunnels = screen.getByRole("tab", { name: "Tunnels" });
+    fireEvent.keyDown(tunnels, { key: "ArrowRight" });
+    expect(screen.getByRole("tab", { name: "Tunnels" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("Home selects the first tab, End selects the last", () => {
+    setupActiveSession("sid-1", "sftp");
+    render(<TabBar />);
+    fireEvent.keyDown(screen.getByRole("tab", { name: "SFTP" }), {
+      key: "End",
+    });
+    expect(screen.getByRole("tab", { name: "Tunnels" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    fireEvent.keyDown(screen.getByRole("tab", { name: "Tunnels" }), {
+      key: "Home",
+    });
+    expect(screen.getByRole("tab", { name: "Terminal" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+});

--- a/src/components/layout/TabBar.tsx
+++ b/src/components/layout/TabBar.tsx
@@ -1,5 +1,6 @@
 // components/layout/TabBar.tsx — Feature tab bar (Terminal / SFTP / Tunnels)
 
+import { useRef } from "react";
 import {
   useSessionStore,
 } from "../../stores/sessionStore";
@@ -17,19 +18,62 @@ export function TabBar() {
   const { activeFeature, setActiveFeature, activeSessionId } =
     useSessionStore();
 
+  // Roving-tabindex refs so keyboard navigation can move DOM focus.
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
   if (!activeSessionId) return null;
 
+  function selectByIndex(index: number) {
+    const feature = FEATURES[index];
+    if (!feature) return;
+    setActiveFeature(feature.key);
+    tabRefs.current[index]?.focus();
+  }
+
+  // WAI-ARIA tabs keyboard pattern: ArrowLeft/Right move (no wrap),
+  // Home → first, End → last. Selection follows focus to match click behavior.
+  function handleKeyDown(e: React.KeyboardEvent, index: number) {
+    switch (e.key) {
+      case "ArrowRight":
+        e.preventDefault();
+        selectByIndex(Math.min(index + 1, FEATURES.length - 1));
+        break;
+      case "ArrowLeft":
+        e.preventDefault();
+        selectByIndex(Math.max(index - 1, 0));
+        break;
+      case "Home":
+        e.preventDefault();
+        selectByIndex(0);
+        break;
+      case "End":
+        e.preventDefault();
+        selectByIndex(FEATURES.length - 1);
+        break;
+    }
+  }
+
   return (
-    <div className="tabbar">
-      {FEATURES.map((f) => (
-        <button
-          key={f.key}
-          className={`tabbar-tab ${activeFeature === f.key ? "tabbar-tab-active" : ""}`}
-          onClick={() => setActiveFeature(f.key)}
-        >
-          {t(f.labelKey)}
-        </button>
-      ))}
+    <div className="tabbar" role="tablist">
+      {FEATURES.map((f, i) => {
+        const isActive = activeFeature === f.key;
+        return (
+          <button
+            key={f.key}
+            ref={(el) => {
+              tabRefs.current[i] = el;
+            }}
+            role="tab"
+            aria-selected={isActive}
+            tabIndex={isActive ? 0 : -1}
+            className={`tabbar-tab ${isActive ? "tabbar-tab-active" : ""}`}
+            onClick={() => setActiveFeature(f.key)}
+            onKeyDown={(e) => handleKeyDown(e, i)}
+          >
+            {t(f.labelKey)}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/ui/Dialog.test.tsx
+++ b/src/components/ui/Dialog.test.tsx
@@ -1,0 +1,47 @@
+// a11y invariant: Dialog exposes role="dialog" and derives its accessible name
+// from an aria-labelledby (and/or aria-label) prop, so assistive tech and
+// getByRole('dialog', { name }) can identify it.
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Dialog } from "./Dialog";
+
+// jsdom does not implement the native <dialog> modal API.
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal = function showModal() {
+    this.open = true;
+  };
+  HTMLDialogElement.prototype.close = function close() {
+    this.open = false;
+  };
+});
+
+describe("Dialog — accessible name", () => {
+  it("exposes role=dialog and is named by aria-labelledby", () => {
+    render(
+      <Dialog
+        open
+        onClose={() => {}}
+        title=""
+        aria-labelledby="dlg-title"
+      >
+        <h3 id="dlg-title">Edit Profile</h3>
+      </Dialog>,
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Edit Profile" });
+    expect(dialog).toBeInTheDocument();
+  });
+
+  it("accepts an aria-label fallback", () => {
+    render(
+      <Dialog open onClose={() => {}} title="" aria-label="Settings">
+        <div>body</div>
+      </Dialog>,
+    );
+
+    expect(
+      screen.getByRole("dialog", { name: "Settings" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/Dialog.tsx
+++ b/src/components/ui/Dialog.tsx
@@ -14,6 +14,10 @@ interface DialogProps {
   width?: string;
   /** Extra class on the inner content wrapper */
   className?: string;
+  /** ID of the element that labels the dialog (accessible name). */
+  "aria-labelledby"?: string;
+  /** Literal accessible name, used when there is no visible labelling element. */
+  "aria-label"?: string;
 }
 
 export function Dialog({
@@ -23,6 +27,8 @@ export function Dialog({
   children,
   width = "480px",
   className = "",
+  "aria-labelledby": ariaLabelledby,
+  "aria-label": ariaLabel,
 }: DialogProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
 
@@ -44,6 +50,8 @@ export function Dialog({
       ref={dialogRef}
       className="dialog"
       style={{ width }}
+      aria-labelledby={ariaLabelledby}
+      aria-label={ariaLabel}
       onClose={(e) => {
         // Native close event (Escape key, .close() call) — sync back to React state
         e.preventDefault();

--- a/src/features/connection/ConnectionDialog.a11y.test.tsx
+++ b/src/features/connection/ConnectionDialog.a11y.test.tsx
@@ -1,0 +1,73 @@
+// a11y invariant: ConnectionDialog wires its visible title (connection.newTitle /
+// editTitle) to the Dialog via aria-labelledby, so the modal has an accessible
+// name and getByRole('dialog', { name: <title> }) resolves.
+
+import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+
+// ─── Stable mock data (module-level to avoid new-ref-per-render loop) ─────────
+const STABLE_PROFILES: never[] = [];
+const STABLE_SAVE = vi.fn().mockResolvedValue("profile-id-1");
+const STABLE_STORE_CRED = vi.fn();
+
+const TITLES: Record<string, string> = {
+  "connection.newTitle": "New Connection",
+  "connection.editTitle": "Edit Profile",
+};
+
+const mockTauriInvoke = vi.fn();
+
+vi.mock("../../lib/tauri", () => ({
+  tauriInvoke: (...args: unknown[]) => mockTauriInvoke(...args),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  Channel: vi.fn().mockImplementation(() => ({ onmessage: null })),
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Return real titles for the labelledby target; pass other keys through.
+vi.mock("../../lib/i18n", () => ({
+  useI18n: () => ({ t: (k: string) => TITLES[k] ?? k }),
+}));
+
+vi.mock("../../stores/profileStore", () => ({
+  useProfileStore: () => ({
+    profiles: STABLE_PROFILES,
+    saveProfile: STABLE_SAVE,
+    storeCredential: STABLE_STORE_CRED,
+  }),
+}));
+
+// Use the REAL Dialog here (not a passthrough mock) so aria-labelledby is exercised.
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal = function showModal() {
+    this.open = true;
+  };
+  HTMLDialogElement.prototype.close = function close() {
+    this.open = false;
+  };
+});
+
+// ─── Import after mocks ───────────────────────────────────────────────────────
+import { ConnectionDialog } from "./ConnectionDialog";
+
+describe("ConnectionDialog — dialog accessible name", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTauriInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "list_ssh_keys") return Promise.resolve([]);
+      return Promise.resolve(undefined);
+    });
+  });
+
+  it("names the dialog via the visible title (new profile)", async () => {
+    await act(async () => {
+      render(<ConnectionDialog open onClose={vi.fn()} />);
+    });
+
+    expect(
+      screen.getByRole("dialog", { name: "New Connection" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/features/connection/ConnectionDialog.test.tsx
+++ b/src/features/connection/ConnectionDialog.test.tsx
@@ -1,0 +1,184 @@
+// ConnectionDialog.test.tsx — TDD: key picker dropdown for publicKey auth
+//
+// Bug: privateKeyPath field is a free-text input — user has to know path.
+//
+// Fix: fetch available SSH keys via `list_ssh_keys`, show them in a dropdown,
+// with a manual fallback for paths not in ~/.ssh.
+//
+// Root cause of the infinite-render trap:
+// The `useEffect([open, editProfileId, profiles])` in ConnectionDialog uses
+// `profiles` as a dep. A naive `() => ({ profiles: [] })` mock creates a NEW
+// array reference on every render, triggering the effect on every render →
+// infinite state updates. We use module-level stable constants to prevent this.
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+
+// ─── Stable mock data (module-level to avoid new-ref-per-render loop) ─────────
+const MOCK_KEYS = [
+  {
+    path: "/Users/dev/.ssh/id_ed25519",
+    keyType: "Ed25519",
+    isEncrypted: false,
+    comment: "dev@laptop",
+  },
+  {
+    path: "/Users/dev/.ssh/id_rsa",
+    keyType: "RSA",
+    isEncrypted: true,
+    comment: null,
+  },
+];
+const STABLE_PROFILES: never[] = [];
+const STABLE_SAVE = vi.fn().mockResolvedValue("profile-id-1");
+const STABLE_STORE_CRED = vi.fn();
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockTauriInvoke = vi.fn();
+
+vi.mock("../../lib/tauri", () => ({
+  tauriInvoke: (...args: unknown[]) => mockTauriInvoke(...args),
+  AppError: class AppError extends Error {
+    constructor(_cmd: string, msg: string) {
+      super(msg);
+    }
+  },
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  Channel: vi.fn().mockImplementation(() => ({ onmessage: null })),
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../lib/i18n", () => ({
+  useI18n: () => ({ t: (k: string) => k }),
+}));
+
+vi.mock("../../stores/profileStore", () => ({
+  useProfileStore: () => ({
+    profiles: STABLE_PROFILES,
+    saveProfile: STABLE_SAVE,
+    storeCredential: STABLE_STORE_CRED,
+  }),
+}));
+
+// Mock Dialog — jsdom doesn't implement showModal()
+vi.mock("../../components/ui/Dialog", () => ({
+  Dialog: ({
+    open,
+    children,
+  }: {
+    open: boolean;
+    children: React.ReactNode;
+    onClose: () => void;
+    title: string;
+    width?: string;
+  }) => (open ? <div role="dialog">{children}</div> : null),
+}));
+
+// ─── Import after mocks ───────────────────────────────────────────────────────
+import { ConnectionDialog } from "./ConnectionDialog";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+async function renderDialogAndWaitForKeys() {
+  let utils!: ReturnType<typeof render>;
+  await act(async () => {
+    utils = render(<ConnectionDialog open onClose={vi.fn()} />);
+  });
+  return utils;
+}
+
+async function switchToPublicKeyAuth() {
+  // Find the key-icon auth button and click it
+  const keyButton = screen.getAllByTitle("connection.publicKey")[0];
+  if (!keyButton) throw new Error("publicKey auth button not found");
+  await act(async () => {
+    fireEvent.click(keyButton);
+  });
+  // Wait for the key list re-fetch on auth type switch
+  await waitFor(() => {
+    expect(mockTauriInvoke).toHaveBeenCalledWith("list_ssh_keys");
+  });
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("ConnectionDialog — SSH key picker dropdown", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: list_ssh_keys returns two keys
+    mockTauriInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "list_ssh_keys") return Promise.resolve(MOCK_KEYS);
+      return Promise.resolve(undefined);
+    });
+  });
+
+  it("calls list_ssh_keys on dialog open", async () => {
+    await renderDialogAndWaitForKeys();
+    expect(mockTauriInvoke).toHaveBeenCalledWith("list_ssh_keys");
+  });
+
+  it("renders a dropdown with discovered keys when publicKey auth is selected", async () => {
+    await renderDialogAndWaitForKeys();
+    await switchToPublicKeyAuth();
+
+    await waitFor(() => {
+      // The dropdown should show the Ed25519 key
+      expect(
+        screen.getByRole("option", { name: /Ed25519.*dev@laptop/ }),
+      ).toBeInTheDocument();
+    });
+
+    // RSA encrypted key
+    expect(
+      screen.getByRole("option", { name: /RSA.*encrypted/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("selecting a key from the dropdown sets privateKeyPath", async () => {
+    await renderDialogAndWaitForKeys();
+    await switchToPublicKeyAuth();
+
+    const select = await waitFor(() =>
+      screen.getByTestId("key-picker-select"),
+    );
+
+    await act(async () => {
+      fireEvent.change(select, { target: { value: "/Users/dev/.ssh/id_ed25519" } });
+    });
+
+    expect((select as HTMLSelectElement).value).toBe("/Users/dev/.ssh/id_ed25519");
+  });
+
+  it("shows a manual path input as fallback (Other... option)", async () => {
+    await renderDialogAndWaitForKeys();
+    await switchToPublicKeyAuth();
+
+    await waitFor(() => {
+      const options = screen.getAllByRole("option");
+      const hasOtherOption = options.some((o) =>
+        o.textContent?.toLowerCase().includes("other") ||
+        o.getAttribute("value") === "",
+      );
+      expect(hasOtherOption).toBe(true);
+    });
+  });
+
+  it("falls back gracefully when list_ssh_keys fails", async () => {
+    mockTauriInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "list_ssh_keys") return Promise.reject(new Error("permission denied"));
+      return Promise.resolve(undefined);
+    });
+
+    // Should not throw — renders without keys
+    await act(async () => {
+      render(<ConnectionDialog open onClose={vi.fn()} />);
+    });
+
+    // Component should still render without crashing
+    expect(document.querySelector(".cd-user-row")).not.toBeNull();
+  });
+});

--- a/src/features/connection/ConnectionDialog.tsx
+++ b/src/features/connection/ConnectionDialog.tsx
@@ -11,7 +11,7 @@ import { useProfileStore } from "../../stores/profileStore";
 import { tauriInvoke } from "../../lib/tauri";
 import { DEFAULT_SSH_PORT } from "../../lib/constants";
 import { useI18n } from "../../lib/i18n";
-import type { ConnectionProfile, AuthMethodConfig, UserCredential, TestConnectionResult } from "../../lib/types";
+import type { ConnectionProfile, AuthMethodConfig, UserCredential, TestConnectionResult, KeyInfo } from "../../lib/types";
 import { classifyTestResult, type TestTone } from "./testResult";
 
 interface ConnectionDialogProps {
@@ -100,6 +100,8 @@ export function ConnectionDialog({
   // Per-user test state
   const [testingUser, setTestingUser] = useState<string | null>(null);
   const [testResults, setTestResults] = useState<Record<string, { tone: TestTone; message: string }>>({});
+  // Discovered SSH keys for the key picker dropdown
+  const [availableKeys, setAvailableKeys] = useState<KeyInfo[]>([]);
 
   useEffect(() => {
     if (open) {
@@ -117,6 +119,15 @@ export function ConnectionDialog({
       setTestResults({});
     }
   }, [open, editProfileId, profiles]);
+
+  // Pre-fetch available SSH keys independently of profile changes.
+  // Separated to avoid re-running when `profiles` reference changes on save.
+  useEffect(() => {
+    if (!open) return;
+    void tauriInvoke<KeyInfo[]>("list_ssh_keys")
+      .then(setAvailableKeys)
+      .catch(() => setAvailableKeys([]));
+  }, [open]);
 
   // ─── User management helpers ─────────────────────────
 
@@ -138,6 +149,10 @@ export function ConnectionDialog({
     let authMethod: AuthMethodConfig;
     if (type === "publicKey") {
       authMethod = { type: "publicKey", privateKeyPath: "", passphraseInKeychain: false };
+      // Fetch (or refresh) available keys when switching to publicKey auth
+      void tauriInvoke<KeyInfo[]>("list_ssh_keys")
+        .then(setAvailableKeys)
+        .catch(() => setAvailableKeys([]));
     } else if (type === "keyboardInteractive") {
       authMethod = { type: "keyboardInteractive" };
     } else {
@@ -414,24 +429,73 @@ export function ConnectionDialog({
                       placeholder={t("connection.passwordPlaceholder")}
                     />
                   ) : (
-                    <input
-                      className={`cd-user-row-input ${errors[`user-${user.id}-keyPath`] ? "cd-user-row-input-error" : ""}`}
-                      value={user.authMethod.type === "publicKey" ? user.authMethod.privateKeyPath : ""}
-                      onChange={(e) => {
+                    // publicKey auth — dropdown picker + manual text fallback
+                    (() => {
+                      const currentPath =
+                        user.authMethod.type === "publicKey"
+                          ? user.authMethod.privateKeyPath
+                          : "";
+                      const passphraseInKeychain =
+                        user.authMethod.type === "publicKey"
+                          ? user.authMethod.passphraseInKeychain
+                          : false;
+                      // "other" means the current value is not in the list
+                      const isOther =
+                        currentPath !== "" &&
+                        !availableKeys.some((k) => k.path === currentPath);
+
+                      function setKeyPath(path: string) {
                         updateUser(user.id, {
                           authMethod: {
                             type: "publicKey",
-                            privateKeyPath: e.target.value,
-                            passphraseInKeychain:
-                              user.authMethod.type === "publicKey"
-                                ? user.authMethod.passphraseInKeychain
-                                : false,
+                            privateKeyPath: path,
+                            passphraseInKeychain,
                           },
                         });
-                      }}
-                      placeholder="~/.ssh/id_ed25519"
-                      spellCheck={false}
-                    />
+                      }
+
+                      return (
+                        <div className="cd-key-picker">
+                          <select
+                            data-testid="key-picker-select"
+                            className={`cd-user-row-input cd-key-picker-select ${errors[`user-${user.id}-keyPath`] ? "cd-user-row-input-error" : ""}`}
+                            value={isOther ? "__other__" : currentPath}
+                            onChange={(e) => {
+                              if (e.target.value === "__other__") {
+                                setKeyPath(currentPath || "");
+                              } else {
+                                setKeyPath(e.target.value);
+                              }
+                            }}
+                          >
+                            <option value="">
+                              {availableKeys.length === 0
+                                ? "~/.ssh/id_ed25519"
+                                : t("connection.privateKeyPath")}
+                            </option>
+                            {availableKeys.map((key) => (
+                              <option key={key.path} value={key.path}>
+                                {key.keyType}
+                                {key.comment ? ` — ${key.comment}` : ""}
+                                {key.isEncrypted ? " (encrypted)" : ""}
+                              </option>
+                            ))}
+                            <option value="__other__">Other…</option>
+                          </select>
+                          {(isOther ||
+                            (currentPath === "" &&
+                              availableKeys.length === 0)) && (
+                            <input
+                              className={`cd-user-row-input cd-key-picker-manual ${errors[`user-${user.id}-keyPath`] ? "cd-user-row-input-error" : ""}`}
+                              value={currentPath}
+                              onChange={(e) => setKeyPath(e.target.value)}
+                              placeholder="~/.ssh/id_ed25519"
+                              spellCheck={false}
+                            />
+                          )}
+                        </div>
+                      );
+                    })()
                   )}
                 </div>
 

--- a/src/features/connection/ConnectionDialog.tsx
+++ b/src/features/connection/ConnectionDialog.tsx
@@ -307,6 +307,7 @@ export function ConnectionDialog({
       onClose={onClose}
       title=""
       width="540px"
+      aria-labelledby="connection-dialog-title"
     >
       {/* ─── Custom Header with Icon ─── */}
       <div className="cd-header">
@@ -314,7 +315,7 @@ export function ConnectionDialog({
           <ServerIcon />
         </div>
         <div className="cd-header-text">
-          <h3 className="cd-title">
+          <h3 id="connection-dialog-title" className="cd-title">
             {isEdit ? t("connection.editTitle") : t("connection.newTitle")}
           </h3>
         </div>

--- a/src/features/connection/ConnectionDialog.tsx
+++ b/src/features/connection/ConnectionDialog.tsx
@@ -63,6 +63,28 @@ function UserPlusIcon() {
   );
 }
 
+function KeyboardIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="2" y="6" width="20" height="12" rx="2" ry="2" />
+      <line x1="6" y1="10" x2="6" y2="10" />
+      <line x1="10" y1="10" x2="10" y2="10" />
+      <line x1="14" y1="10" x2="14" y2="10" />
+      <line x1="18" y1="10" x2="18" y2="10" />
+      <line x1="6" y1="14" x2="18" y2="14" />
+    </svg>
+  );
+}
+
+function AgentIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+      <path d="M9 12l2 2 4-4" />
+    </svg>
+  );
+}
+
 function newUserCredential(): UserCredential {
   return {
     id: crypto.randomUUID(),
@@ -157,6 +179,8 @@ export function ConnectionDialog({
         .catch(() => setAvailableKeys([]));
     } else if (type === "keyboardInteractive") {
       authMethod = { type: "keyboardInteractive" };
+    } else if (type === "agent") {
+      authMethod = { type: "agent" };
     } else {
       authMethod = { type: "password" };
     }
@@ -412,9 +436,25 @@ export function ConnectionDialog({
                   >
                     <KeyIcon />
                   </button>
+                  <button
+                    type="button"
+                    className={`cd-user-row-auth-btn ${user.authMethod.type === "keyboardInteractive" ? "cd-user-row-auth-btn-active" : ""}`}
+                    onClick={() => setUserAuthType(user.id, "keyboardInteractive")}
+                    title={t("connection.keyboardInteractive")}
+                  >
+                    <KeyboardIcon />
+                  </button>
+                  <button
+                    type="button"
+                    className={`cd-user-row-auth-btn ${user.authMethod.type === "agent" ? "cd-user-row-auth-btn-active" : ""}`}
+                    onClick={() => setUserAuthType(user.id, "agent")}
+                    title={t("connection.agent")}
+                  >
+                    <AgentIcon />
+                  </button>
                 </div>
 
-                {/* Credential field (password or key path) */}
+                {/* Credential field (password, key picker, or hint) */}
                 <div className="cd-user-row-field cd-user-row-credential">
                   {user.authMethod.type === "password" ? (
                     <input
@@ -432,17 +472,11 @@ export function ConnectionDialog({
                       }}
                       placeholder={t("connection.passwordPlaceholder")}
                     />
-                  ) : (
+                  ) : user.authMethod.type === "publicKey" ? (
                     // publicKey auth — dropdown picker + manual text fallback
                     (() => {
-                      const currentPath =
-                        user.authMethod.type === "publicKey"
-                          ? user.authMethod.privateKeyPath
-                          : "";
-                      const passphraseInKeychain =
-                        user.authMethod.type === "publicKey"
-                          ? user.authMethod.passphraseInKeychain
-                          : false;
+                      const currentPath = user.authMethod.privateKeyPath;
+                      const passphraseInKeychain = user.authMethod.passphraseInKeychain;
                       // "other" means the current value is not in the list
                       const isOther =
                         currentPath !== "" &&
@@ -500,6 +534,11 @@ export function ConnectionDialog({
                         </div>
                       );
                     })()
+                  ) : user.authMethod.type === "agent" ? (
+                    <span className="cd-auth-hint">{t("connection.agentHint")}</span>
+                  ) : (
+                    // keyboardInteractive
+                    <span className="cd-auth-hint">{t("connection.keyboardInteractiveHint")}</span>
                   )}
                 </div>
 

--- a/src/features/connection/ConnectionDialog.tsx
+++ b/src/features/connection/ConnectionDialog.tsx
@@ -13,6 +13,7 @@ import { DEFAULT_SSH_PORT } from "../../lib/constants";
 import { useI18n } from "../../lib/i18n";
 import type { ConnectionProfile, AuthMethodConfig, UserCredential, TestConnectionResult, KeyInfo } from "../../lib/types";
 import { classifyTestResult, type TestTone } from "./testResult";
+import { normalizeStartupCommands } from "./startupCommands";
 
 interface ConnectionDialogProps {
   open: boolean;
@@ -79,6 +80,7 @@ function newProfile(): ConnectionProfile {
     host: "",
     port: DEFAULT_SSH_PORT,
     users: [defaultUser],
+    startupCommands: [],
     tunnels: [],
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
@@ -221,7 +223,8 @@ export function ConnectionDialog({
     if (!validate()) return;
     setSaving(true);
     try {
-      const id = await saveProfile(profile);
+      const normalized = normalizeStartupCommands(profile.startupCommands ?? []);
+      const id = await saveProfile({ ...profile, startupCommands: normalized });
       // Store ALL passwords that have content in vault
       for (const user of profile.users) {
         const pw = passwords[user.id];
@@ -574,6 +577,30 @@ export function ConnectionDialog({
             <UserPlusIcon />
             <span>{t("connection.addUser")}</span>
           </button>
+        </div>
+      </div>
+
+      {/* ─── Section: Startup Commands ─── */}
+      <div className="cd-section">
+        <div className="cd-section-label">{t("connection.sectionStartup")}</div>
+        <div className="cd-section-content">
+          <label htmlFor="startup-commands" className="sr-only">
+            {t("connection.sectionStartup")}
+          </label>
+          <textarea
+            id="startup-commands"
+            className="cd-startup-textarea"
+            value={(profile.startupCommands ?? []).join("\n")}
+            onChange={(e) =>
+              setProfile((p) => ({
+                ...p,
+                startupCommands: e.target.value.split("\n"),
+              }))
+            }
+            placeholder={t("connection.startupPlaceholder")}
+            rows={4}
+            spellCheck={false}
+          />
         </div>
       </div>
 

--- a/src/features/connection/MfaChallengeDialog.test.tsx
+++ b/src/features/connection/MfaChallengeDialog.test.tsx
@@ -1,0 +1,165 @@
+// MfaChallengeDialog.test.tsx — TDD tests for keyboard-interactive challenge UI
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MfaChallengeDialog } from "./MfaChallengeDialog";
+import type { KeyboardInteractiveChallengeRequest } from "../../lib/types";
+
+vi.mock("../../lib/i18n", () => ({
+  useI18n: () => ({ t: (k: string) => k }),
+}));
+
+const echoPrompt: KeyboardInteractiveChallengeRequest = {
+  sessionId: "s1",
+  name: "MFA",
+  instruction: "Enter your code",
+  prompts: [
+    { text: "Code:", echo: false },
+    { text: "Backup:", echo: true },
+  ],
+  round: 1,
+};
+
+const singlePrompt: KeyboardInteractiveChallengeRequest = {
+  sessionId: "s1",
+  name: "SSH",
+  instruction: "",
+  prompts: [{ text: "Password:", echo: false }],
+  round: 1,
+};
+
+const noPrompts: KeyboardInteractiveChallengeRequest = {
+  sessionId: "s1",
+  name: "Two-factor",
+  instruction: "",
+  prompts: [],
+  round: 1,
+};
+
+describe("MfaChallengeDialog", () => {
+  it("renders null when open=false", () => {
+    const { container } = render(
+      <MfaChallengeDialog
+        open={false}
+        challenge={singlePrompt}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders null when challenge=null", () => {
+    const { container } = render(
+      <MfaChallengeDialog
+        open={true}
+        challenge={null}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders one input per prompt", () => {
+    render(
+      <MfaChallengeDialog
+        open={true}
+        challenge={echoPrompt}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const inputs = screen.getAllByRole("textbox").concat(
+      // password inputs are not role=textbox
+      Array.from(document.querySelectorAll('input[type="password"]')),
+    );
+    expect(inputs).toHaveLength(2);
+  });
+
+  it("echo=false → input type password", () => {
+    render(
+      <MfaChallengeDialog
+        open={true}
+        challenge={singlePrompt}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const input = document.querySelector('input[type="password"]');
+    expect(input).not.toBeNull();
+  });
+
+  it("echo=true → input type text", () => {
+    render(
+      <MfaChallengeDialog
+        open={true}
+        challenge={echoPrompt}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const textInputs = screen.getAllByRole("textbox");
+    expect(textInputs.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("submit calls onSubmit with answers in prompt order", () => {
+    const onSubmit = vi.fn();
+    render(
+      <MfaChallengeDialog
+        open={true}
+        challenge={echoPrompt}
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+    );
+    const pwInput = document.querySelector('input[type="password"]') as HTMLInputElement;
+    const textInput = screen.getByRole("textbox") as HTMLInputElement;
+    fireEvent.change(pwInput, { target: { value: "secret" } });
+    fireEvent.change(textInput, { target: { value: "backup123" } });
+    fireEvent.click(screen.getByRole("button", { name: "mfa.submit" }));
+    expect(onSubmit).toHaveBeenCalledWith(["secret", "backup123"]);
+  });
+
+  it("cancel calls onCancel", () => {
+    const onCancel = vi.fn();
+    render(
+      <MfaChallengeDialog
+        open={true}
+        challenge={singlePrompt}
+        onSubmit={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "mfa.cancel" }));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("dialog has an accessible name", () => {
+    render(
+      <MfaChallengeDialog
+        open={true}
+        challenge={singlePrompt}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    // The dialog element should be labelled (aria-labelledby or aria-label)
+    const dialog = document.querySelector("[role='dialog'], [aria-labelledby], [aria-label]");
+    expect(dialog).not.toBeNull();
+  });
+
+  it("prompts.length 0 — submit sends empty array", () => {
+    const onSubmit = vi.fn();
+    render(
+      <MfaChallengeDialog
+        open={true}
+        challenge={noPrompts}
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "mfa.submit" }));
+    expect(onSubmit).toHaveBeenCalledWith([]);
+  });
+});

--- a/src/features/connection/MfaChallengeDialog.tsx
+++ b/src/features/connection/MfaChallengeDialog.tsx
@@ -1,0 +1,114 @@
+// features/connection/MfaChallengeDialog.tsx — Keyboard-interactive MFA prompt
+//
+// Mirrors HostKeyDialog overlay/modal structure.
+// Renders one input per prompt; echo=false → password, echo=true → text.
+
+import { useState, useEffect } from "react";
+import { useI18n } from "../../lib/i18n";
+import type { KeyboardInteractiveChallengeRequest } from "../../lib/types";
+
+interface MfaChallengeDialogProps {
+  open: boolean;
+  challenge: KeyboardInteractiveChallengeRequest | null;
+  onSubmit: (answers: string[]) => void;
+  onCancel: () => void;
+}
+
+export function MfaChallengeDialog({
+  open,
+  challenge,
+  onSubmit,
+  onCancel,
+}: MfaChallengeDialogProps) {
+  const { t } = useI18n();
+  const [answers, setAnswers] = useState<string[]>([]);
+
+  // Reset answers whenever the challenge changes (new round or new challenge)
+  useEffect(() => {
+    if (challenge) {
+      setAnswers(challenge.prompts.map(() => ""));
+    }
+  }, [challenge]);
+
+  if (!challenge || !open) return null;
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    onSubmit(answers);
+  }
+
+  function setAnswer(index: number, value: string) {
+    setAnswers((prev) => {
+      const next = [...prev];
+      next[index] = value;
+      return next;
+    });
+  }
+
+  const titleId = "mfa-dialog-title";
+
+  return (
+    <div className="hk-overlay" onClick={onCancel}>
+      <div
+        className="hk-modal"
+        role="dialog"
+        aria-labelledby={titleId}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="hk-header">
+          <div className="hk-header-text">
+            <h3 id={titleId} className="hk-title">
+              {t("mfa.title")}
+            </h3>
+            {challenge.name && (
+              <p className="hk-subtitle">{challenge.name}</p>
+            )}
+          </div>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <div className="hk-body">
+            {challenge.instruction && (
+              <p className="hk-mfa-instruction">{challenge.instruction}</p>
+            )}
+
+            {challenge.prompts.map((prompt, i) => (
+              <div key={i} className="hk-mfa-prompt-row">
+                <label
+                  htmlFor={`mfa-input-${i}`}
+                  className="hk-mfa-prompt-label"
+                >
+                  {prompt.text}
+                </label>
+                <input
+                  id={`mfa-input-${i}`}
+                  className="hk-mfa-input"
+                  type={prompt.echo ? "text" : "password"}
+                  value={answers[i] ?? ""}
+                  onChange={(e) => setAnswer(i, e.target.value)}
+                  autoFocus={i === 0}
+                  autoComplete="off"
+                />
+              </div>
+            ))}
+          </div>
+
+          <div className="hk-actions">
+            <button
+              type="button"
+              className="hk-btn hk-btn-ghost"
+              onClick={onCancel}
+            >
+              {t("mfa.cancel")}
+            </button>
+            <div className="hk-actions-right">
+              <button type="submit" className="hk-btn hk-btn-primary">
+                {t("mfa.submit")}
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/features/connection/StartupCommandsDialog.test.tsx
+++ b/src/features/connection/StartupCommandsDialog.test.tsx
@@ -1,0 +1,114 @@
+// Tests for StartupCommandsDialog.
+// Written BEFORE the implementation (TDD RED phase).
+
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// jsdom does not implement native <dialog> modal API
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal = function showModal() {
+    this.open = true;
+  };
+  HTMLDialogElement.prototype.close = function close() {
+    this.open = false;
+  };
+});
+
+vi.mock("../../lib/i18n", () => ({
+  useI18n: () => ({
+    t: (k: string) => {
+      const keys: Record<string, string> = {
+        "startup.title": "Run startup commands?",
+        "startup.subtitle":
+          "These commands will run in the new session. Review before running.",
+        "startup.run": "Run",
+        "startup.cancel": "Skip",
+      };
+      return keys[k] ?? k;
+    },
+  }),
+}));
+
+import { StartupCommandsDialog } from "./StartupCommandsDialog";
+
+const COMMANDS = ["ls -la", "uptime"];
+
+describe("StartupCommandsDialog", () => {
+  it("renders the list of commands as text", () => {
+    render(
+      <StartupCommandsDialog
+        open
+        commands={COMMANDS}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("ls -la")).toBeInTheDocument();
+    expect(screen.getByText("uptime")).toBeInTheDocument();
+  });
+
+  it("calls onConfirm when the Run button is clicked", async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+
+    render(
+      <StartupCommandsDialog
+        open
+        commands={COMMANDS}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Run" }));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it("calls onCancel when the Skip button is clicked", async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+
+    render(
+      <StartupCommandsDialog
+        open
+        commands={COMMANDS}
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Skip" }));
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("exposes an accessible dialog name via aria-labelledby", () => {
+    render(
+      <StartupCommandsDialog
+        open
+        commands={COMMANDS}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("dialog", { name: "Run startup commands?" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the profile name in the dialog when provided", () => {
+    render(
+      <StartupCommandsDialog
+        open
+        commands={COMMANDS}
+        profileName="My Server"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("My Server")).toBeInTheDocument();
+  });
+});

--- a/src/features/connection/StartupCommandsDialog.tsx
+++ b/src/features/connection/StartupCommandsDialog.tsx
@@ -1,0 +1,68 @@
+// features/connection/StartupCommandsDialog.tsx — Startup commands preview dialog
+//
+// Renders before running any startup commands so the user can review and confirm.
+// Posture: preview+confirm on every connect — never silent auto-run.
+
+import { Dialog } from "../../components/ui/Dialog";
+import { useI18n } from "../../lib/i18n";
+
+interface StartupCommandsDialogProps {
+  open: boolean;
+  commands: string[];
+  profileName?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function StartupCommandsDialog({
+  open,
+  commands,
+  profileName,
+  onConfirm,
+  onCancel,
+}: StartupCommandsDialogProps) {
+  const { t } = useI18n();
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onCancel}
+      title=""
+      width="480px"
+      aria-labelledby="startup-cmd-title"
+    >
+      <div className="cd-header">
+        <div className="cd-header-text">
+          <h3 id="startup-cmd-title" className="cd-title">
+            {t("startup.title")}
+          </h3>
+          {profileName && (
+            <span className="cd-header-subtitle">{profileName}</span>
+          )}
+        </div>
+      </div>
+
+      <div className="cd-section">
+        <p className="startup-subtitle">{t("startup.subtitle")}</p>
+        <ol className="startup-command-list">
+          {commands.map((cmd, i) => (
+            <li key={i} className="startup-command-item">
+              <code>{cmd}</code>
+            </li>
+          ))}
+        </ol>
+      </div>
+
+      <div className="cd-actions">
+        <button type="button" className="btn-ghost" onClick={onCancel}>
+          {t("startup.cancel")}
+        </button>
+        <div className="cd-actions-right">
+          <button type="button" className="btn-primary" onClick={onConfirm}>
+            {t("startup.run")}
+          </button>
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/src/features/connection/startupCommands.test.ts
+++ b/src/features/connection/startupCommands.test.ts
@@ -1,0 +1,35 @@
+// Unit tests for normalizeStartupCommands helper.
+// Written BEFORE the implementation (TDD RED phase).
+
+import { describe, it, expect } from "vitest";
+import { normalizeStartupCommands } from "./startupCommands";
+
+describe("normalizeStartupCommands", () => {
+  it("trims whitespace from each command", () => {
+    expect(normalizeStartupCommands(["  ls -la  ", "uptime"])).toEqual([
+      "ls -la",
+      "uptime",
+    ]);
+  });
+
+  it("drops blank and whitespace-only lines", () => {
+    expect(normalizeStartupCommands(["ls -la", "", "  ", "uptime"])).toEqual([
+      "ls -la",
+      "uptime",
+    ]);
+  });
+
+  it("preserves order of commands", () => {
+    expect(
+      normalizeStartupCommands(["echo a", "echo b", "echo c"]),
+    ).toEqual(["echo a", "echo b", "echo c"]);
+  });
+
+  it("returns empty array for all-blank input", () => {
+    expect(normalizeStartupCommands(["", "  ", "\t"])).toEqual([]);
+  });
+
+  it("handles empty input array", () => {
+    expect(normalizeStartupCommands([])).toEqual([]);
+  });
+});

--- a/src/features/connection/startupCommands.ts
+++ b/src/features/connection/startupCommands.ts
@@ -1,0 +1,6 @@
+// features/connection/startupCommands.ts — Pure helpers for startup command handling
+
+/** Trim and filter blank lines from a raw startup commands list. */
+export function normalizeStartupCommands(raw: string[]): string[] {
+  return raw.map((s) => s.trim()).filter(Boolean);
+}

--- a/src/features/connection/useConnection.test.ts
+++ b/src/features/connection/useConnection.test.ts
@@ -36,11 +36,32 @@ vi.mock("../../lib/tauri", () => ({
   },
 }));
 
+// Captured channel instance — populated by the Channel constructor mock.
+// Must use a regular function (not arrow) so `new Channel()` works.
+let lastChannelInstance: { onmessage: ((msg: unknown) => void) | null } = { onmessage: null };
+
 // Mock @tauri-apps/api/core
-vi.mock("@tauri-apps/api/core", () => ({
-  Channel: vi.fn().mockImplementation(() => ({ onmessage: null })),
-  invoke: vi.fn().mockResolvedValue(undefined),
-}));
+vi.mock("@tauri-apps/api/core", () => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+  const ChannelMock: Function = vi.fn(function(this: unknown) {
+    lastChannelInstance = { onmessage: null };
+    Object.assign(this as object, lastChannelInstance);
+    // Proxy onmessage so assignments on `this` update lastChannelInstance
+    Object.defineProperty(this, "onmessage", {
+      set(v: ((msg: unknown) => void) | null) {
+        lastChannelInstance.onmessage = v;
+      },
+      get() {
+        return lastChannelInstance.onmessage;
+      },
+      configurable: true,
+    });
+  });
+  return {
+    Channel: ChannelMock,
+    invoke: vi.fn().mockResolvedValue(undefined),
+  };
+});
 
 // ─── Store reset ──────────────────────────────────────────────────────────────
 
@@ -136,6 +157,188 @@ describe("useConnection — disposeSessionTerminals called on disconnect", () =>
 
     expect(callOrder[0]).toBe("disposeSessionTerminals");
     expect(callOrder[1]).toBe("removeSession");
+  });
+});
+
+// ─── BLOCKER #1 & #2: helpers ────────────────────────────────────────────────
+//
+// The global Channel mock (above) captures each new instance in lastChannelInstance.
+// connect() assigns onEvent.onmessage = handler; we then fire events through that.
+
+import { useProfileStore } from "../../stores/profileStore";
+import type { ConnectionProfile } from "../../lib/types";
+
+function makeProfile(id: string): ConnectionProfile {
+  return {
+    id,
+    name: "Test Profile",
+    host: "10.0.0.1",
+    port: 22,
+    users: [
+      {
+        id: "user-1",
+        username: "admin",
+        authMethod: { type: "password" },
+        isDefault: true,
+      },
+    ],
+    startupCommands: [],
+    tunnels: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function seedProfile(id: string) {
+  useProfileStore.setState({ profiles: [makeProfile(id)] });
+}
+
+async function startConnect(
+  result: { current: ReturnType<typeof useConnection> },
+  profileId: string,
+) {
+  await act(async () => {
+    await result.current.connect(profileId);
+  });
+}
+
+function fireChannelEvent(msg: unknown) {
+  lastChannelInstance.onmessage?.(msg);
+}
+
+// ─── BLOCKER #1: keyboardInteractiveChallenge event ──────────────────────────
+
+describe("useConnection — keyboardInteractiveChallenge event and respondMfa", () => {
+  beforeEach(() => {
+    mockDisposeSessionTerminals.mockClear();
+    vi.mocked(tauriInvoke).mockClear();
+    vi.mocked(tauriInvoke).mockResolvedValue("session-mfa-1" as never);
+    resetStore();
+  });
+
+  it("sets mfaChallenge when keyboardInteractiveChallenge event fires", async () => {
+    const profileId = "profile-mfa";
+    seedProfile(profileId);
+
+    const { result } = renderHook(() => useConnection());
+    await startConnect(result, profileId);
+
+    const sessionId = "s1";
+    act(() => {
+      fireChannelEvent({
+        event: "keyboardInteractiveChallenge",
+        data: {
+          sessionId,
+          name: "MFA",
+          instruction: "",
+          prompts: [{ text: "Code:", echo: false }],
+          round: 1,
+        },
+      });
+    });
+
+    expect(result.current.mfaChallenge).not.toBeNull();
+    expect(result.current.mfaChallenge?.sessionId).toBe(sessionId);
+    expect(result.current.mfaChallenge?.prompts).toHaveLength(1);
+  });
+
+  it("respondMfa calls tauriInvoke with nested responses shape and clears mfaChallenge", async () => {
+    const profileId = "profile-mfa-2";
+    seedProfile(profileId);
+
+    const { result } = renderHook(() => useConnection());
+    await startConnect(result, profileId);
+
+    const sessionId = "s1";
+    act(() => {
+      fireChannelEvent({
+        event: "keyboardInteractiveChallenge",
+        data: {
+          sessionId,
+          name: "MFA",
+          instruction: "",
+          prompts: [{ text: "Code:", echo: false }],
+          round: 1,
+        },
+      });
+    });
+
+    expect(result.current.mfaChallenge).not.toBeNull();
+
+    await act(async () => {
+      result.current.respondMfa(["123"]);
+    });
+
+    const mockInvoke = vi.mocked(tauriInvoke);
+    const mfaCalls = mockInvoke.mock.calls.filter(
+      ([cmd]) => cmd === "respond_keyboard_interactive_challenge",
+    );
+    expect(mfaCalls).toHaveLength(1);
+    expect(mfaCalls[0]![1]).toMatchObject({
+      sessionId,
+      responses: { responses: ["123"] },
+    });
+
+    expect(result.current.mfaChallenge).toBeNull();
+  });
+});
+
+// ─── BLOCKER #2: server-initiated disconnect cleanup ─────────────────────────
+
+describe("useConnection — server-initiated disconnect cleans up session", () => {
+  beforeEach(() => {
+    mockDisposeSessionTerminals.mockClear();
+    vi.mocked(tauriInvoke).mockClear();
+    vi.mocked(tauriInvoke).mockResolvedValue("session-srv-disc" as never);
+    resetStore();
+  });
+
+  it("calls removeSession and disposeSessionTerminals on stateChanged disconnected", async () => {
+    const profileId = "profile-disc-1";
+    seedProfile(profileId);
+
+    const sessionId = "session-disconnect";
+    useSessionStore.setState((s) => ({
+      sessions: new Map([...s.sessions, [sessionId, makeSession(sessionId)]]),
+      activeSessionId: sessionId,
+    }));
+
+    const { result } = renderHook(() => useConnection());
+    await startConnect(result, profileId);
+
+    act(() => {
+      fireChannelEvent({
+        event: "stateChanged",
+        data: { sessionId, state: "disconnected" },
+      });
+    });
+
+    expect(mockDisposeSessionTerminals).toHaveBeenCalledWith(sessionId);
+    expect(useSessionStore.getState().sessions.has(sessionId)).toBe(false);
+  });
+
+  it("calls removeSession on stateChanged error object", async () => {
+    const profileId = "profile-disc-2";
+    seedProfile(profileId);
+
+    const sessionId = "session-error";
+    useSessionStore.setState((s) => ({
+      sessions: new Map([...s.sessions, [sessionId, makeSession(sessionId)]]),
+      activeSessionId: sessionId,
+    }));
+
+    const { result } = renderHook(() => useConnection());
+    await startConnect(result, profileId);
+
+    act(() => {
+      fireChannelEvent({
+        event: "stateChanged",
+        data: { sessionId, state: { error: { message: "Connection reset" } } },
+      });
+    });
+
+    expect(mockDisposeSessionTerminals).toHaveBeenCalledWith(sessionId);
+    expect(useSessionStore.getState().sessions.has(sessionId)).toBe(false);
   });
 });
 

--- a/src/features/connection/useConnection.test.ts
+++ b/src/features/connection/useConnection.test.ts
@@ -1,0 +1,140 @@
+// useConnection.test.ts — TDD: disposeSessionTerminals called on disconnect
+//
+// Bug: disconnect() calls the backend and removeSession() but never calls
+// disposeSessionTerminals(), leaving xterm.js Terminals/ResizeObservers alive.
+//
+// Fix: disconnect() calls disposeSessionTerminals(sessionId) before removeSession().
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+// Track disposeSessionTerminals calls
+const mockDisposeSessionTerminals = vi.fn();
+
+// Mock useTerminal — return a spy for disposeSessionTerminals
+vi.mock("../terminal/useTerminal", () => ({
+  useTerminal: () => ({
+    openTerminal: vi.fn(),
+    closeTerminal: vi.fn(),
+    getTerminal: vi.fn(),
+    focusTerminal: vi.fn(),
+    reattachTerminal: vi.fn(),
+    disposeSessionTerminals: mockDisposeSessionTerminals,
+  }),
+}));
+
+// Mock tauriInvoke — disconnect command returns void
+vi.mock("../../lib/tauri", () => ({
+  tauriInvoke: vi.fn().mockResolvedValue(undefined),
+  AppError: class AppError extends Error {
+    constructor(_cmd: string, msg: string) {
+      super(msg);
+      this.name = "AppError";
+    }
+  },
+}));
+
+// Mock @tauri-apps/api/core
+vi.mock("@tauri-apps/api/core", () => ({
+  Channel: vi.fn().mockImplementation(() => ({ onmessage: null })),
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+// ─── Store reset ──────────────────────────────────────────────────────────────
+
+import { useSessionStore } from "../../stores/sessionStore";
+import type { SessionEntry } from "../../stores/sessionStore";
+
+function makeSession(id: string): SessionEntry {
+  return {
+    id,
+    profileId: "profile-1",
+    profileName: "Test",
+    host: "10.0.0.1:22",
+    userId: "user-1",
+    username: "admin",
+    port: 22,
+    connectedAt: Date.now(),
+    state: "connected",
+    terminals: [],
+    activeTerminalId: null,
+  };
+}
+
+function resetStore() {
+  useSessionStore.setState({
+    sessions: new Map(),
+    activeSessionId: null,
+    activeFeature: "terminal",
+  });
+}
+
+// ─── Import hook AFTER mocks ──────────────────────────────────────────────────
+import { useConnection } from "./useConnection";
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("useConnection — disposeSessionTerminals called on disconnect", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStore();
+  });
+
+  it(
+    "calls disposeSessionTerminals(sessionId) when disconnect() is invoked",
+    async () => {
+      // Seed the session store so removeSession has something to remove
+      const sessionId = "test-session-id";
+      const session = makeSession(sessionId);
+      useSessionStore.setState({
+        sessions: new Map([[sessionId, session]]),
+        activeSessionId: sessionId,
+      });
+
+      const { result } = renderHook(() => useConnection());
+
+      await act(async () => {
+        await result.current.disconnect(sessionId);
+      });
+
+      // The fix: disposeSessionTerminals MUST be called with the sessionId
+      expect(mockDisposeSessionTerminals).toHaveBeenCalledWith(sessionId);
+      expect(mockDisposeSessionTerminals).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("calls disposeSessionTerminals before removeSession (dispose first)", async () => {
+    const sessionId = "test-session-id-2";
+    const session = makeSession(sessionId);
+    useSessionStore.setState({
+      sessions: new Map([[sessionId, session]]),
+      activeSessionId: sessionId,
+    });
+
+    const callOrder: string[] = [];
+
+    mockDisposeSessionTerminals.mockImplementation(() => {
+      callOrder.push("disposeSessionTerminals");
+    });
+
+    // Spy on removeSession by watching the store's sessions map
+    const originalRemoveSession = useSessionStore.getState().removeSession;
+    useSessionStore.setState({
+      removeSession: (id: string) => {
+        callOrder.push("removeSession");
+        originalRemoveSession(id);
+      },
+    });
+
+    const { result } = renderHook(() => useConnection());
+
+    await act(async () => {
+      await result.current.disconnect(sessionId);
+    });
+
+    expect(callOrder[0]).toBe("disposeSessionTerminals");
+    expect(callOrder[1]).toBe("removeSession");
+  });
+});

--- a/src/features/connection/useConnection.test.ts
+++ b/src/features/connection/useConnection.test.ts
@@ -5,7 +5,7 @@
 //
 // Fix: disconnect() calls disposeSessionTerminals(sessionId) before removeSession().
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 
 // ─── Mocks ───────────────────────────────────────────────────────────────────
@@ -136,5 +136,166 @@ describe("useConnection — disposeSessionTerminals called on disconnect", () =>
 
     expect(callOrder[0]).toBe("disposeSessionTerminals");
     expect(callOrder[1]).toBe("removeSession");
+  });
+});
+
+// ─── runStartupCommands ───────────────────────────────────────────────────────
+
+import { tauriInvoke } from "../../lib/tauri";
+
+describe("useConnection — runStartupCommands", () => {
+  const SESSION_ID = "session-startup";
+  const TERMINAL_ID = "terminal-real-uuid";
+
+  function seedSession(activeTerminalId: string | null) {
+    useSessionStore.setState({
+      sessions: new Map([
+        [
+          SESSION_ID,
+          {
+            ...makeSession(SESSION_ID),
+            activeTerminalId,
+          },
+        ],
+      ]),
+      activeSessionId: SESSION_ID,
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStore();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("calls write_terminal once per command with correct payload", async () => {
+    seedSession(TERMINAL_ID);
+
+    const { result } = renderHook(() => useConnection());
+
+    await act(async () => {
+      await result.current.runStartupCommands(SESSION_ID, ["ls -la", "pwd"]);
+    });
+
+    const mockInvoke = vi.mocked(tauriInvoke);
+    const writeCalls = mockInvoke.mock.calls.filter(
+      ([cmd]) => cmd === "write_terminal",
+    );
+
+    expect(writeCalls).toHaveLength(2);
+
+    expect(writeCalls[0]![1]).toMatchObject({
+      sessionId: SESSION_ID,
+      terminalId: TERMINAL_ID,
+      data: Array.from(new TextEncoder().encode("ls -la\n")),
+    });
+
+    expect(writeCalls[1]![1]).toMatchObject({
+      sessionId: SESSION_ID,
+      terminalId: TERMINAL_ID,
+      data: Array.from(new TextEncoder().encode("pwd\n")),
+    });
+  });
+
+  it("sends commands in order", async () => {
+    seedSession(TERMINAL_ID);
+
+    const order: string[] = [];
+    vi.mocked(tauriInvoke).mockImplementation(async (cmd, args) => {
+      if (cmd === "write_terminal" && args) {
+        const enc = new TextDecoder();
+        const text = enc.decode(new Uint8Array(args.data as number[]));
+        order.push(text.trim());
+      }
+      return undefined as never;
+    });
+
+    const { result } = renderHook(() => useConnection());
+
+    await act(async () => {
+      await result.current.runStartupCommands(SESSION_ID, [
+        "echo first",
+        "echo second",
+        "echo third",
+      ]);
+    });
+
+    expect(order).toEqual(["echo first", "echo second", "echo third"]);
+  });
+
+  it("resolves without calling write_terminal when activeTerminalId stays null (timeout path)", async () => {
+    vi.useFakeTimers();
+    seedSession(null);
+
+    const { result } = renderHook(() => useConnection());
+
+    const runPromise = act(async () => {
+      const p = result.current.runStartupCommands(SESSION_ID, ["whoami"]);
+      // Advance past the full poll window: 50 iterations × 100ms = 5 000ms
+      await vi.advanceTimersByTimeAsync(5100);
+      return p;
+    });
+
+    await runPromise;
+
+    const mockInvoke = vi.mocked(tauriInvoke);
+    const writeCalls = mockInvoke.mock.calls.filter(
+      ([cmd]) => cmd === "write_terminal",
+    );
+    expect(writeCalls).toHaveLength(0);
+  });
+
+  it("does not throw when write_terminal rejects", async () => {
+    seedSession(TERMINAL_ID);
+
+    vi.mocked(tauriInvoke).mockRejectedValueOnce(new Error("PTY write error"));
+
+    const { result } = renderHook(() => useConnection());
+
+    await expect(
+      act(async () => {
+        await result.current.runStartupCommands(SESSION_ID, ["bad-cmd"]);
+      }),
+    ).resolves.not.toThrow();
+  });
+
+  it("polls until activeTerminalId becomes a real id (pending → real)", async () => {
+    vi.useFakeTimers();
+
+    // Start with pending id
+    seedSession("pending-some-uuid");
+
+    const { result } = renderHook(() => useConnection());
+
+    let done = false;
+    const runPromise = result.current
+      .runStartupCommands(SESSION_ID, ["uname"])
+      .then(() => {
+        done = true;
+      });
+
+    // After 2 poll ticks, swap in the real id
+    await vi.advanceTimersByTimeAsync(200);
+    useSessionStore.setState((state) => {
+      const next = new Map(state.sessions);
+      const entry = next.get(SESSION_ID)!;
+      next.set(SESSION_ID, { ...entry, activeTerminalId: TERMINAL_ID });
+      return { sessions: next };
+    });
+
+    await vi.advanceTimersByTimeAsync(200);
+    await act(async () => {
+      await runPromise;
+    });
+
+    expect(done).toBe(true);
+    const mockInvoke = vi.mocked(tauriInvoke);
+    const writeCalls = mockInvoke.mock.calls.filter(
+      ([cmd]) => cmd === "write_terminal",
+    );
+    expect(writeCalls).toHaveLength(1);
   });
 });

--- a/src/features/connection/useConnection.ts
+++ b/src/features/connection/useConnection.ts
@@ -7,6 +7,7 @@ import { Channel } from "@tauri-apps/api/core";
 import { tauriInvoke } from "../../lib/tauri";
 import { useSessionStore } from "../../stores/sessionStore";
 import { useProfileStore } from "../../stores/profileStore";
+import { useTerminal } from "../terminal/useTerminal";
 import type {
   SessionId,
   SessionState,
@@ -39,6 +40,7 @@ interface UseConnectionReturn {
 export function useConnection(): UseConnectionReturn {
   const { addSession, removeSession, updateSessionState } = useSessionStore();
   const { storeCredential } = useProfileStore();
+  const { disposeSessionTerminals } = useTerminal();
 
   const [connecting, setConnecting] = useState(false);
   // H6 fix: Use a ref for the connecting guard so the double-connect check
@@ -169,12 +171,15 @@ export function useConnection(): UseConnectionReturn {
     async (sessionId: string) => {
       try {
         await tauriInvoke<void>("disconnect", { sessionId });
+        // Dispose xterm.js instances BEFORE removing the session from the store
+        // so any remaining references are cleaned up first (PTY leak fix).
+        disposeSessionTerminals(sessionId);
         removeSession(sessionId);
       } catch (err) {
         setConnectError(String(err));
       }
     },
-    [removeSession],
+    [removeSession, disposeSessionTerminals],
   );
 
   const respondHostKey = useCallback(

--- a/src/features/connection/useConnection.ts
+++ b/src/features/connection/useConnection.ts
@@ -8,6 +8,7 @@ import { tauriInvoke } from "../../lib/tauri";
 import { useSessionStore } from "../../stores/sessionStore";
 import { useProfileStore } from "../../stores/profileStore";
 import { useTerminal } from "../terminal/useTerminal";
+import { normalizeStartupCommands } from "./startupCommands";
 import type {
   SessionId,
   SessionState,
@@ -35,10 +36,12 @@ interface UseConnectionReturn {
   submitPassword: (password: string, remember: boolean) => void;
   cancelConnect: () => void;
   clearError: () => void;
+  runStartupCommands: (sessionId: string, commands: string[]) => Promise<void>;
 }
 
 export function useConnection(): UseConnectionReturn {
-  const { addSession, removeSession, updateSessionState } = useSessionStore();
+  const { addSession, removeSession, updateSessionState, setStartupPreview } =
+    useSessionStore();
   const { storeCredential } = useProfileStore();
   const { disposeSessionTerminals } = useTerminal();
 
@@ -143,6 +146,18 @@ export function useConnection(): UseConnectionReturn {
           activeTerminalId: null,
         });
 
+        // Trigger startup commands preview if the profile has any
+        const commands = normalizeStartupCommands(
+          profile.startupCommands ?? [],
+        );
+        if (commands.length > 0) {
+          setStartupPreview({
+            sessionId,
+            commands,
+            profileName: profile.name,
+          });
+        }
+
         setConnecting(false);
         connectingProfileIdRef.current = null;
         setConnectingProfileId(null);
@@ -164,7 +179,7 @@ export function useConnection(): UseConnectionReturn {
         }
       }
     },
-    [addSession, updateSessionState],
+    [addSession, updateSessionState, setStartupPreview],
   );
 
   const disconnect = useCallback(
@@ -230,6 +245,43 @@ export function useConnection(): UseConnectionReturn {
     setConnectError(null);
   }, []);
 
+  // Inject startup commands into the active terminal PTY sequentially.
+  // Guards against a missing activeTerminalId (acceptable — confirm latency
+  // means the terminal is essentially always ready, but we never crash).
+  const runStartupCommands = useCallback(
+    async (sessionId: string, commands: string[]) => {
+      // The preview can be confirmed before the PTY is ready: activeTerminalId
+      // is null until TerminalTabs mounts, then a placeholder 'pending-<uuid>'
+      // until onTerminalOpened swaps in the real id. Writing to either is a
+      // no-op (null) or a backend reject (pending). Wait briefly for a real id.
+      const isReady = (id: string | null | undefined): id is string =>
+        !!id && !id.startsWith("pending-");
+
+      let terminalId =
+        useSessionStore.getState().sessions.get(sessionId)?.activeTerminalId;
+      for (let i = 0; i < 50 && !isReady(terminalId); i++) {
+        await new Promise((r) => setTimeout(r, 100));
+        terminalId =
+          useSessionStore.getState().sessions.get(sessionId)?.activeTerminalId;
+      }
+      if (!isReady(terminalId)) return;
+
+      try {
+        for (const cmd of commands) {
+          const data = Array.from(new TextEncoder().encode(cmd + "\n"));
+          await tauriInvoke<void>("write_terminal", {
+            sessionId,
+            terminalId,
+            data,
+          });
+        }
+      } catch (err) {
+        console.error("Failed to run startup commands", err);
+      }
+    },
+    [],
+  );
+
   return {
     connecting,
     connectingProfileId,
@@ -244,5 +296,6 @@ export function useConnection(): UseConnectionReturn {
     submitPassword,
     cancelConnect,
     clearError,
+    runStartupCommands,
   };
 }

--- a/src/features/connection/useConnection.ts
+++ b/src/features/connection/useConnection.ts
@@ -14,25 +14,29 @@ import type {
   SessionState,
   HostKeyVerificationRequest,
   HostKeyVerificationResponse,
+  KeyboardInteractiveChallengeRequest,
   UserCredential,
 } from "../../lib/types";
 
 // Mirror the Rust SessionStateEvent enum
 type SessionStateEvent =
   | { event: "stateChanged"; data: { sessionId: string; state: SessionState } }
-  | { event: "hostKeyVerification"; data: HostKeyVerificationRequest };
+  | { event: "hostKeyVerification"; data: HostKeyVerificationRequest }
+  | { event: "keyboardInteractiveChallenge"; data: KeyboardInteractiveChallengeRequest };
 
 interface UseConnectionReturn {
   connecting: boolean;
   connectingProfileId: string | null;
   connectError: string | null;
   hostKeyRequest: HostKeyVerificationRequest | null;
+  mfaChallenge: KeyboardInteractiveChallengeRequest | null;
   needsPassword: boolean;
   pendingProfileId: string | null;
   pendingUser: UserCredential | null;
   connect: (profileId: string, password?: string, userId?: string) => Promise<void>;
   disconnect: (sessionId: string) => Promise<void>;
   respondHostKey: (response: HostKeyVerificationResponse) => void;
+  respondMfa: (answers: string[]) => void;
   submitPassword: (password: string, remember: boolean) => void;
   cancelConnect: () => void;
   clearError: () => void;
@@ -53,6 +57,8 @@ export function useConnection(): UseConnectionReturn {
   const [connectError, setConnectError] = useState<string | null>(null);
   const [hostKeyRequest, setHostKeyRequest] =
     useState<HostKeyVerificationRequest | null>(null);
+  const [mfaChallenge, setMfaChallenge] =
+    useState<KeyboardInteractiveChallengeRequest | null>(null);
   const [needsPassword, setNeedsPassword] = useState(false);
   const [pendingProfileId, setPendingProfileId] = useState<string | null>(null);
   const [pendingUser, setPendingUser] = useState<UserCredential | null>(null);
@@ -110,6 +116,16 @@ export function useConnection(): UseConnectionReturn {
           if (message.event === "stateChanged") {
             const { sessionId, state } = message.data;
             updateSessionState(sessionId, state);
+            // Server-initiated disconnect: clean up session just as the
+            // explicit disconnect button does. state may be the string
+            // "disconnected" or an error object { error: { message } }.
+            const isTerminal =
+              state === "disconnected" ||
+              (typeof state === "object" && "error" in state);
+            if (isTerminal) {
+              disposeSessionTerminals(sessionId);
+              removeSession(sessionId);
+            }
           } else if (message.event === "hostKeyVerification") {
             // The Rust side injects sessionId into the HK event so we can
             // respond immediately — without waiting for the connect promise.
@@ -119,6 +135,11 @@ export function useConnection(): UseConnectionReturn {
               setPendingSessionId(message.data.sessionId);
             }
             setHostKeyRequest(message.data);
+          } else if (message.event === "keyboardInteractiveChallenge") {
+            if (message.data.sessionId) {
+              setPendingSessionId(message.data.sessionId);
+            }
+            setMfaChallenge(message.data);
           }
         };
 
@@ -179,7 +200,7 @@ export function useConnection(): UseConnectionReturn {
         }
       }
     },
-    [addSession, updateSessionState, setStartupPreview],
+    [addSession, updateSessionState, setStartupPreview, removeSession, disposeSessionTerminals],
   );
 
   const disconnect = useCallback(
@@ -215,6 +236,21 @@ export function useConnection(): UseConnectionReturn {
     [hostKeyRequest, pendingSessionId],
   );
 
+  const respondMfa = useCallback(
+    (answers: string[]) => {
+      const sessionId = mfaChallenge?.sessionId ?? pendingSessionId;
+      if (!sessionId) return;
+      setMfaChallenge(null);
+      void tauriInvoke<void>("respond_keyboard_interactive_challenge", {
+        sessionId,
+        responses: { responses: answers },
+      }).catch((err) => {
+        setConnectError(String(err));
+      });
+    },
+    [mfaChallenge, pendingSessionId],
+  );
+
   const submitPassword = useCallback(
     (password: string, remember: boolean) => {
       setNeedsPassword(false);
@@ -235,6 +271,7 @@ export function useConnection(): UseConnectionReturn {
     setConnectingProfileId(null);
     setConnectError(null);
     setHostKeyRequest(null);
+    setMfaChallenge(null);
     setNeedsPassword(false);
     setPendingProfileId(null);
     setPendingUser(null);
@@ -287,12 +324,14 @@ export function useConnection(): UseConnectionReturn {
     connectingProfileId,
     connectError,
     hostKeyRequest,
+    mfaChallenge,
     needsPassword,
     pendingProfileId,
     pendingUser,
     connect,
     disconnect,
     respondHostKey,
+    respondMfa,
     submitPassword,
     cancelConnect,
     clearError,

--- a/src/features/terminal/TerminalTabs.a11y.test.tsx
+++ b/src/features/terminal/TerminalTabs.a11y.test.tsx
@@ -1,0 +1,213 @@
+// a11y invariant: the terminal tab strip is a WAI-ARIA tablist — role="tablist"
+// wraps role="tab" elements with aria-selected reflecting the active terminal,
+// roving tabindex (active=0/others=-1), and Arrow/Home/End keyboard navigation.
+// All hooks stay unconditional (no Rules-of-Hooks regression).
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useSessionStore } from "../../stores/sessionStore";
+import type { SessionEntry } from "../../stores/sessionStore";
+
+// This jsdom config has a non-functional localStorage; the workspace store
+// persist middleware resolves its storage at import time, so the in-memory stub
+// MUST be installed before any store module loads. vi.hoisted runs first.
+vi.hoisted(() => {
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, String(v)),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => void store.clear(),
+      key: (i: number) => [...store.keys()][i] ?? null,
+      get length() {
+        return store.size;
+      },
+    },
+  });
+});
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+vi.mock("../../lib/tauri", () => ({
+  tauriInvoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  Channel: vi.fn().mockImplementation(() => ({ onmessage: null })),
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: vi.fn().mockImplementation(() => ({
+    loadAddon: vi.fn(),
+    open: vi.fn(),
+    fit: vi.fn(),
+    cols: 80,
+    rows: 24,
+    onData: vi.fn(),
+    onBinary: vi.fn(),
+    focus: vi.fn(),
+    dispose: vi.fn(),
+    write: vi.fn(),
+    writeln: vi.fn(),
+    element: document.createElement("div"),
+  })),
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: vi.fn().mockImplementation(() => ({ fit: vi.fn(), dispose: vi.fn() })),
+}));
+
+vi.mock("@xterm/addon-web-links", () => ({
+  WebLinksAddon: vi.fn().mockImplementation(() => ({ dispose: vi.fn() })),
+}));
+
+vi.mock("./TerminalView", () => ({
+  TerminalView: ({ active }: { active: boolean }) => (
+    <div data-testid="terminal-view" data-active={active} />
+  ),
+}));
+
+vi.mock("../../lib/i18n", () => ({
+  useI18n: () => ({ t: (k: string) => k }),
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeSession(id: string, activeTerminalId = "term-1"): SessionEntry {
+  return {
+    id,
+    profileId: "profile-1",
+    profileName: "Test Server",
+    host: "192.168.1.1",
+    userId: "user-1",
+    username: "admin",
+    port: 22,
+    connectedAt: Date.now() - 5000,
+    state: "connected",
+    terminals: [
+      { id: "term-1", label: "Terminal 1", sessionId: id, reactKey: "rk-1" },
+      { id: "term-2", label: "Terminal 2", sessionId: id, reactKey: "rk-2" },
+      { id: "term-3", label: "Terminal 3", sessionId: id, reactKey: "rk-3" },
+    ],
+    activeTerminalId,
+  };
+}
+
+// eslint-disable-next-line import/first
+import { TerminalTabs } from "./TerminalTabs";
+
+function resetStore() {
+  useSessionStore.setState({
+    sessions: new Map(),
+    activeSessionId: null,
+    activeFeature: "terminal",
+  });
+}
+
+function setup(id = "sid-1", activeTerminalId = "term-1") {
+  useSessionStore.setState({
+    sessions: new Map([[id, makeSession(id, activeTerminalId)]]),
+    activeSessionId: id,
+  });
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("TerminalTabs — WAI-ARIA tabs", () => {
+  beforeEach(() => {
+    resetStore();
+    setup();
+  });
+
+  afterEach(() => {
+    resetStore();
+  });
+
+  it("renders a tablist with one tab per terminal", () => {
+    render(<TerminalTabs sessionId="sid-1" />);
+    expect(screen.getByRole("tablist")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /Terminal 1/ })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /Terminal 2/ })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /Terminal 3/ })).toBeInTheDocument();
+  });
+
+  it("marks the active terminal with aria-selected=true", () => {
+    render(<TerminalTabs sessionId="sid-1" />);
+    expect(screen.getByRole("tab", { name: /Terminal 1/ })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByRole("tab", { name: /Terminal 2/ })).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
+  });
+
+  it("applies roving tabindex (active=0, others=-1)", () => {
+    render(<TerminalTabs sessionId="sid-1" />);
+    expect(screen.getByRole("tab", { name: /Terminal 1/ })).toHaveAttribute(
+      "tabindex",
+      "0",
+    );
+    expect(screen.getByRole("tab", { name: /Terminal 2/ })).toHaveAttribute(
+      "tabindex",
+      "-1",
+    );
+  });
+
+  it("click still selects a terminal tab (existing behavior preserved)", () => {
+    render(<TerminalTabs sessionId="sid-1" />);
+    fireEvent.click(screen.getByRole("tab", { name: /Terminal 2/ }));
+    expect(screen.getByRole("tab", { name: /Terminal 2/ })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("ArrowRight moves selection to the next terminal", () => {
+    render(<TerminalTabs sessionId="sid-1" />);
+    fireEvent.keyDown(screen.getByRole("tab", { name: /Terminal 1/ }), {
+      key: "ArrowRight",
+    });
+    expect(screen.getByRole("tab", { name: /Terminal 2/ })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("ArrowLeft moves selection to the previous terminal", () => {
+    resetStore();
+    setup("sid-1", "term-2");
+    render(<TerminalTabs sessionId="sid-1" />);
+    fireEvent.keyDown(screen.getByRole("tab", { name: /Terminal 2/ }), {
+      key: "ArrowLeft",
+    });
+    expect(screen.getByRole("tab", { name: /Terminal 1/ })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("Home selects the first terminal, End selects the last", () => {
+    resetStore();
+    setup("sid-1", "term-2");
+    render(<TerminalTabs sessionId="sid-1" />);
+    fireEvent.keyDown(screen.getByRole("tab", { name: /Terminal 2/ }), {
+      key: "End",
+    });
+    expect(screen.getByRole("tab", { name: /Terminal 3/ })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    fireEvent.keyDown(screen.getByRole("tab", { name: /Terminal 3/ }), {
+      key: "Home",
+    });
+    expect(screen.getByRole("tab", { name: /Terminal 1/ })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+});

--- a/src/features/terminal/TerminalTabs.test.tsx
+++ b/src/features/terminal/TerminalTabs.test.tsx
@@ -1,0 +1,180 @@
+// TerminalTabs.test.tsx — TDD: Rules-of-Hooks violation fix
+//
+// Bug: `if (!session) return null` sits BEFORE all hooks → hook count changes
+// on session removal → React throws "Rendered fewer hooks than expected".
+//
+// Fix: all hooks run unconditionally; early return moves to just before JSX.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { useSessionStore } from "../../stores/sessionStore";
+import type { SessionEntry } from "../../stores/sessionStore";
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+// Mock tauri — TerminalTabs → useTerminal → tauriInvoke
+vi.mock("../../lib/tauri", () => ({
+  tauriInvoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock @tauri-apps/api/core (Channel, etc.)
+vi.mock("@tauri-apps/api/core", () => ({
+  Channel: vi.fn().mockImplementation(() => ({
+    onmessage: null,
+  })),
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock xterm — heavy native module, not needed in unit tests
+vi.mock("@xterm/xterm", () => ({
+  Terminal: vi.fn().mockImplementation(() => ({
+    loadAddon: vi.fn(),
+    open: vi.fn(),
+    fit: vi.fn(),
+    cols: 80,
+    rows: 24,
+    onData: vi.fn(),
+    onBinary: vi.fn(),
+    focus: vi.fn(),
+    dispose: vi.fn(),
+    write: vi.fn(),
+    writeln: vi.fn(),
+    element: document.createElement("div"),
+  })),
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: vi.fn().mockImplementation(() => ({
+    fit: vi.fn(),
+    dispose: vi.fn(),
+  })),
+}));
+
+vi.mock("@xterm/addon-web-links", () => ({
+  WebLinksAddon: vi.fn().mockImplementation(() => ({
+    dispose: vi.fn(),
+  })),
+}));
+
+// Mock TerminalView — we only care about TerminalTabs rendering the shell
+vi.mock("./TerminalView", () => ({
+  TerminalView: ({ active }: { active: boolean }) => (
+    <div data-testid="terminal-view" data-active={active} />
+  ),
+}));
+
+// Mock i18n
+vi.mock("../../lib/i18n", () => ({
+  useI18n: () => ({ t: (k: string) => k }),
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeSession(id: string): SessionEntry {
+  return {
+    id,
+    profileId: "profile-1",
+    profileName: "Test Server",
+    host: "192.168.1.1:22",
+    userId: "user-1",
+    username: "admin",
+    port: 22,
+    connectedAt: Date.now() - 5000,
+    state: "connected",
+    terminals: [
+      {
+        id: "term-1",
+        label: "Terminal 1",
+        sessionId: id,
+        reactKey: "rk-1",
+      },
+    ],
+    activeTerminalId: "term-1",
+  };
+}
+
+// ─── Import TerminalTabs AFTER mocks ─────────────────────────────────────────
+// eslint-disable-next-line import/first
+import { TerminalTabs } from "./TerminalTabs";
+
+// ─── Store reset helper ───────────────────────────────────────────────────────
+function resetStore() {
+  useSessionStore.setState({
+    sessions: new Map(),
+    activeSessionId: null,
+    activeFeature: "terminal",
+  });
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("TerminalTabs — Rules-of-Hooks fix", () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  afterEach(() => {
+    resetStore();
+  });
+
+  it("renders the tab bar when a session is present", () => {
+    const session = makeSession("sid-1");
+    useSessionStore.setState({
+      sessions: new Map([["sid-1", session]]),
+      activeSessionId: "sid-1",
+    });
+
+    render(<TerminalTabs sessionId="sid-1" />);
+
+    // Tab bar should be present
+    expect(document.querySelector(".terminal-tabbar")).not.toBeNull();
+
+    // Connection info bar shows host
+    expect(screen.getByText(/admin@192\.168\.1\.1/)).toBeInTheDocument();
+
+    // TerminalView rendered for the tab
+    expect(screen.getAllByTestId("terminal-view").length).toBeGreaterThan(0);
+  });
+
+  it(
+    "returns null without throwing when session is deleted (hooks-violation fix)",
+    () => {
+      const session = makeSession("sid-2");
+      useSessionStore.setState({
+        sessions: new Map([["sid-2", session]]),
+        activeSessionId: "sid-2",
+      });
+
+      const { rerender, container } = render(<TerminalTabs sessionId="sid-2" />);
+      expect(container.querySelector(".terminal-tabs")).not.toBeNull();
+
+      // Remove the session from the store — before the fix this triggers
+      // "Rendered fewer hooks than expected" because the early return cut the
+      // hook chain.
+      act(() => {
+        useSessionStore.setState({
+          sessions: new Map(),
+          activeSessionId: null,
+        });
+      });
+
+      // Rerender with the same sessionId (now invalid) — MUST NOT throw.
+      expect(() => rerender(<TerminalTabs sessionId="sid-2" />)).not.toThrow();
+
+      // And the component should render nothing (null)
+      expect(container.querySelector(".terminal-tabs")).toBeNull();
+    },
+  );
+
+  it("shows the new-tab button when a session exists", () => {
+    const session = makeSession("sid-3");
+    useSessionStore.setState({
+      sessions: new Map([["sid-3", session]]),
+      activeSessionId: "sid-3",
+    });
+
+    render(<TerminalTabs sessionId="sid-3" />);
+    const newTabBtn = document.querySelector(".terminal-tab-new");
+    expect(newTabBtn).not.toBeNull();
+  });
+});

--- a/src/features/terminal/TerminalTabs.tsx
+++ b/src/features/terminal/TerminalTabs.tsx
@@ -3,7 +3,7 @@
 // Shows tab bar for multiple terminal channels on the same session.
 // Each tab wraps a TerminalView that stays alive when hidden (not destroyed).
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
 import { useSessionStore, type TerminalTab } from "../../stores/sessionStore";
 import { TerminalView } from "./TerminalView";
 import { useTerminal } from "./useTerminal";
@@ -109,6 +109,39 @@ export function TerminalTabs({ sessionId }: TerminalTabsProps) {
   );
 
   const tabBarRef = useRef<HTMLDivElement>(null);
+  // Roving-tabindex refs so keyboard navigation can move DOM focus.
+  // Declared before the early return to keep the hook order stable.
+  const tabRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  // WAI-ARIA tabs keyboard pattern: ArrowLeft/Right move (no wrap),
+  // Home → first, End → last. Selection follows focus to match click behavior.
+  // Defined as a hook-free closure after the refs so it captures current values.
+  const handleTabKeyDown = useCallback(
+    (e: KeyboardEvent, index: number) => {
+      const move = (target: number) => {
+        const tab = terminals[target];
+        if (!tab) return;
+        e.preventDefault();
+        setActiveTerminal(sessionId, tab.id);
+        tabRefs.current[target]?.focus();
+      };
+      switch (e.key) {
+        case "ArrowRight":
+          move(Math.min(index + 1, terminals.length - 1));
+          break;
+        case "ArrowLeft":
+          move(Math.max(index - 1, 0));
+          break;
+        case "Home":
+          move(0);
+          break;
+        case "End":
+          move(terminals.length - 1);
+          break;
+      }
+    },
+    [terminals, sessionId, setActiveTerminal],
+  );
 
   // All hooks have run — safe to early-return now
   if (!session) return null;
@@ -117,26 +150,37 @@ export function TerminalTabs({ sessionId }: TerminalTabsProps) {
     <div className="terminal-tabs">
       {/* Tab bar */}
       <div className="terminal-tabbar" ref={tabBarRef}>
-        <div className="terminal-tabbar-scroll">
-          {terminals.map((tab) => (
-            <div
-              key={tab.reactKey}
-              className={`terminal-tab ${tab.id === activeTerminalId ? "terminal-tab-active" : ""}`}
-              onClick={() => setActiveTerminal(sessionId, tab.id)}
-            >
-              <span className="terminal-tab-label">{tab.label}</span>
-              <button
-                className="terminal-tab-close"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  void handleCloseTab(tab);
+        <div className="terminal-tabbar-scroll" role="tablist">
+          {terminals.map((tab, i) => {
+            const isActive = tab.id === activeTerminalId;
+            return (
+              <div
+                key={tab.reactKey}
+                ref={(el) => {
+                  tabRefs.current[i] = el;
                 }}
-                title={t("terminal.closeTab")}
+                role="tab"
+                aria-selected={isActive}
+                aria-label={tab.label}
+                tabIndex={isActive ? 0 : -1}
+                className={`terminal-tab ${isActive ? "terminal-tab-active" : ""}`}
+                onClick={() => setActiveTerminal(sessionId, tab.id)}
+                onKeyDown={(e) => handleTabKeyDown(e, i)}
               >
-                ×
-              </button>
-            </div>
-          ))}
+                <span className="terminal-tab-label">{tab.label}</span>
+                <button
+                  className="terminal-tab-close"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    void handleCloseTab(tab);
+                  }}
+                  title={t("terminal.closeTab")}
+                >
+                  ×
+                </button>
+              </div>
+            );
+          })}
         </div>
         <button
           className="terminal-tab-new"

--- a/src/features/terminal/TerminalTabs.tsx
+++ b/src/features/terminal/TerminalTabs.tsx
@@ -30,15 +30,20 @@ export function TerminalTabs({ sessionId }: TerminalTabsProps) {
     useSessionStore();
   const { closeTerminal } = useTerminal();
 
+  // Read session — may be undefined after disconnect/session-switch.
+  // ALL hooks must run unconditionally before any early return so the
+  // hook count stays stable across renders (Rules of Hooks).
   const session = sessions.get(sessionId);
-  if (!session) return null;
 
-  const { terminals, activeTerminalId } = session;
+  // Null-safe derived values — used by hooks below
+  const terminals = session?.terminals ?? [];
+  const activeTerminalId = session?.activeTerminalId;
 
   // Connection info for the info bar
   const hostLabel = useMemo(
-    () => `${session.username}@${session.host}`,
-    [session.username, session.host],
+    () => (session ? `${session.username}@${session.host}` : ""),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [session?.username, session?.host],
   );
 
   // Tick elapsed time every 30s
@@ -47,7 +52,7 @@ export function TerminalTabs({ sessionId }: TerminalTabsProps) {
     const interval = setInterval(() => setTick((t) => t + 1), 30_000);
     return () => clearInterval(interval);
   }, []);
-  const elapsed = formatElapsed(session.connectedAt);
+  const elapsed = session ? formatElapsed(session.connectedAt) : "";
 
   // Derive next label number from existing labels to avoid gaps
   const getNextTerminalNumber = useCallback((): number => {
@@ -67,6 +72,7 @@ export function TerminalTabs({ sessionId }: TerminalTabsProps) {
   // destroying the xterm.js DOM container and leaving the screen blank.
   const autoCreatedRef = useRef<string | null>(null);
   useEffect(() => {
+    if (!session) return;
     if (terminals.length === 0 && autoCreatedRef.current !== sessionId) {
       autoCreatedRef.current = sessionId;
       const stableKey = crypto.randomUUID();
@@ -78,7 +84,7 @@ export function TerminalTabs({ sessionId }: TerminalTabsProps) {
         reactKey: stableKey,
       });
     }
-  }, [terminals.length, sessionId, addTerminalTab]);
+  }, [session, terminals.length, sessionId, addTerminalTab]);
 
   const handleNewTab = useCallback(async () => {
     const nextNum = getNextTerminalNumber();
@@ -103,6 +109,9 @@ export function TerminalTabs({ sessionId }: TerminalTabsProps) {
   );
 
   const tabBarRef = useRef<HTMLDivElement>(null);
+
+  // All hooks have run — safe to early-return now
+  if (!session) return null;
 
   return (
     <div className="terminal-tabs">

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -9,29 +9,35 @@ export const TERMINAL_FONT_FAMILY =
 export const TERMINAL_FONT_SIZE = 13;
 export const TERMINAL_LINE_HEIGHT = 1.35;
 export const TERMINAL_THEME = {
-  background: "#0d1117",
-  foreground: "#e6edf3",
-  cursor: "#58a6ff",
-  cursorAccent: "#0d1117",
-  selectionBackground: "#388bfd33",
+  // LAMPLIGHT chrome — bg-abyss canvas, warm foreground, copper cursor
+  background: "#0f0b09",       // var(--bg-abyss)
+  foreground: "#eeeae7",       // var(--text-primary)
+  cursor: "#ea9e51",           // var(--accent) copper
+  cursorAccent: "#0f0b09",     // var(--bg-abyss) — text on cursor block
+  // accent-wash at ~65% opacity — copper selection replaces old blue #388bfd33
+  selectionBackground: "#3c2918a6",
   selectionForeground: undefined,
-  // ANSI colors (GitHub Dark inspired)
-  black: "#484f58",
-  red: "#ff7b72",
-  green: "#3fb950",
-  yellow: "#d29922",
-  blue: "#58a6ff",
-  magenta: "#bc8cff",
-  cyan: "#39d353",
-  white: "#b1bac4",
-  brightBlack: "#6e7681",
-  brightRed: "#ffa198",
-  brightGreen: "#56d364",
-  brightYellow: "#e3b341",
-  brightBlue: "#79c0ff",
-  brightMagenta: "#d2a8ff",
-  brightCyan: "#56d364",
-  brightWhite: "#f0f6fc",
+  // ANSI 16-color ramp — warmed slightly to sit in the warm field while staying
+  // perceptually correct for `git diff`, `ls --color`, colored logs.
+  // Red stays unmistakably red (error-safe). Green shifts toward jade family
+  // (distinct from live-state jade; still clearly green). Blue stays blue for
+  // diffs/links. Magenta/cyan slightly desaturated to avoid neon pops.
+  black:         "#3e3830",    // warm near-black (replaces cool #484f58)
+  red:           "#e05c4a",    // warm brick-red, still clearly error (was #ff7b72)
+  green:         "#4ec99a",    // jade-family green, readable as "ok" (was #3fb950)
+  yellow:        "#d4a03a",    // warm ochre, distinct from accent (was #d29922)
+  blue:          "#5aabf0",    // stays blue, slightly warmed (was #58a6ff)
+  magenta:       "#b589e8",    // slightly desaturated (was #bc8cff)
+  cyan:          "#3fc9a0",    // jade-tinted cyan (was #39d353)
+  white:         "#b6b0ab",    // var(--text-secondary) warm (was #b1bac4)
+  brightBlack:   "#635c57",    // var(--text-faint) warm (was #6e7681)
+  brightRed:     "#f5897e",    // brighter warm red (was #ffa198)
+  brightGreen:   "#66c7a0",    // var(--connected) jade (was #56d364)
+  brightYellow:  "#e8b84e",    // bright warm ochre (was #e3b341)
+  brightBlue:    "#82c8ff",    // bright warm blue (was #79c0ff)
+  brightMagenta: "#cca8f8",    // bright desaturated magenta (was #d2a8ff)
+  brightCyan:    "#66c7a0",    // jade — consistent with brightGreen (was #56d364)
+  brightWhite:   "#eeeae7",    // var(--text-primary) (was #f0f6fc)
 } as const;
 
 export const APP_NAME = "NexTerm";

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -88,6 +88,8 @@ export const en = {
   "connection.testAuthFailed": "Credentials rejected",
   "connection.testUntrusted": "Host key not trusted",
   "connection.testMitm": "Host key changed or revoked",
+  "connection.sectionStartup": "Startup Commands",
+  "connection.startupPlaceholder": "One command per line — run after connect",
 
   // Host key dialog
   "hostKey.unknownTitle": "New Host",
@@ -366,6 +368,12 @@ export const en = {
   "tour.done": "Done",
   "tour.stepOf": "{current} of {total}",
   "tour.helpButton": "Tour",
+
+  // Startup commands preview dialog
+  "startup.title": "Run startup commands?",
+  "startup.subtitle": "These commands will run in the new session. Review before running.",
+  "startup.run": "Run",
+  "startup.cancel": "Skip",
 
   // General
   "general.ok": "OK",

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -121,10 +121,27 @@ export const en = {
   "auth.cancel": "Cancel",
   "auth.connect": "Connect",
 
-  // Welcome
+  // Welcome / empty state (Lamplight launchpad)
   "welcome.title": "NexTerm",
   "welcome.connecting": "Connecting...",
   "welcome.message": "Select a profile to connect, or create a new one.",
+  "welcome.headline": "Ready when you are",
+  "welcome.subline": "Open a server to start a session.",
+  "welcome.cta": "Connect to a server",
+  "welcome.hint": "or press ⌘N",
+  "welcome.recent": "Recent",
+  "welcome.reconnect": "Reconnect",
+  "welcome.connectingTo": "Connecting to {host}...",
+  "welcome.cancelConnect": "Cancel",
+  // Sidebar groups (derived, presentational only)
+  "sidebar.group.production": "PRODUCTION",
+  "sidebar.group.development": "DEVELOPMENT",
+  "sidebar.group.certification": "CERTIFICATION",
+  "sidebar.group.staging": "STAGING",
+  "sidebar.group.other": "PROFILES",
+  // Sidebar credentials label
+  "sidebar.credentials": "{n} credentials",
+  "sidebar.overflow": "More actions",
 
   // Tab bar (features)
   "tabbar.terminal": "Terminal",

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -81,6 +81,9 @@ export const en = {
   "connection.usernameRequired": "Username is required for each user",
   "connection.selectUser": "Select user",
   "connection.keyboardInteractive": "Keyboard Interactive",
+  "connection.agent": "SSH Agent",
+  "connection.agentHint": "Using SSH agent",
+  "connection.keyboardInteractiveHint": "Server will prompt at connect",
   "connection.testUser": "Test connection",
   "connection.testingUser": "Testing\u2026",
   "connection.testSuccess": "Connection successful",
@@ -374,6 +377,11 @@ export const en = {
   "startup.subtitle": "These commands will run in the new session. Review before running.",
   "startup.run": "Run",
   "startup.cancel": "Skip",
+
+  // MFA / keyboard-interactive challenge dialog
+  "mfa.title": "Authentication Required",
+  "mfa.submit": "Submit",
+  "mfa.cancel": "Cancel",
 
   // General
   "general.ok": "OK",

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -123,10 +123,27 @@ export const es: Record<TranslationKey, string> = {
   "auth.cancel": "Cancelar",
   "auth.connect": "Conectar",
 
-  // Welcome
+  // Welcome / empty state (Lamplight launchpad)
   "welcome.title": "NexTerm",
   "welcome.connecting": "Conectando...",
   "welcome.message": "Selecciona un perfil para conectar, o crea uno nuevo.",
+  "welcome.headline": "Listo cuando vos quieras",
+  "welcome.subline": "Abri un servidor para iniciar una sesión.",
+  "welcome.cta": "Conectar a un servidor",
+  "welcome.hint": "o presioná ⌘N",
+  "welcome.recent": "Recientes",
+  "welcome.reconnect": "Reconectar",
+  "welcome.connectingTo": "Conectando a {host}...",
+  "welcome.cancelConnect": "Cancelar",
+  // Sidebar groups (derived, presentational only)
+  "sidebar.group.production": "PRODUCCIÓN",
+  "sidebar.group.development": "DESARROLLO",
+  "sidebar.group.certification": "CERTIFICACIÓN",
+  "sidebar.group.staging": "STAGING",
+  "sidebar.group.other": "PERFILES",
+  // Sidebar credentials label
+  "sidebar.credentials": "{n} credenciales",
+  "sidebar.overflow": "Más acciones",
 
   // Tab bar (features)
   "tabbar.terminal": "Terminal",

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -83,6 +83,9 @@ export const es: Record<TranslationKey, string> = {
   "connection.usernameRequired": "El nombre de usuario es obligatorio para cada usuario",
   "connection.selectUser": "Seleccionar usuario",
   "connection.keyboardInteractive": "Interactivo por Teclado",
+  "connection.agent": "Agente SSH",
+  "connection.agentHint": "Usando agente SSH",
+  "connection.keyboardInteractiveHint": "El servidor solicitará credenciales al conectar",
   "connection.testUser": "Probar conexi\u00f3n",
   "connection.testingUser": "Probando\u2026",
   "connection.testSuccess": "Conexi\u00f3n exitosa",
@@ -376,6 +379,11 @@ export const es: Record<TranslationKey, string> = {
   "startup.subtitle": "Estos comandos se ejecutarán en la nueva sesión. Revísalos antes de confirmar.",
   "startup.run": "Ejecutar",
   "startup.cancel": "Omitir",
+
+  // MFA / keyboard-interactive challenge dialog
+  "mfa.title": "Autenticación Requerida",
+  "mfa.submit": "Enviar",
+  "mfa.cancel": "Cancelar",
 
   // General
   "general.ok": "OK",

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -90,6 +90,8 @@ export const es: Record<TranslationKey, string> = {
   "connection.testAuthFailed": "Credenciales rechazadas",
   "connection.testUntrusted": "Clave de host no confiable",
   "connection.testMitm": "Clave de host cambiada o revocada",
+  "connection.sectionStartup": "Comandos de Inicio",
+  "connection.startupPlaceholder": "Un comando por línea — se ejecutan al conectar",
 
   // Host key dialog
   "hostKey.unknownTitle": "Host Nuevo",
@@ -368,6 +370,12 @@ export const es: Record<TranslationKey, string> = {
   "tour.done": "Listo",
   "tour.stepOf": "{current} de {total}",
   "tour.helpButton": "Tour",
+
+  // Startup commands preview dialog
+  "startup.title": "¿Ejecutar comandos de inicio?",
+  "startup.subtitle": "Estos comandos se ejecutarán en la nueva sesión. Revísalos antes de confirmar.",
+  "startup.run": "Ejecutar",
+  "startup.cancel": "Omitir",
 
   // General
   "general.ok": "OK",

--- a/src/lib/i18n/index.test.tsx
+++ b/src/lib/i18n/index.test.tsx
@@ -1,0 +1,71 @@
+// a11y invariant: I18nProvider keeps document.documentElement.lang in sync with
+// the active locale (mount + on change), so screen readers announce content in
+// the correct language.
+
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { I18nProvider, useI18n } from "./index";
+
+// This jsdom config has a non-functional localStorage (setItem throws); i18n
+// reads/writes the "locale" key. Force an in-memory stub so it works.
+beforeAll(() => {
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, String(v)),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => void store.clear(),
+      key: (i: number) => [...store.keys()][i] ?? null,
+      get length() {
+        return store.size;
+      },
+    },
+  });
+});
+
+function LocaleProbe() {
+  const { locale, setLocale } = useI18n();
+  return (
+    <div>
+      <span data-testid="locale">{locale}</span>
+      <button onClick={() => setLocale("es")}>to-es</button>
+      <button onClick={() => setLocale("en")}>to-en</button>
+    </div>
+  );
+}
+
+describe("I18nProvider — html lang sync", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute("lang");
+  });
+
+  it("sets document.documentElement.lang to the active locale on mount", () => {
+    render(
+      <I18nProvider>
+        <LocaleProbe />
+      </I18nProvider>,
+    );
+    expect(document.documentElement.lang).toBe(
+      screen.getByTestId("locale").textContent,
+    );
+    // Default detect resolves to 'en' in jsdom.
+    expect(document.documentElement.lang).toBe("en");
+  });
+
+  it("updates document.documentElement.lang when the locale changes", () => {
+    render(
+      <I18nProvider>
+        <LocaleProbe />
+      </I18nProvider>,
+    );
+
+    fireEvent.click(screen.getByText("to-es"));
+    expect(document.documentElement.lang).toBe("es");
+
+    fireEvent.click(screen.getByText("to-en"));
+    expect(document.documentElement.lang).toBe("en");
+  });
+});

--- a/src/lib/i18n/index.tsx
+++ b/src/lib/i18n/index.tsx
@@ -1,6 +1,6 @@
 // lib/i18n/index.tsx — Lightweight i18n system (context + hook)
 
-import { createContext, useContext, useState, useCallback, useMemo, type ReactNode } from "react";
+import { createContext, useContext, useEffect, useState, useCallback, useMemo, type ReactNode } from "react";
 import { en, type TranslationKey } from "./en";
 import { es } from "./es";
 
@@ -34,6 +34,13 @@ function detectLocale(): Locale {
 
 export function I18nProvider({ children }: { children: ReactNode }) {
   const [locale, setLocaleState] = useState<Locale>(detectLocale);
+
+  // Keep the document language in sync with the active locale so assistive
+  // technology announces content in the correct language. Runs on mount and
+  // whenever the locale changes.
+  useEffect(() => {
+    document.documentElement.lang = locale;
+  }, [locale]);
 
   const t: TranslateFn = useCallback(
     (key, params) => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -202,6 +202,16 @@ export interface TestConnectionResult {
   message: string;
 }
 
+// ─── SSH Key Discovery ───────────────────────────────
+
+/** Mirrors ssh/keys.rs KeyInfo (serde camelCase) */
+export interface KeyInfo {
+  path: string;
+  keyType: string;
+  isEncrypted: boolean;
+  comment: string | null;
+}
+
 // ─── Search Result (SFTP recursive search) ──────────
 
 export interface SearchResult {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -30,6 +30,7 @@ export interface ConnectionProfile {
   port: number;
   users: UserCredential[];
   startupDirectory?: string;
+  startupCommands?: string[];
   tunnels: TunnelConfig[];
   displayOrder?: number;
   createdAt: string; // ISO 8601

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -40,7 +40,8 @@ export interface ConnectionProfile {
 export type AuthMethodConfig =
   | { type: "password" }
   | { type: "publicKey"; privateKeyPath: string; passphraseInKeychain: boolean }
-  | { type: "keyboardInteractive" };
+  | { type: "keyboardInteractive" }
+  | { type: "agent"; keyId?: string };
 
 // ─── Session State ──────────────────────────────────────
 
@@ -191,6 +192,21 @@ export type HostKeyVerificationResponse =
   | "accept"
   | "acceptAndSave"
   | "reject";
+
+// ─── Keyboard-Interactive (MFA) Challenge ───────────
+
+export interface KeyboardInteractivePrompt {
+  text: string;
+  echo: boolean;
+}
+
+export interface KeyboardInteractiveChallengeRequest {
+  sessionId?: string;
+  name: string;
+  instruction: string;
+  prompts: KeyboardInteractivePrompt[];
+  round: number;
+}
 
 // ─── Test Connection Result ──────────────────────────
 

--- a/src/stores/sessionStore.ts
+++ b/src/stores/sessionStore.ts
@@ -14,6 +14,12 @@ import {
   useWorkspaceStore,
 } from "./workspaceStore";
 
+export interface StartupPreview {
+  sessionId: SessionId;
+  commands: string[];
+  profileName?: string;
+}
+
 export interface TerminalTab {
   id: TerminalId;
   label: string;
@@ -42,12 +48,15 @@ interface SessionStoreState {
   sessions: Map<string, SessionEntry>;
   activeSessionId: string | null;
   activeFeature: ActiveFeature;
+  startupPreview: StartupPreview | null;
 
   addSession: (session: SessionEntry) => void;
   removeSession: (sessionId: string) => void;
   setActiveSession: (sessionId: string | null) => void;
   setActiveFeature: (feature: ActiveFeature) => void;
   updateSessionState: (sessionId: string, state: SessionState) => void;
+  setStartupPreview: (preview: StartupPreview) => void;
+  clearStartupPreview: () => void;
 
   // Terminal tab management
   addTerminalTab: (sessionId: string, tab: TerminalTab) => void;
@@ -60,6 +69,7 @@ export const useSessionStore = create<SessionStoreState>((set) => ({
   sessions: new Map(),
   activeSessionId: null,
   activeFeature: "terminal",
+  startupPreview: null,
 
   addSession: (session) =>
     set((state) => {
@@ -98,7 +108,12 @@ export const useSessionStore = create<SessionStoreState>((set) => ({
             ).activeFeature
         : state.activeFeature;
 
-      return { sessions: next, activeSessionId, activeFeature };
+      const startupPreview =
+        state.startupPreview?.sessionId === sessionId
+          ? null
+          : state.startupPreview;
+
+      return { sessions: next, activeSessionId, activeFeature, startupPreview };
     }),
 
   setActiveSession: (sessionId) =>
@@ -158,6 +173,18 @@ export const useSessionStore = create<SessionStoreState>((set) => ({
       next.set(sessionId, { ...entry, state: newState });
       return { sessions: next };
     }),
+
+  setStartupPreview: (preview) =>
+    set((state) =>
+      // Do not clobber an unresolved preview for a different session: the user
+      // must resolve (confirm/skip) the visible one first so no connect's
+      // commands are silently dropped.
+      state.startupPreview && state.startupPreview.sessionId !== preview.sessionId
+        ? state
+        : { startupPreview: preview },
+    ),
+
+  clearStartupPreview: () => set({ startupPreview: null }),
 
   addTerminalTab: (sessionId, tab) =>
     set((state) => {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3039,6 +3039,73 @@ dialog::backdrop {
   vertical-align: middle;
 }
 
+/* ─── Startup Commands (in connection dialog + preview dialog) ──── */
+
+.cd-startup-textarea {
+  width: 100%;
+  min-height: 80px;
+  padding: 8px 10px;
+  background: var(--bg-raised);
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: var(--fs-body);
+  line-height: var(--lh-body);
+  resize: vertical;
+  outline: none;
+  box-sizing: border-box;
+}
+
+.cd-startup-textarea:focus-visible {
+  border-color: var(--hairline-strong);
+  box-shadow: 0 0 0 2px var(--focus-ring);
+}
+
+.startup-subtitle {
+  font-size: var(--fs-body);
+  color: var(--text-secondary);
+  margin: 0 0 12px;
+}
+
+.startup-command-list {
+  list-style: decimal;
+  padding-left: 20px;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.startup-command-item code {
+  font-family: var(--font-mono);
+  font-size: var(--fs-body);
+  background: var(--bg-raised);
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-sm);
+  padding: 2px 6px;
+  color: var(--text-primary);
+}
+
+.cd-header-subtitle {
+  font-size: var(--fs-body);
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+/* Visually hidden helper (accessible label for textarea) */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* ─── User Card (in connection dialog) ──────────── */
 
 /* ─── User Rows (inline editing) ─────────────────── */

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2570,6 +2570,42 @@ dialog::backdrop {
   gap: 12px;
 }
 
+/* ─── MFA (keyboard-interactive) challenge ─── */
+
+.hk-mfa-instruction {
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.hk-mfa-prompt-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.hk-mfa-prompt-label {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.hk-mfa-input {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: var(--font-mono);
+  outline: none;
+  transition: border-color var(--transition-fast);
+}
+
+.hk-mfa-input:focus {
+  border-color: var(--accent);
+}
+
 /* ─── Info card ─── */
 
 .hk-info-card {
@@ -3160,6 +3196,12 @@ dialog::backdrop {
 
 .cd-user-row-input-error {
   border-color: var(--danger);
+}
+
+.cd-auth-hint {
+  font-size: 12px;
+  color: var(--text-secondary);
+  font-style: italic;
 }
 
 .cd-user-row-auth {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,63 +1,151 @@
 /* ═══════════════════════════════════════════════════════════════
-   NexTerm — Premium Dark Theme
-   Inspired by GitHub Dark, Termius, Warp, modern macOS apps
+   NexTerm — LAMPLIGHT
+   Warm graphite instrument panel, one copper accent, jade = live.
+   Drop-in replacement for the :root block in src/styles/globals.css
+   (currently lines 6-61). OKLCH primary, hex fallback in comments.
+
+   HUE SWAP GUIDE (to retheme the whole app):
+   - Neutral hue ........ --hue-neutral (60-66 warm). Raise toward 250 for a
+     cool field, but keep ALL neutrals on ONE hue.
+   - Accent hue ......... --hue-accent  (64 copper). Move this single value to
+     re-brand the accent; everything below references it.
+   - Live/connected hue . --hue-live    (165 jade). Keep it ~100deg from accent
+     so "live" always pops against the accent.
    ═══════════════════════════════════════════════════════════════ */
 
 :root {
-  /* ─── Backgrounds (layered depth system) ─── */
-  --bg-primary: #0d1117;
-  --bg-secondary: #161b22;
-  --bg-tertiary: #21262d;
-  --bg-hover: #30363d;
-  --bg-active: rgba(56, 139, 253, 0.1);
-  --bg-surface: #1c2128;
+  /* ─── Hue anchors (the only values you change to retheme) ─── */
+  --hue-neutral: 62;
+  --hue-accent: 64;
+  --hue-live: 165;
+  --hue-warn: 80;
+  --hue-error: 32;
 
-  /* ─── Borders ─── */
-  --border: rgba(240, 246, 252, 0.1);
-  --border-subtle: rgba(240, 246, 252, 0.06);
-  --border-emphasis: rgba(240, 246, 252, 0.16);
+  /* ─── Backgrounds (warm graphite, layered; lighter = closer) ─── */
+  --bg-abyss:    oklch(0.155 0.008 var(--hue-neutral)); /* #0f0b09 terminal canvas, deepest */
+  --bg-base:     oklch(0.185 0.008 var(--hue-neutral)); /* #15120f app + content pane */
+  --bg-panel:    oklch(0.215 0.009 var(--hue-neutral)); /* #1d1915 sidebar, status bar, tab bars */
+  --bg-raised:   oklch(0.255 0.010 var(--hue-neutral)); /* #26221e inputs, row hover */
+  --bg-raised-2: oklch(0.300 0.011 var(--hue-neutral)); /* #322d28 pressed / active / selected */
+  --bg-dialog:   oklch(0.235 0.010 var(--hue-neutral)); /* #221d19 modal surface */
+  --bg-overlay:  oklch(0.155 0.008 var(--hue-neutral) / 0.60); /* warm dim scrim, NO blur */
 
-  /* ─── Text ─── */
-  --text-primary: #e6edf3;
-  --text-secondary: #8b949e;
-  --text-tertiary: #6e7681;
+  /* ── Back-compat aliases (so existing var(--bg-*) usages keep working) ── */
+  --bg-primary:   var(--bg-base);
+  --bg-secondary: var(--bg-panel);
+  --bg-tertiary:  var(--bg-raised);
+  --bg-hover:     var(--bg-raised);
+  --bg-active:    var(--accent-wash);
+  --bg-surface:   var(--bg-dialog);
 
-  /* ─── Accent ─── */
-  --accent: #58a6ff;
-  --accent-emphasis: #1f6feb;
-  --accent-subtle: rgba(56, 139, 253, 0.15);
+  /* ─── Borders / hairlines (warm, never gray, opaque so they read on any layer) ─── */
+  --hairline:        oklch(0.330 0.012 var(--hue-neutral)); /* #3a342f default 1px divider */
+  --hairline-strong: oklch(0.420 0.014 var(--hue-neutral)); /* #534c45 focused field, active edge */
+  /* back-compat */
+  --border:          var(--hairline);
+  --border-subtle:   oklch(0.300 0.011 var(--hue-neutral)); /* slightly under hairline */
+  --border-emphasis: var(--hairline-strong);
 
-  /* ─── Semantic ─── */
-  --success: #3fb950;
-  --success-subtle: rgba(63, 185, 80, 0.15);
-  --warning: #d29922;
-  --warning-subtle: rgba(210, 153, 34, 0.15);
-  --danger: #f85149;
-  --danger-subtle: rgba(248, 81, 73, 0.15);
-  --error: #f85149;
+  /* ─── Text (warm off-white -> warm graphite, NEVER #fff) ─── */
+  --text-primary:   oklch(0.940 0.006 70); /* #eeeae7  14.6:1 on panel */
+  --text-secondary: oklch(0.760 0.010 66); /* #b6b0ab   8.1:1 -- host:port, labels */
+  --text-muted:     oklch(0.600 0.012 64); /* #867f79   4.4:1 -- counts, timestamps */
+  --text-faint:     oklch(0.480 0.012 62); /* #635c57  decorative glyphs only */
+  /* back-compat: the audit's missing --text-quaternary finally has a value */
+  --text-tertiary:    var(--text-muted);
+  --text-quaternary:  var(--text-faint);
+
+  /* ─── Accent -- copper-amber (THE one color, <=10% of surface) ─── */
+  --accent:        oklch(0.760 0.130 var(--hue-accent)); /* #ea9e51  icons, active tab, primary btn */
+  --accent-strong: oklch(0.700 0.150 58);                /* #e2832d  hover / press */
+  --accent-on:     oklch(0.220 0.020 60);                /* #221811  text/icon ON accent fill, 7.9:1 */
+  --accent-wash:   oklch(0.300 0.040 var(--hue-accent)); /* #3c2918  selected-row / badge bg */
+  --focus-ring:    oklch(0.800 0.130 66);                /* #f6ac5c  brighter amber, 2px outer ring */
+  /* back-compat */
+  --accent-emphasis: var(--accent-strong);
+  --accent-subtle:   var(--accent-wash);
+  --color-on-accent: var(--accent-on);  /* kills the hardcoded #ffffff on btn-primary etc. */
+
+  /* ─── Connected / online (jade -- amber's complement, so LIVE pops) ─── */
+  --connected:      oklch(0.760 0.110 var(--hue-live)); /* #66c7a0  status dot, live edge, 8.5:1 */
+  --connected-wash: oklch(0.300 0.040 var(--hue-live)); /* #193429  live-row tint */
+  /* back-compat: demote green from brand to this single semantic role */
+  --success:        var(--connected);
+  --success-subtle: var(--connected-wash);
+
+  /* ─── Connecting / authenticating (reuses accent; it pulses) ─── */
+  --connecting: var(--accent);
+
+  /* ─── Warning (ochre, distinct from accent by lightness + hue) ─── */
+  --warning:      oklch(0.780 0.130 var(--hue-warn)); /* #e3ad4b */
+  --warning-wash: oklch(0.300 0.060 var(--hue-warn)); /* warm ochre wash */
+  --warning-subtle: var(--warning-wash);
+
+  /* ─── Error / danger (warm brick, NOT the cold #f85149) ─── */
+  --error:      oklch(0.640 0.150 var(--hue-error)); /* #d8644f  4.9:1 */
+  --error-wash: oklch(0.300 0.060 var(--hue-error)); /* #47211a  danger banner bg */
+  /* back-compat: merges the --error/--danger duplicate into ONE source */
+  --danger:        var(--error);
+  --danger-subtle: var(--error-wash);
 
   /* ─── Layout ─── */
-  --sidebar-width: 300px;
-  --statusbar-height: 28px;
-  --tabbar-height: 38px;
-  --radius-sm: 4px;
-  --radius-md: 6px;
-  --radius-lg: 8px;
+  --sidebar-width:     300px;  /* keep; raise to 320 if long hostnames truncate */
+  --statusbar-height:  28px;
+  --tabbar-height:     34px;   /* reclaimed from 38 when bars merge */
 
-  /* ─── Typography ─── */
-  --font-mono: "JetBrains Mono", "Fira Code", "Cascadia Code", "SF Mono", monospace;
-  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif;
+  /* ─── Radii (unifies the rogue raw 12px/16px the audit flagged) ─── */
+  --radius-sm: 5px;  /* badges, status-dot halo, micro-buttons */
+  --radius-md: 7px;  /* inputs, profile rows, buttons */
+  --radius-lg: 10px; /* dialogs, panels -- map the old 12px/16px here */
 
-  /* ─── Transitions ─── */
-  --transition-fast: 120ms ease;
-  --transition-normal: 180ms ease;
-  --transition-slow: 250ms ease;
+  /* ─── Typography families ─── */
+  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif;
+  --font-mono: "JetBrains Mono", "Fira Code", "Cascadia Code", "SF Mono", "Menlo", monospace;
 
-  /* ─── Shadows ─── */
-  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
-  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
-  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.5);
-  --shadow-xl: 0 12px 40px rgba(0, 0, 0, 0.6);
+  /* ─── Type scale -- 1.25 major third, base 13px (the audit found ZERO size tokens) ─── */
+  --fs-caption: 0.5625rem; /*  9px -- status-bar legend (uppercase, tracked)        */
+  --fs-meta:    0.6875rem; /* 11px -- counts, timestamps, section eyebrows, btn text */
+  --fs-body:    0.8125rem; /* 13px -- row names, input text, body                    */
+  --fs-subhead: 1rem;      /* 16px -- dialog field-group titles, terminal infobar    */
+  --fs-title:   1.25rem;   /* 20px -- dialog title, empty-state headline             */
+  --fs-display: 1.5625rem; /* 25px -- empty-state hero line only                     */
+
+  --lh-tight:  1.2;
+  --lh-snug:   1.35;
+  --lh-body:   1.5;        /* body copy; pair with max-width: 38rem for 65-75ch     */
+
+  --fw-regular:  400;
+  --fw-medium:   500;
+  --fw-semibold: 600;      /* titles, primary button, empty-state headline          */
+
+  --tracking-eyebrow: 0.08em; /* PROFILES / CONNECTION uppercase labels             */
+
+  /* ─── Motion -- ease-out exponential family, zero bounce/elastic ─── */
+  --ease-out:      cubic-bezier(0.16, 1, 0.30, 1);  /* quint-ish, default            */
+  --ease-out-soft: cubic-bezier(0.22, 1, 0.36, 1);  /* gentler settle                */
+  --transition-fast:   120ms var(--ease-out); /* hover / press feedback              */
+  --transition-normal: 180ms var(--ease-out); /* selection move, reveal              */
+  --transition-slow:   240ms var(--ease-out); /* dialog enter                        */
+
+  /* ─── Shadows (warm-tinted, lamp source; NEVER pure black, NO four-step ramp) ─── */
+  --shadow-sm:  0 1px  2px oklch(0.120 0.010 50 / 0.35);
+  --shadow-md:  0 4px 12px oklch(0.120 0.010 50 / 0.45);
+  --shadow-lg:  0 8px 24px oklch(0.120 0.010 50 / 0.50);
+  --shadow-pop: 0 16px 40px oklch(0.120 0.010 50 / 0.55); /* dialogs / pop-overs only */
+  --shadow-xl:  var(--shadow-pop);
+
+  /* ─── The single luminous trick (replaces glassmorphism entirely) ─── */
+  /* a 4%-white top hairline simulating the lamp catching a raised plane's edge */
+  --lit-edge: inset 0 1px 0 oklch(1 0 0 / 0.04);
+}
+
+/* Honor reduced motion: kill transforms + the connecting pulse, keep opacity */
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --transition-fast: 0ms;
+    --transition-normal: 0ms;
+    --transition-slow: 90ms ease;
+  }
 }
 
 /* ─── Reset ──────────────────────────────────────── */
@@ -525,7 +613,7 @@ body {
 .sidebar-search-input:focus {
   border-color: var(--accent);
   background-color: rgba(240, 246, 252, 0.06);
-  box-shadow: 0 0 0 3px rgba(56, 139, 253, 0.1);
+  box-shadow: 0 0 0 3px oklch(0.760 0.130 var(--hue-accent) / 0.15);
 }
 
 .sidebar-search-input::placeholder {
@@ -628,14 +716,15 @@ body {
 /* ─── Section Collapse Animation ─────────────────── */
 
 .sidebar-section-content {
+  display: grid;
+  grid-template-rows: 1fr;
   overflow: hidden;
-  transition: max-height var(--transition-slow), opacity var(--transition-normal);
-  max-height: 2000px;
+  transition: grid-template-rows var(--transition-slow), opacity var(--transition-normal);
   opacity: 1;
 }
 
 .sidebar-section-content-collapsed {
-  max-height: 0;
+  grid-template-rows: 0fr;
   opacity: 0;
 }
 
@@ -939,40 +1028,97 @@ body {
   grid-row: 2;
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 8px;
   padding: 0 16px;
-  background-color: var(--bg-secondary);
-  border-top: 1px solid var(--border);
-  font-size: 11px;
-  color: var(--text-tertiary);
+  background-color: var(--bg-panel);
+  border-top: 1px solid var(--hairline);
+  font-size: var(--fs-meta);
+  color: var(--text-muted);
+  font-family: var(--font-sans);
+}
+
+/* ── Left / right clusters ── */
+.statusbar-cluster {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.statusbar-cluster-left {
+  /* left cluster natural width */
+}
+
+.statusbar-cluster-right {
+  margin-left: auto;
+  gap: 8px;
 }
 
 .statusbar-item {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
+  color: var(--text-muted);
+  font-size: var(--fs-meta);
+  white-space: nowrap;
 }
 
-.statusbar-spacer {
-  flex: 1;
+/* ── Jade live dot ── */
+.statusbar-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
 }
 
+.statusbar-dot-live {
+  background-color: var(--connected);
+}
+
+/* ── Terminal glyph (decorative) ── */
+.statusbar-glyph {
+  color: var(--text-faint);
+  font-size: var(--fs-meta);
+  line-height: 1;
+}
+
+/* ── 1px hairline divider between clusters ── */
+.statusbar-divider {
+  width: 1px;
+  height: 14px;
+  background-color: var(--hairline);
+  flex-shrink: 0;
+  margin: 0;
+}
+
+/* ── Active target: host@user in mono ── */
+.statusbar-target {
+  font-family: var(--font-mono);
+  font-size: var(--fs-meta);
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 200px;
+}
+
+/* ── Language toggle ── */
 .statusbar-lang-toggle {
   background: none;
-  border: 1px solid var(--border);
-  border-radius: 3px;
-  color: var(--text-secondary);
-  font-size: 10px;
-  font-weight: 600;
-  padding: 1px 6px;
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  font-size: var(--fs-meta);
+  font-weight: var(--fw-medium);
+  padding: 1px 5px;
   cursor: pointer;
-  letter-spacing: 0.5px;
-  transition: background-color 0.15s, color 0.15s;
+  letter-spacing: 0.04em;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
 }
 
 .statusbar-lang-toggle:hover {
-  background-color: var(--bg-hover);
-  color: var(--text-primary);
+  color: var(--accent);
+  border-color: var(--accent);
 }
 
 /* ═══════════════════════════════════════════════════
@@ -1004,6 +1150,11 @@ body {
 .tabbar-tab:hover {
   color: var(--text-secondary);
   background-color: rgba(240, 246, 252, 0.03);
+}
+
+.tabbar-tab:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
 }
 
 .tabbar-tab-active {
@@ -1081,6 +1232,11 @@ body {
 .terminal-tab:hover {
   background-color: rgba(240, 246, 252, 0.04);
   color: var(--text-secondary);
+}
+
+.terminal-tab:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
 }
 
 .terminal-tab-active {
@@ -1218,13 +1374,14 @@ body {
   flex: 1;
   overflow: hidden;
   position: relative;
-  background-color: #0d1117;
+  background-color: var(--bg-abyss);
 }
 
 /* ═══════════════════════════════════════════════════
    Welcome Screen
    ═══════════════════════════════════════════════════ */
 
+/* Legacy .welcome kept as no-op for any remaining references */
 .welcome {
   display: flex;
   flex-direction: column;
@@ -1239,6 +1396,728 @@ body {
   font-size: 20px;
   font-weight: 600;
   color: var(--text-secondary);
+}
+
+/* ═══════════════════════════════════════════════════
+   LAMPLIGHT — Profile Row (lp-profile-row)
+   Replaces .sidebar-profile-card with richer states.
+   ═══════════════════════════════════════════════════ */
+
+/* Row geometry: 44px tall, 10px/12px padding */
+.lp-profile-row {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  padding: 0 8px 0 0;
+  height: 44px;
+  cursor: pointer;
+  user-select: none;
+  border-radius: var(--radius-md);
+  position: relative;
+  transition:
+    background-color var(--transition-fast),
+    box-shadow var(--transition-normal);
+}
+
+.lp-profile-row:hover {
+  background-color: var(--bg-raised);
+  box-shadow: var(--lit-edge);
+}
+
+/* Live row: connected-wash fill + 2px jade inset left light-catch */
+.lp-profile-row-live {
+  background-color: var(--connected-wash);
+  box-shadow: inset 2px 0 0 var(--connected), var(--lit-edge);
+}
+
+.lp-profile-row-live:hover {
+  background-color: var(--connected-wash);
+  box-shadow: inset 2px 0 0 var(--connected), var(--lit-edge);
+}
+
+/* Connecting row: subtle accent-wash tint */
+.lp-profile-row-connecting {
+  background-color: var(--accent-wash);
+}
+
+.lp-profile-row-connecting:hover {
+  background-color: var(--accent-wash);
+}
+
+/* Keyboard-focus cue: a subtle background only. The prominent copper marker is
+   reserved for the ACTIVE connection (.lp-profile-row-active) so the highlight
+   tracks "where I am", not a stale keyboard-focus index. */
+.lp-profile-row-focused {
+  background-color: var(--bg-raised);
+}
+
+/* The active connection (its session is the one shown in the terminal): the
+   persistent "you are here" marker, a copper outline ON the actual row. Uses
+   outline (not box-shadow) so it never clobbers the live-row jade inset bar. */
+.lp-profile-row-active {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+/* ─── Status Dots ─────────────────────────────────── */
+
+/* Idle: hollow ring in --text-faint (monochrome, NO color) */
+.lp-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  transition:
+    background-color 140ms var(--ease-out),
+    box-shadow 140ms var(--ease-out),
+    opacity var(--transition-fast);
+}
+
+.lp-status-dot-idle {
+  background-color: transparent;
+  border: 1.5px solid var(--text-faint);
+}
+
+/* Connecting: copper dot pulsing opacity 0.55->1, 1.6s --ease-out-soft */
+.lp-status-dot-connecting {
+  background-color: var(--connecting);
+  animation: lp-dot-pulse 1.6s var(--ease-out-soft) infinite;
+}
+
+@keyframes lp-dot-pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.55; }
+}
+
+/* Honor reduced-motion: kill pulse */
+@media (prefers-reduced-motion: reduce) {
+  .lp-status-dot-connecting {
+    animation: none;
+    opacity: 0.8;
+  }
+}
+
+/* Live: jade dot — the only green in the sidebar */
+.lp-status-dot-live {
+  background-color: var(--connected);
+}
+
+/* ─── Profile text ────────────────────────────────── */
+
+.lp-profile-text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+  flex: 1;
+}
+
+.lp-profile-name {
+  font-family: var(--font-sans);
+  font-size: var(--fs-body);    /* 13px */
+  font-weight: var(--fw-medium); /* 500 */
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  letter-spacing: -0.01em;
+}
+
+.lp-profile-meta {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+
+/* host:port in mono — middle-ellipsis done in JS, CSS just clips */
+.lp-profile-host {
+  font-family: var(--font-mono);
+  font-size: var(--fs-meta);     /* 11px */
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+}
+
+/* "N credentials" badge */
+.lp-credential-badge {
+  font-family: var(--font-sans);
+  font-size: var(--fs-meta);
+  color: var(--text-muted);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* ─── Actions area ────────────────────────────────── */
+
+.lp-profile-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+  /* Hidden by default; connect btn always visible, overflow hidden until hover */
+}
+
+/* Connect button — always visible */
+.lp-action-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px 5px;
+  border-radius: var(--radius-sm);
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    color var(--transition-fast),
+    background-color var(--transition-fast),
+    opacity var(--transition-fast);
+  color: var(--text-muted);
+}
+
+.lp-action-btn:hover {
+  color: var(--text-primary);
+  background-color: var(--bg-raised-2);
+}
+
+.lp-action-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+/* Connect: accent-colored play button, distinct from overflow */
+.lp-action-btn-connect {
+  color: var(--text-secondary);
+}
+
+.lp-action-btn-connect:hover {
+  color: var(--accent);
+  background-color: var(--accent-wash);
+}
+
+/* "Add session" variant (already connected) */
+.lp-action-btn-add {
+  color: var(--text-muted);
+}
+
+.lp-action-btn-add:hover {
+  color: var(--accent);
+  background-color: var(--accent-wash);
+}
+
+/* Overflow ··· — hidden until row hover, revealed via opacity + translateX */
+.lp-action-btn-overflow {
+  opacity: 0;
+  transform: translateX(4px);
+  transition:
+    opacity var(--transition-fast),
+    transform var(--transition-fast),
+    color var(--transition-fast),
+    background-color var(--transition-fast);
+  color: var(--text-faint);
+  font-size: var(--fs-meta);
+  letter-spacing: 0.06em;
+}
+
+.lp-profile-row:hover .lp-action-btn-overflow,
+.lp-profile-row-focused .lp-action-btn-overflow {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+/* Override: keep overflow visible when its menu is open */
+.lp-overflow-wrapper:focus-within .lp-action-btn-overflow {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.lp-overflow-dots {
+  font-family: var(--font-sans);
+  font-weight: var(--fw-medium);
+  line-height: 1;
+}
+
+/* Overflow dropdown menu */
+.lp-overflow-wrapper {
+  position: relative;
+}
+
+.lp-overflow-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 60;
+  min-width: 130px;
+  padding: 4px;
+  background-color: var(--bg-dialog);
+  border: 1px solid var(--hairline-strong);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-pop);
+}
+
+.lp-overflow-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 10px;
+  border: none;
+  background: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: var(--fs-meta);
+  font-family: var(--font-sans);
+  cursor: pointer;
+  text-align: left;
+  transition: background-color var(--transition-fast), color var(--transition-fast);
+}
+
+.lp-overflow-item:hover {
+  background-color: var(--bg-raised);
+}
+
+.lp-overflow-item-danger {
+  color: var(--danger);
+}
+
+.lp-overflow-item-danger:hover {
+  background-color: var(--error-wash);
+  color: var(--danger);
+}
+
+/* ─── Elapsed time for live sessions ─────────────── */
+.lp-elapsed {
+  font-family: var(--font-mono);
+  font-size: var(--fs-meta);
+  color: var(--text-muted);
+  padding-right: 2px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* ─── Connecting spinner (replaces old sidebar-btn-spinner) */
+.lp-spinner {
+  display: inline-block;
+  width: 11px;
+  height: 11px;
+  border: 1.5px solid transparent;
+  border-top-color: var(--connecting);
+  border-radius: 50%;
+  animation: lp-spin 0.7s linear infinite;
+}
+
+@keyframes lp-spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lp-spinner {
+    animation: none;
+    opacity: 0.6;
+  }
+}
+
+/* ─── Drag handle ────────────────────────────────── */
+.lp-drag-handle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  flex-shrink: 0;
+  cursor: grab;
+  opacity: 0;
+  transition: opacity var(--transition-normal);
+  padding: 4px 0;
+  touch-action: none;
+}
+
+.lp-drag-handle:active {
+  cursor: grabbing;
+}
+
+.lp-profile-row:hover .lp-drag-handle {
+  opacity: 0.35;
+}
+
+.lp-drag-handle:hover {
+  opacity: 0.8 !important;
+}
+
+.lp-drag-dots {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 6px;
+}
+
+.lp-drag-dots::before,
+.lp-drag-dots::after {
+  content: "";
+  display: block;
+  width: 6px;
+  height: 2px;
+  background: var(--text-faint);
+  border-radius: 1px;
+}
+
+.lp-drag-dots::before {
+  box-shadow: 0 4px 0 var(--text-faint);
+}
+
+/* ─── Connect wrapper ────────────────────────────── */
+.lp-connect-wrapper {
+  position: relative;
+}
+
+/* ═══════════════════════════════════════════════════
+   LAMPLIGHT — Profile List & Groups
+   ═══════════════════════════════════════════════════ */
+
+/* The outermost list container — focusable for keyboard nav */
+.lp-profile-list {
+  position: relative;
+  padding: 0 6px 8px;
+  outline: none; /* custom focus handled by bar */
+}
+
+.lp-profile-list:focus-visible {
+  box-shadow: inset 0 0 0 2px var(--focus-ring);
+  border-radius: var(--radius-md);
+}
+
+/* Group container — adds gap BETWEEN groups (16px), 8px to first row */
+.lp-group {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.lp-group-gap {
+  margin-top: 16px;
+}
+
+/* Group header eyebrow */
+.lp-group-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 10px;
+  margin-bottom: 8px;
+  height: 22px;
+  user-select: none;
+}
+
+.lp-group-label {
+  font-family: var(--font-sans);
+  font-size: var(--fs-meta);       /* 11px */
+  font-weight: var(--fw-medium);   /* 500 */
+  letter-spacing: var(--tracking-eyebrow); /* 0.08em */
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.lp-group-count {
+  font-family: var(--font-sans);
+  font-size: var(--fs-meta);
+  font-weight: var(--fw-regular);
+  color: var(--text-faint);
+}
+
+/* ═══════════════════════════════════════════════════
+   LAMPLIGHT — Welcome / Empty State (Launchpad)
+   ═══════════════════════════════════════════════════ */
+
+.lp-welcome {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  background-color: var(--bg-base);
+}
+
+/* Centered ~380px column */
+.lp-welcome-column {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0;
+  width: 380px;
+  max-width: 90vw;
+  text-align: center;
+}
+
+/* Server glyph — text-faint strokes, one copper highlight */
+.lp-welcome-glyph {
+  color: var(--text-faint);
+  margin-bottom: 24px;
+  flex-shrink: 0;
+}
+
+/* Copper highlight circle inside the glyph */
+.lp-glyph-accent {
+  fill: var(--accent);
+}
+
+/* Display headline — --fs-display / --fw-semibold */
+.lp-welcome-headline {
+  font-family: var(--font-sans);
+  font-size: var(--fs-display);    /* 25px */
+  font-weight: var(--fw-semibold); /* 600 */
+  color: var(--text-primary);
+  line-height: var(--lh-tight);
+  margin-bottom: 10px;
+}
+
+/* Subline — --fs-body / --text-secondary */
+.lp-welcome-subline {
+  font-family: var(--font-sans);
+  font-size: var(--fs-body);
+  color: var(--text-secondary);
+  line-height: var(--lh-body);
+  margin-bottom: 24px;
+}
+
+/* Primary CTA — copper fill, --accent-on text */
+.lp-welcome-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 9px 20px;
+  background-color: var(--accent);
+  color: var(--accent-on);
+  border: none;
+  border-radius: var(--radius-md);
+  font-family: var(--font-sans);
+  font-size: var(--fs-body);
+  font-weight: var(--fw-medium);
+  cursor: pointer;
+  transition:
+    background-color var(--transition-fast),
+    transform var(--transition-fast),
+    box-shadow var(--transition-fast);
+  box-shadow: var(--shadow-sm);
+  white-space: nowrap;
+  margin-bottom: 12px;
+}
+
+.lp-welcome-cta:hover {
+  background-color: var(--accent-strong);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
+}
+
+.lp-welcome-cta:active {
+  transform: translateY(0);
+  box-shadow: var(--shadow-sm);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lp-welcome-cta {
+    transition: background-color var(--transition-fast);
+  }
+  .lp-welcome-cta:hover {
+    transform: none;
+  }
+}
+
+/* Keyboard hint — mono, --text-muted */
+.lp-welcome-hint {
+  font-family: var(--font-mono);
+  font-size: var(--fs-meta);
+  color: var(--text-muted);
+  margin-bottom: 32px;
+}
+
+/* Error inline */
+.lp-welcome-error {
+  font-family: var(--font-sans);
+  font-size: var(--fs-meta);
+  color: var(--danger);
+  background-color: var(--error-wash);
+  border-radius: var(--radius-sm);
+  padding: 6px 12px;
+  margin-bottom: 16px;
+}
+
+/* Connecting inline progress row */
+.lp-welcome-connecting {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 16px;
+  border-radius: var(--radius-md);
+  background-color: var(--accent-wash);
+  box-shadow: var(--lit-edge);
+}
+
+.lp-connecting-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: var(--connecting);
+  flex-shrink: 0;
+  animation: lp-dot-pulse 1.6s var(--ease-out-soft) infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lp-connecting-dot {
+    animation: none;
+    opacity: 0.8;
+  }
+}
+
+.lp-connecting-label {
+  font-family: var(--font-sans);
+  font-size: var(--fs-body);
+  color: var(--text-primary);
+  flex: 1;
+}
+
+.lp-connecting-cancel {
+  background: none;
+  border: none;
+  font-family: var(--font-sans);
+  font-size: var(--fs-meta);
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  transition: color var(--transition-fast), background-color var(--transition-fast);
+  flex-shrink: 0;
+}
+
+.lp-connecting-cancel:hover {
+  color: var(--text-primary);
+  background-color: var(--bg-raised);
+}
+
+/* ─── Recent list ────────────────────────────────── */
+.lp-recent {
+  width: 100%;
+  text-align: left;
+}
+
+.lp-recent-header {
+  font-family: var(--font-sans);
+  font-size: var(--fs-meta);
+  font-weight: var(--fw-medium);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+  padding: 0 2px;
+}
+
+.lp-recent-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.lp-recent-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 7px 10px;
+  background: none;
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  text-align: left;
+  transition: background-color var(--transition-fast);
+  border-bottom: 1px solid var(--hairline);
+}
+
+.lp-recent-row:last-child {
+  border-bottom: none;
+}
+
+.lp-recent-row:hover {
+  background-color: var(--bg-raised);
+}
+
+.lp-recent-name {
+  font-family: var(--font-sans);
+  font-size: var(--fs-meta);
+  font-weight: var(--fw-medium);
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 80px;
+}
+
+.lp-recent-host {
+  font-family: var(--font-mono);
+  font-size: var(--fs-meta);
+  color: var(--text-secondary);
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.lp-recent-age {
+  font-family: var(--font-mono);
+  font-size: var(--fs-meta);
+  color: var(--text-faint);
+  flex-shrink: 0;
+}
+
+/* ─── LAMPLIGHT sidebar-specific overrides ─────────
+   Keep the existing .sidebar-* rules intact;
+   these override only the values that changed.     */
+
+/* Warm scrollbar instead of cool gray */
+.sidebar:hover::-webkit-scrollbar-thumb {
+  background-color: rgba(99, 92, 87, 0.25); /* --text-faint warm equivalent */
+}
+
+/* Search input focus ring: warm amber, not blue */
+.sidebar-search-input:focus {
+  border-color: var(--accent);
+  background-color: var(--bg-raised);
+  box-shadow: 0 0 0 3px oklch(0.760 0.130 var(--hue-accent) / 0.15);
+}
+
+/* Primary action button: warm copper, not blue */
+.sidebar-action-btn-primary {
+  background-color: var(--accent-wash) !important;
+  color: var(--accent) !important;
+  border-color: oklch(0.760 0.130 var(--hue-accent) / 0.35) !important;
+}
+
+.sidebar-action-btn-primary:hover {
+  background-color: oklch(0.350 0.060 var(--hue-accent)) !important;
+  border-color: var(--accent) !important;
+}
+
+
+/* Status indicators: update glow colors to warm tokens */
+.indicator-success {
+  background-color: var(--connected);
+  /* warm jade glow, not neon green */
+  box-shadow: 0 0 6px oklch(0.760 0.110 var(--hue-live) / 0.45);
+}
+
+.indicator-warning {
+  background-color: var(--connecting);
+  box-shadow: 0 0 6px oklch(0.760 0.130 var(--hue-accent) / 0.35);
+}
+
+.indicator-error {
+  background-color: var(--danger);
+  box-shadow: 0 0 6px oklch(0.640 0.150 var(--hue-error) / 0.35);
+}
+
+.indicator-muted {
+  background-color: var(--text-faint);
+  opacity: 0.6;
 }
 
 .placeholder {
@@ -1291,12 +2170,12 @@ body {
 
 .btn-primary {
   background-color: var(--accent-emphasis);
-  color: #ffffff;
+  color: var(--accent-on);
   border-color: rgba(240, 246, 252, 0.1);
 }
 
 .btn-primary:hover:not(:disabled) {
-  background-color: #388bfd;
+  background-color: var(--accent-strong);
 }
 
 .btn-secondary {
@@ -1313,12 +2192,12 @@ body {
 
 .btn-danger {
   background-color: var(--danger);
-  color: #ffffff;
-  border-color: rgba(248, 81, 73, 0.4);
+  color: var(--accent-on);
+  border-color: color-mix(in srgb, var(--danger) 40%, transparent);
 }
 
 .btn-danger:hover:not(:disabled) {
-  background-color: #da3633;
+  background-color: var(--error);
 }
 
 .btn-ghost {
@@ -1563,7 +2442,7 @@ dialog::backdrop {
 }
 
 .hk-modal-danger {
-  border-color: rgba(248, 81, 73, 0.3);
+  border-color: color-mix(in srgb, var(--danger) 30%, transparent);
 }
 
 .hk-modal-warning {
@@ -1640,7 +2519,7 @@ dialog::backdrop {
   margin: 16px 24px 0;
   padding: 12px 14px;
   background-color: var(--danger-subtle);
-  border: 1px solid rgba(248, 81, 73, 0.25);
+  border: 1px solid color-mix(in srgb, var(--danger) 25%, transparent);
   border-radius: var(--radius-md);
 }
 
@@ -1857,13 +2736,13 @@ dialog::backdrop {
 .hk-btn-primary {
   padding: 8px 20px;
   background-color: var(--accent-emphasis);
-  color: #ffffff;
+  color: var(--accent-on);
   border: 1px solid rgba(240, 246, 252, 0.1);
 }
 
 .hk-btn-primary:hover {
-  background-color: #388bfd;
-  box-shadow: 0 2px 8px rgba(56, 139, 253, 0.3);
+  background-color: var(--accent-strong);
+  box-shadow: 0 2px 8px oklch(0.760 0.130 64 / 0.30);
 }
 
 .hk-btn-ghost {
@@ -1896,12 +2775,12 @@ dialog::backdrop {
   padding: 8px 16px;
   background: none;
   color: var(--danger);
-  border: 1px solid rgba(248, 81, 73, 0.3);
+  border: 1px solid color-mix(in srgb, var(--danger) 30%, transparent);
 }
 
 .hk-btn-danger-outline:hover {
   background-color: var(--danger-subtle);
-  border-color: rgba(248, 81, 73, 0.5);
+  border-color: color-mix(in srgb, var(--danger) 50%, transparent);
 }
 
 /* ─── Auth Prompt (legacy — kept for compat) ──────── */
@@ -2089,7 +2968,7 @@ dialog::backdrop {
 
 .cd-toggle-on .cd-toggle-thumb {
   transform: translateX(16px);
-  background-color: #ffffff;
+  background-color: var(--accent-on);
 }
 
 .cd-toggle-label {
@@ -2107,7 +2986,7 @@ dialog::backdrop {
   font-size: 12px;
   color: var(--danger);
   background-color: var(--danger-subtle);
-  border: 1px solid rgba(248, 81, 73, 0.2);
+  border: 1px solid color-mix(in srgb, var(--danger) 20%, transparent);
   border-radius: var(--radius-md);
   margin-bottom: 4px;
   line-height: 1.5;
@@ -2137,7 +3016,7 @@ dialog::backdrop {
   color: var(--danger);
   font-size: 12px;
   padding: 6px 8px;
-  background: rgba(255, 59, 48, 0.08);
+  background: var(--error-wash);
   border-radius: 4px;
   margin-top: 8px;
 }
@@ -2978,7 +3857,7 @@ dialog::backdrop {
 }
 
 .sftp-row-selected .sftp-file-name {
-  color: #ffffff;
+  color: var(--text-primary);
 }
 
 .sftp-row-selected .sftp-col-size,
@@ -3372,7 +4251,7 @@ dialog::backdrop {
   align-items: center;
   justify-content: center;
   background-color: var(--accent-emphasis);
-  color: #ffffff;
+  color: var(--accent-on);
   font-size: 10px;
   font-weight: 700;
   min-width: 18px;
@@ -4527,10 +5406,10 @@ dialog::backdrop {
   font-weight: 500;
   user-select: none;
   padding: 24px 32px;
-  background-color: rgba(13, 17, 23, 0.7);
+  background-color: var(--bg-overlay);
   border-radius: var(--radius-lg);
-  border: 1px solid rgba(88, 166, 255, 0.2);
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  border: 1px solid oklch(0.760 0.130 64 / 0.20);
+  box-shadow: var(--shadow-md);
 }
 
 .sftp-drop-overlay-content svg {
@@ -4752,21 +5631,21 @@ dialog::backdrop {
 .statusbar-update-badge {
   display: flex;
   align-items: center;
-  gap: 5px;
+  gap: 4px;
   background: none;
-  border: 1px solid var(--accent-subtle);
-  border-radius: 3px;
+  border: 1px solid var(--accent-wash);
+  border-radius: var(--radius-sm);
   color: var(--accent);
-  font-size: 10px;
-  font-weight: 600;
+  font-size: var(--fs-meta);
+  font-weight: var(--fw-medium);
   padding: 1px 6px;
   cursor: pointer;
-  letter-spacing: 0.3px;
-  transition: background-color 0.15s, border-color 0.15s;
+  letter-spacing: 0.02em;
+  transition: background-color var(--transition-fast), border-color var(--transition-fast);
 }
 
 .statusbar-update-badge:hover {
-  background-color: var(--accent-subtle);
+  background-color: var(--accent-wash);
   border-color: var(--accent);
 }
 
@@ -4786,14 +5665,14 @@ dialog::backdrop {
 /* ─── StatusBar Help Button ────────────────────────── */
 
 .statusbar-help-btn {
-  width: 20px;
-  height: 20px;
+  width: 18px;
+  height: 18px;
   border-radius: 50%;
-  border: 1px solid var(--border);
+  border: 1px solid var(--hairline);
   background: none;
-  color: var(--text-tertiary);
-  font-size: 12px;
-  font-weight: 600;
+  color: var(--text-muted);
+  font-size: var(--fs-meta);
+  font-weight: var(--fw-semibold);
   font-family: var(--font-sans);
   cursor: pointer;
   display: flex;
@@ -4801,13 +5680,13 @@ dialog::backdrop {
   justify-content: center;
   padding: 0;
   line-height: 1;
-  transition: color var(--transition-fast), border-color var(--transition-fast), background-color var(--transition-fast);
+  transition: color var(--transition-fast), border-color var(--transition-fast);
+  flex-shrink: 0;
 }
 
 .statusbar-help-btn:hover {
-  color: var(--text-primary);
-  border-color: var(--border-emphasis);
-  background: var(--bg-hover);
+  color: var(--accent);
+  border-color: var(--accent);
 }
 
 /* ─── Onboarding Tour ──────────────────────────────── */
@@ -4896,7 +5775,7 @@ dialog::backdrop {
 .tour-tooltip-btn-primary {
   background: var(--accent-emphasis);
   border-color: var(--accent-emphasis);
-  color: #fff;
+  color: var(--accent-on);
 }
 
 .tour-tooltip-btn-primary:hover {

--- a/src/styles/terminal.css
+++ b/src/styles/terminal.css
@@ -37,16 +37,18 @@
 }
 
 .xterm:hover .xterm-viewport::-webkit-scrollbar-thumb {
-  background-color: rgba(139, 148, 158, 0.25);
+  /* warm muted derived from --text-faint (#635c57) */
+  background-color: rgba(99, 92, 87, 0.30);
 }
 
 .xterm-viewport::-webkit-scrollbar-thumb:hover {
-  background-color: rgba(139, 148, 158, 0.4);
+  background-color: rgba(99, 92, 87, 0.50);
 }
 
-/* Selection color consistency */
+/* Selection color consistency — copper accent-wash, kept in sync with
+   TERMINAL_THEME.selectionBackground ("#3c2918a6") in src/lib/constants.ts */
 .xterm .xterm-selection div {
-  background-color: rgba(56, 139, 253, 0.2) !important;
+  background-color: rgba(60, 41, 24, 0.65) !important;
 }
 
 /* ═══════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

A combined **CI + hardening** pass on NexTerm (Tauri 2 / russh 0.48 + React 19 + Zustand). Adds a CI pipeline, fixes several HIGH-severity SSH/vault security issues, introduces and **fully wires** new authentication methods, adds vault idle/suspend auto-lock, ships the LAMPLIGHT UI theme with integrated accessibility, and adds a preview-confirm startup-commands feature.

## What changed (by theme)

### CI
- GitHub Actions workflow running `fmt`, `clippy -D warnings`, Rust tests, TS typecheck and vitest on PRs and `main`.
- Repo-wide `rustfmt` + clippy lint cleanup.

### Security hardening
- **Empty-vault password bypass closed**; vault file format hardened.
- **known_hosts revocation honored**, stale hashed entries removed.
- **Plaintext credentials zeroized** across auth hops (derived key in `Zeroizing<[u8;32]>`, `vault.get()` returns `Zeroizing<String>`).
- **Local tunnels default to loopback bind** instead of all interfaces.
- **known_hosts atomic write now uses a unique temp file** so ProxyJump's two handshakes can't race and drop a host-key change.

### Authentication methods (backend + frontend)
- SSH key picker (select from discovered keys instead of typing a path).
- Single-hop **ProxyJump / bastion** support.
- **Keyboard-interactive (MFA)** auth — backend challenge loop **and** the frontend `MfaChallengeDialog` + response bridge.
- **SSH agent** auth via russh-keys `AgentClient`, selectable from the connection dialog.

### Vault auto-lock
- Idle-timeout and OS-suspend auto-lock, with a 15s background tick and activity-based timer reset on credential use.

### LAMPLIGHT theme + accessibility
- Warm OKLCH terminal palette and full UI overhaul.
- a11y: tablist roles + keyboard nav, accessible dialog names, focus-visible rings, `html[lang]` sync.

### Startup commands
- Per-profile `startup_commands`, **previewed and confirmed on connect** (never auto-run) before being injected into the PTY.

## Testing
`cargo fmt --check` + `cargo clippy --all-targets -D warnings` clean · `cargo test` (171) green · `cargo build` green · `tsc --noEmit` clean · `vite build` green · `vitest` (68) green.

## Resolved during pre-PR holistic review
A full-branch integration review (beyond the per-slice reviews) surfaced and **fixed** four integration gaps before this PR:
1. Keyboard-interactive (MFA) had no frontend → a challenge would hang `connect()`. Now wired end-to-end with a dialog and response handler.
2. `AuthMethodConfig` TS union was missing the `agent` variant and the dialog had no agent toggle → fixed; agent + keyboard-interactive are now selectable.
3. Server-initiated disconnects left zombie sessions → `stateChanged: disconnected/error` now disposes terminals and removes the session.
4. known_hosts atomic write shared a fixed temp filename → unique temp file (see Security hardening).

## Known limitations / follow-ups (non-blocking)
- `startup_commands` uses a single preview slot, not a queue: two profiles connecting in rapid succession drop the second preview.
- ProxyJump and vault auto-lock have backend support but **no dedicated UI yet** (bastion editor; idle countdown/warning) — tracked as follow-ups.
- Additional hardening follow-ups identified in review: zeroize decrypted creds in `migrate_v1`/`change_master_password`; sanitize `sftp_open_*` path components; lower-bound `vault_set_idle_timeout`; move `SSH_MSG_DISCONNECT` text to debug logging; pin CI actions to SHAs; fill `CHANGELOG`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
