### PR TITLE
feat(theme): theme system — LAMPLIGHT + DARK presets

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,26 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet" />
+    <!-- FOUC-guard: reads persisted theme before React mounts so the correct
+         [data-theme] is on <html> before the first CSS paint (zero FOUC).
+         Parses the Zustand persist envelope {"state":{"themeId":"..."},"version":0}.
+         Default "lamplight" MUST equal DEFAULT_THEME_ID in src/lib/themes.ts. -->
+    <script>
+      (function () {
+        try {
+          var raw = localStorage.getItem("nexterm-theme");
+          var id = "lamplight"; /* default = DEFAULT_THEME_ID */
+          if (raw) {
+            var parsed = JSON.parse(raw);
+            var v = parsed && parsed.state && parsed.state.themeId;
+            if (v === "lamplight" || v === "dark") id = v;
+          }
+          document.documentElement.dataset.theme = id;
+        } catch (e) {
+          document.documentElement.dataset.theme = "lamplight";
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/index.html
+++ b/index.html
@@ -11,20 +11,24 @@
     <!-- FOUC-guard: reads persisted theme before React mounts so the correct
          [data-theme] is on <html> before the first CSS paint (zero FOUC).
          Parses the Zustand persist envelope {"state":{"themeId":"..."},"version":0}.
-         Default "lamplight" MUST equal DEFAULT_THEME_ID in src/lib/themes.ts. -->
+         LAMPLIGHT is the CSS default — its attribute is REMOVED, not set to "lamplight".
+         Default (absence of attribute) MUST equal DEFAULT_THEME_ID in src/lib/themes.ts. -->
     <script>
       (function () {
         try {
           var raw = localStorage.getItem("nexterm-theme");
-          var id = "lamplight"; /* default = DEFAULT_THEME_ID */
           if (raw) {
             var parsed = JSON.parse(raw);
             var v = parsed && parsed.state && parsed.state.themeId;
-            if (v === "lamplight" || v === "dark") id = v;
+            if (v === "dark") {
+              document.documentElement.dataset.theme = "dark";
+              return;
+            }
           }
-          document.documentElement.dataset.theme = id;
+          // lamplight (default) — remove attribute so the bare :root {} block applies
+          delete document.documentElement.dataset.theme;
         } catch (e) {
-          document.documentElement.dataset.theme = "lamplight";
+          delete document.documentElement.dataset.theme;
         }
       })();
     </script>

--- a/src/components/layout/StatusBar.test.tsx
+++ b/src/components/layout/StatusBar.test.tsx
@@ -1,0 +1,105 @@
+// src/components/layout/StatusBar.test.tsx — TDD: theme toggle in StatusBar
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+// ── localStorage stub (vi.hoisted — must be in place before any persist store loads) ──
+vi.hoisted(() => {
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, String(v)),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => void store.clear(),
+      key: (i: number) => [...store.keys()][i] ?? null,
+      get length() { return store.size; },
+    },
+  });
+});
+
+// ── Mock useTerminal so applyThemeToAllTerminals is a no-op ──
+vi.mock("../../features/terminal/useTerminal", () => ({
+  applyThemeToAllTerminals: vi.fn(),
+}));
+
+// ── Minimal i18n mock — return key as label for simplicity ──
+vi.mock("../../lib/i18n", () => ({
+  useI18n: () => ({
+    t: (k: string, p?: Record<string, string | number>) => {
+      if (p) return `${k}:${JSON.stringify(p)}`;
+      return k;
+    },
+    locale: "en",
+    setLocale: vi.fn(),
+  }),
+  I18nProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// ── Mock session + update stores (StatusBar reads them) ──
+vi.mock("../../stores/sessionStore", () => ({
+  useSessionStore: () => ({
+    sessions: new Map(),
+    activeSessionId: null,
+  }),
+}));
+vi.mock("../../stores/updateStore", () => ({
+  useUpdateStore: () => ({ status: "idle", isCritical: false }),
+}));
+
+import { StatusBar } from "./StatusBar";
+import { useThemeStore } from "../../stores/themeStore";
+
+beforeEach(() => {
+  useThemeStore.setState({ themeId: "lamplight" });
+  document.documentElement.removeAttribute("data-theme");
+});
+
+describe("StatusBar — theme toggle", () => {
+  it("renders the theme toggle button", () => {
+    render(<StatusBar />);
+    // The button should have a title or aria-label reflecting the current theme
+    const btn = screen.getByTitle(/Lamplight|lamplight|Dark|dark|theme/i);
+    expect(btn).toBeDefined();
+  });
+
+  it("theme toggle is present next to the language toggle", () => {
+    render(<StatusBar />);
+    const themeBtn = screen.getByTitle(/Lamplight|lamplight|Dark|dark|theme/i);
+    const langBtn = screen.getByTitle(/settings\.language/i);
+    // Both should exist in the DOM
+    expect(themeBtn).toBeDefined();
+    expect(langBtn).toBeDefined();
+  });
+
+  it("clicking theme toggle switches from lamplight to dark", () => {
+    render(<StatusBar />);
+    const btn = screen.getByTitle(/Lamplight|lamplight|Dark|dark|theme/i);
+    fireEvent.click(btn);
+    expect(useThemeStore.getState().themeId).toBe("dark");
+  });
+
+  it("clicking theme toggle again switches back to lamplight", () => {
+    useThemeStore.setState({ themeId: "dark" });
+    render(<StatusBar />);
+    // Re-render after state change to get updated button
+    const btn = screen.getByTitle(/Lamplight|lamplight|Dark|dark|theme/i);
+    fireEvent.click(btn);
+    expect(useThemeStore.getState().themeId).toBe("lamplight");
+  });
+
+  it("toggle label reflects current theme (Lamplight when active)", () => {
+    render(<StatusBar />);
+    const btn = screen.getByTitle(/Lamplight|lamplight|Dark|dark|theme/i);
+    // The button should display the current theme label
+    expect(btn.textContent).toMatch(/Lamplight|lamplight/i);
+  });
+
+  it("toggle label reflects dark theme when active", () => {
+    useThemeStore.setState({ themeId: "dark" });
+    render(<StatusBar />);
+    const btn = screen.getByTitle(/Lamplight|lamplight|Dark|dark|theme/i);
+    expect(btn.textContent).toMatch(/Dark|dark/i);
+  });
+});

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -1,8 +1,11 @@
-// components/layout/StatusBar.tsx — Bottom status bar with language switcher + update badge
+// components/layout/StatusBar.tsx — Bottom status bar with language switcher + theme toggle + update badge
 
 import { useSessionStore } from "../../stores/sessionStore";
 import { useUpdateStore } from "../../stores/updateStore";
 import { useI18n, type Locale } from "../../lib/i18n";
+import { useThemeStore } from "../../stores/themeStore";
+import { THEMES } from "../../lib/themes";
+import type { ThemeId } from "../../lib/themes";
 
 interface StatusBarProps {
   onStartTour?: () => void;
@@ -12,6 +15,9 @@ export function StatusBar({ onStartTour }: StatusBarProps) {
   const { t, locale, setLocale } = useI18n();
   const { sessions, activeSessionId } = useSessionStore();
   const { status, isCritical } = useUpdateStore();
+  const themeId = useThemeStore((s) => s.themeId);
+  const setTheme = useThemeStore((s) => s.setTheme);
+  const oppositeThemeId: ThemeId = themeId === "lamplight" ? "dark" : "lamplight";
 
   // Show badge when user dismissed a normal update
   const showUpdateBadge = status === "dismissed" && !isCritical;
@@ -97,6 +103,15 @@ export function StatusBar({ onStartTour }: StatusBarProps) {
             ?
           </button>
         )}
+
+        <button
+          className="statusbar-theme-toggle"
+          onClick={() => setTheme(oppositeThemeId)}
+          title={THEMES[themeId].label}
+          aria-label={THEMES[themeId].label}
+        >
+          {THEMES[themeId].label}
+        </button>
 
         <button
           className="statusbar-lang-toggle"

--- a/src/features/terminal/useTerminal.test.ts
+++ b/src/features/terminal/useTerminal.test.ts
@@ -98,3 +98,33 @@ describe("applyThemeToAllTerminals", () => {
     expect(() => applyThemeToAllTerminals(fullTheme)).not.toThrow();
   });
 });
+
+// MINOR-4: applyThemeToAllTerminals live-instance coverage
+// We expose a test-only seeding helper to register fake instances into the Map.
+// Import it only in test context; production code never uses it.
+import { _testSeedTerminalInstance } from "./useTerminal";
+
+describe("applyThemeToAllTerminals — live and disposed instances (MINOR-4)", () => {
+  it("sets options.theme on live instances and skips disposed ones", () => {
+    const liveOptions1: { theme?: ITheme } = {};
+    const liveOptions2: { theme?: ITheme } = {};
+    const disposedOptions: { theme?: ITheme } = {};
+
+    const fakeTerminal1 = { options: liveOptions1 };
+    const fakeTerminal2 = { options: liveOptions2 };
+    const fakeDisposed = { options: disposedOptions };
+
+    // Register fake instances before calling the applier
+    _testSeedTerminalInstance("live-1", { terminal: fakeTerminal1 as never, disposed: false } as never);
+    _testSeedTerminalInstance("live-2", { terminal: fakeTerminal2 as never, disposed: false } as never);
+    _testSeedTerminalInstance("disposed-1", { terminal: fakeDisposed as never, disposed: true } as never);
+
+    const theme: ITheme = { background: "#123456", foreground: "#abcdef" };
+    applyThemeToAllTerminals(theme);
+
+    expect(liveOptions1.theme).toBe(theme);
+    expect(liveOptions2.theme).toBe(theme);
+    // disposed instance must NOT be re-themed
+    expect(disposedOptions.theme).toBeUndefined();
+  });
+});

--- a/src/features/terminal/useTerminal.test.ts
+++ b/src/features/terminal/useTerminal.test.ts
@@ -1,0 +1,100 @@
+// src/features/terminal/useTerminal.test.ts — TDD: applyThemeToAllTerminals export
+
+import { describe, it, expect, vi } from "vitest";
+import type { ITheme } from "@xterm/xterm";
+
+// ── localStorage stub so themeStore (imported dynamically by useTerminal) can work ──
+vi.hoisted(() => {
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, String(v)),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => void store.clear(),
+      key: (i: number) => [...store.keys()][i] ?? null,
+      get length() { return store.size; },
+    },
+  });
+});
+
+// ── Mock heavy native modules ──
+vi.mock("@xterm/xterm", () => ({
+  Terminal: vi.fn().mockImplementation(() => ({
+    loadAddon: vi.fn(),
+    open: vi.fn(),
+    cols: 80,
+    rows: 24,
+    onData: vi.fn(),
+    onBinary: vi.fn(),
+    focus: vi.fn(),
+    dispose: vi.fn(),
+    write: vi.fn(),
+    writeln: vi.fn(),
+    element: null,
+    options: {},
+  })),
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: vi.fn().mockImplementation(() => ({ fit: vi.fn(), dispose: vi.fn() })),
+}));
+
+vi.mock("@xterm/addon-web-links", () => ({
+  WebLinksAddon: vi.fn().mockImplementation(() => ({ dispose: vi.fn() })),
+}));
+
+vi.mock("../../lib/tauri", () => ({
+  tauriInvoke: vi.fn().mockResolvedValue("term-id-1"),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  Channel: vi.fn().mockImplementation(() => ({ onmessage: null })),
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { applyThemeToAllTerminals } from "./useTerminal";
+
+const mockTheme: ITheme = {
+  background: "#000000",
+  foreground: "#ffffff",
+};
+
+describe("applyThemeToAllTerminals", () => {
+  it("is exported from useTerminal as a function", () => {
+    expect(typeof applyThemeToAllTerminals).toBe("function");
+  });
+
+  it("does not throw when called with no terminal instances (empty map)", () => {
+    // The module-level Map is empty in this test context; calling should be a no-op.
+    expect(() => applyThemeToAllTerminals(mockTheme)).not.toThrow();
+  });
+
+  it("accepts an ITheme argument without type errors", () => {
+    const fullTheme: ITheme = {
+      background: "#0c0e12",
+      foreground: "#eef0f3",
+      cursor: "#c49a60",
+      cursorAccent: "#181c25",
+      selectionBackground: "#3b2e18a6",
+      black: "#3e3830",
+      red: "#e05c4a",
+      green: "#4ec99a",
+      yellow: "#d4a03a",
+      blue: "#5aabf0",
+      magenta: "#b589e8",
+      cyan: "#3fc9a0",
+      white: "#b6b0ab",
+      brightBlack: "#635c57",
+      brightRed: "#f5897e",
+      brightGreen: "#66c7a0",
+      brightYellow: "#e8b84e",
+      brightBlue: "#82c8ff",
+      brightMagenta: "#cca8f8",
+      brightCyan: "#66c7a0",
+      brightWhite: "#eeeae7",
+    };
+    expect(() => applyThemeToAllTerminals(fullTheme)).not.toThrow();
+  });
+});

--- a/src/features/terminal/useTerminal.ts
+++ b/src/features/terminal/useTerminal.ts
@@ -5,6 +5,7 @@
 
 import { useCallback } from "react";
 import { Terminal } from "@xterm/xterm";
+import type { ITheme } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { Channel } from "@tauri-apps/api/core";
@@ -13,9 +14,9 @@ import {
   TERMINAL_FONT_FAMILY,
   TERMINAL_FONT_SIZE,
   TERMINAL_LINE_HEIGHT,
-  TERMINAL_THEME,
   RESIZE_DEBOUNCE_MS,
 } from "../../lib/constants";
+import { THEMES } from "../../lib/themes";
 import type { SessionId, TerminalId, TerminalEvent } from "../../lib/types";
 
 interface TerminalInstance {
@@ -36,6 +37,21 @@ interface TerminalInstance {
 // each call useTerminal() independently (Bug H3).
 const terminalInstances = new Map<string, TerminalInstance>();
 
+/**
+ * Re-themes all live (non-disposed) terminal instances.
+ *
+ * Called by themeStore.applyThemeSideEffects when the user switches themes.
+ * The terminalInstances Map stays private; this is the only export that touches it.
+ * xterm v6 supports terminal.options.theme as a live setter (no dispose+recreate needed).
+ */
+export function applyThemeToAllTerminals(theme: ITheme): void {
+  for (const instance of terminalInstances.values()) {
+    if (!instance.disposed) {
+      instance.terminal.options.theme = theme;
+    }
+  }
+}
+
 function isApplePlatform() {
   return /Mac|iPhone|iPad|iPod/.test(window.navigator.platform);
 }
@@ -47,12 +63,20 @@ export function useTerminal() {
       container: HTMLDivElement,
       sessionId: SessionId,
     ): Promise<TerminalId> => {
+      // Lazy runtime import avoids a module-level cycle: themeStore imports this
+      // module for applyThemeToAllTerminals; this module reads themeStore only
+      // at call time (never at module evaluation). ESM safe. If the bundler warns,
+      // the fallback is parseStoredThemeId(localStorage.getItem("nexterm-theme")).
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { useThemeStore } = await import("../../stores/themeStore");
+      const initialThemeId = useThemeStore.getState().themeId;
+
       // Create xterm.js Terminal
       const term = new Terminal({
         fontFamily: TERMINAL_FONT_FAMILY,
         fontSize: TERMINAL_FONT_SIZE,
         lineHeight: TERMINAL_LINE_HEIGHT,
-        theme: TERMINAL_THEME,
+        theme: THEMES[initialThemeId].terminalTheme,
         cursorBlink: true,
         cursorStyle: "block",
         allowProposedApi: true,

--- a/src/features/terminal/useTerminal.ts
+++ b/src/features/terminal/useTerminal.ts
@@ -67,7 +67,6 @@ export function useTerminal() {
       // module for applyThemeToAllTerminals; this module reads themeStore only
       // at call time (never at module evaluation). ESM safe. If the bundler warns,
       // the fallback is parseStoredThemeId(localStorage.getItem("nexterm-theme")).
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
       const { useThemeStore } = await import("../../stores/themeStore");
       const initialThemeId = useThemeStore.getState().themeId;
 
@@ -281,4 +280,16 @@ export function useTerminal() {
   }, []);
 
   return { openTerminal, closeTerminal, getTerminal, focusTerminal, reattachTerminal, disposeSessionTerminals };
+}
+
+/**
+ * TEST-ONLY helper — seeds a fake TerminalInstance into the module-level Map
+ * so unit tests can verify applyThemeToAllTerminals behaves correctly on live
+ * and disposed instances without standing up a real xterm.js environment.
+ *
+ * This export is guarded by the module-level Map being private; calling it in
+ * production is a no-op for callers who don't import it explicitly.
+ */
+export function _testSeedTerminalInstance(id: string, instance: TerminalInstance): void {
+  terminalInstances.set(id, instance);
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,5 +1,7 @@
 // lib/constants.ts — Application constants and defaults
 
+import { THEMES } from "./themes";
+
 export const DEFAULT_SSH_PORT = 22;
 export const DEFAULT_TIMEOUT_SECS = 30;
 export const DEFAULT_KEEPALIVE_SECS = 30;
@@ -8,37 +10,10 @@ export const TERMINAL_FONT_FAMILY =
   '"JetBrains Mono", "Fira Code", "Cascadia Code", "SF Mono", "Menlo", monospace';
 export const TERMINAL_FONT_SIZE = 13;
 export const TERMINAL_LINE_HEIGHT = 1.35;
-export const TERMINAL_THEME = {
-  // LAMPLIGHT chrome — bg-abyss canvas, warm foreground, copper cursor
-  background: "#0f0b09",       // var(--bg-abyss)
-  foreground: "#eeeae7",       // var(--text-primary)
-  cursor: "#ea9e51",           // var(--accent) copper
-  cursorAccent: "#0f0b09",     // var(--bg-abyss) — text on cursor block
-  // accent-wash at ~65% opacity — copper selection replaces old blue #388bfd33
-  selectionBackground: "#3c2918a6",
-  selectionForeground: undefined,
-  // ANSI 16-color ramp — warmed slightly to sit in the warm field while staying
-  // perceptually correct for `git diff`, `ls --color`, colored logs.
-  // Red stays unmistakably red (error-safe). Green shifts toward jade family
-  // (distinct from live-state jade; still clearly green). Blue stays blue for
-  // diffs/links. Magenta/cyan slightly desaturated to avoid neon pops.
-  black:         "#3e3830",    // warm near-black (replaces cool #484f58)
-  red:           "#e05c4a",    // warm brick-red, still clearly error (was #ff7b72)
-  green:         "#4ec99a",    // jade-family green, readable as "ok" (was #3fb950)
-  yellow:        "#d4a03a",    // warm ochre, distinct from accent (was #d29922)
-  blue:          "#5aabf0",    // stays blue, slightly warmed (was #58a6ff)
-  magenta:       "#b589e8",    // slightly desaturated (was #bc8cff)
-  cyan:          "#3fc9a0",    // jade-tinted cyan (was #39d353)
-  white:         "#b6b0ab",    // var(--text-secondary) warm (was #b1bac4)
-  brightBlack:   "#635c57",    // var(--text-faint) warm (was #6e7681)
-  brightRed:     "#f5897e",    // brighter warm red (was #ffa198)
-  brightGreen:   "#66c7a0",    // var(--connected) jade (was #56d364)
-  brightYellow:  "#e8b84e",    // bright warm ochre (was #e3b341)
-  brightBlue:    "#82c8ff",    // bright warm blue (was #79c0ff)
-  brightMagenta: "#cca8f8",    // bright desaturated magenta (was #d2a8ff)
-  brightCyan:    "#66c7a0",    // jade — consistent with brightGreen (was #56d364)
-  brightWhite:   "#eeeae7",    // var(--text-primary) (was #f0f6fc)
-} as const;
+
+// Back-compat re-export: the literal has moved to src/lib/themes.ts (THEMES.lamplight.terminalTheme).
+// All existing importers of TERMINAL_THEME continue to work without changes.
+export const TERMINAL_THEME = THEMES.lamplight.terminalTheme;
 
 export const APP_NAME = "NexTerm";
 export const KEYCHAIN_SERVICE = "nexterm";

--- a/src/lib/theme/ThemeProvider.test.tsx
+++ b/src/lib/theme/ThemeProvider.test.tsx
@@ -1,0 +1,82 @@
+// src/lib/theme/ThemeProvider.test.tsx — TDD: ThemeProvider applies data-theme on mount
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+
+// ── localStorage stub (same pattern as i18n/index.test.tsx) ──
+const { localStorageMap } = vi.hoisted(() => {
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, String(v)),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => void store.clear(),
+      key: (i: number) => [...store.keys()][i] ?? null,
+      get length() { return store.size; },
+    },
+  });
+  return { localStorageMap: store };
+});
+
+// ── Mock useTerminal so applyThemeToAllTerminals is a no-op ──
+vi.mock("../../features/terminal/useTerminal", () => ({
+  applyThemeToAllTerminals: vi.fn(),
+}));
+
+import { ThemeProvider } from "./ThemeProvider";
+import { useThemeStore } from "../../stores/themeStore";
+
+beforeEach(() => {
+  localStorageMap.clear();
+  useThemeStore.setState({ themeId: "lamplight" });
+  document.documentElement.removeAttribute("data-theme");
+});
+
+describe("ThemeProvider", () => {
+  it("applies data-theme from store themeId on mount (lamplight)", () => {
+    render(
+      <ThemeProvider>
+        <div />
+      </ThemeProvider>,
+    );
+    expect(document.documentElement.dataset.theme).toBe("lamplight");
+  });
+
+  it("applies data-theme dark when store is seeded with dark", () => {
+    // Pre-seed store as if restored from localStorage
+    useThemeStore.setState({ themeId: "dark" });
+
+    render(
+      <ThemeProvider>
+        <div />
+      </ThemeProvider>,
+    );
+    expect(document.documentElement.dataset.theme).toBe("dark");
+  });
+
+  it("renders children transparently", () => {
+    const { container } = render(
+      <ThemeProvider>
+        <span data-testid="child">hello</span>
+      </ThemeProvider>,
+    );
+    expect(container.querySelector('[data-testid="child"]')).not.toBeNull();
+  });
+
+  it("reacts to themeId store changes after mount", () => {
+    render(
+      <ThemeProvider>
+        <div />
+      </ThemeProvider>,
+    );
+
+    // Simulate theme switch
+    useThemeStore.getState().setTheme("dark");
+    expect(document.documentElement.dataset.theme).toBe("dark");
+
+    useThemeStore.getState().setTheme("lamplight");
+    expect(document.documentElement.dataset.theme).toBe("lamplight");
+  });
+});

--- a/src/lib/theme/ThemeProvider.test.tsx
+++ b/src/lib/theme/ThemeProvider.test.tsx
@@ -41,7 +41,8 @@ describe("ThemeProvider", () => {
         <div />
       </ThemeProvider>,
     );
-    expect(document.documentElement.dataset.theme).toBe("lamplight");
+    // MINOR-2: LAMPLIGHT must NOT set data-theme attribute (spec: no [data-theme] for default)
+    expect(document.documentElement.hasAttribute("data-theme")).toBe(false);
   });
 
   it("applies data-theme dark when store is seeded with dark", () => {
@@ -76,7 +77,22 @@ describe("ThemeProvider", () => {
     useThemeStore.getState().setTheme("dark");
     expect(document.documentElement.dataset.theme).toBe("dark");
 
+    // MINOR-2: switching back to lamplight REMOVES data-theme attribute entirely
     useThemeStore.getState().setTheme("lamplight");
-    expect(document.documentElement.dataset.theme).toBe("lamplight");
+    expect(document.documentElement.hasAttribute("data-theme")).toBe(false);
+  });
+
+  it("setTheme(lamplight) removes data-theme attribute instead of setting it", () => {
+    // Start with dark, then switch to lamplight — attribute must be removed
+    useThemeStore.setState({ themeId: "dark" });
+    document.documentElement.dataset.theme = "dark";
+
+    render(
+      <ThemeProvider>
+        <div />
+      </ThemeProvider>,
+    );
+    useThemeStore.getState().setTheme("lamplight");
+    expect(document.documentElement.hasAttribute("data-theme")).toBe(false);
   });
 });

--- a/src/lib/theme/ThemeProvider.tsx
+++ b/src/lib/theme/ThemeProvider.tsx
@@ -1,0 +1,26 @@
+// src/lib/theme/ThemeProvider.tsx — Applies [data-theme] on mount and on theme changes.
+//
+// The FOUC inline script in index.html sets data-theme synchronously before React
+// mounts (using the same Zustand persist envelope parse logic). ThemeProvider is
+// idempotent with that script: it re-applies the same value on mount (no flicker)
+// and keeps data-theme in sync when the user switches themes at runtime.
+
+import { useEffect, type ReactNode } from "react";
+import { useThemeStore } from "../../stores/themeStore";
+import { applyThemeSideEffects } from "../../stores/themeStore";
+
+interface ThemeProviderProps {
+  children: ReactNode;
+}
+
+export function ThemeProvider({ children }: ThemeProviderProps) {
+  const themeId = useThemeStore((s) => s.themeId);
+
+  // Apply on every themeId change (including initial mount).
+  // This is idempotent with the inline FOUC script.
+  useEffect(() => {
+    applyThemeSideEffects(themeId);
+  }, [themeId]);
+
+  return <>{children}</>;
+}

--- a/src/lib/themes.test.ts
+++ b/src/lib/themes.test.ts
@@ -1,0 +1,127 @@
+// src/lib/themes.test.ts — TDD: Theme preset module + validator
+
+import { describe, it, expect } from "vitest";
+import {
+  isThemeId,
+  DEFAULT_THEME_ID,
+  THEME_IDS,
+  THEMES,
+  parseStoredThemeId,
+} from "./themes";
+
+describe("themes — core exports", () => {
+  it("DEFAULT_THEME_ID is lamplight", () => {
+    expect(DEFAULT_THEME_ID).toBe("lamplight");
+  });
+
+  it("THEME_IDS has exactly 2 members", () => {
+    expect(THEME_IDS).toHaveLength(2);
+    expect(THEME_IDS).toContain("lamplight");
+    expect(THEME_IDS).toContain("dark");
+  });
+
+  it("THEMES keys match THEME_IDS", () => {
+    expect(Object.keys(THEMES).sort()).toEqual([...THEME_IDS].sort());
+  });
+});
+
+describe("isThemeId", () => {
+  it("accepts lamplight", () => {
+    expect(isThemeId("lamplight")).toBe(true);
+  });
+
+  it("accepts dark", () => {
+    expect(isThemeId("dark")).toBe(true);
+  });
+
+  it("rejects light", () => {
+    expect(isThemeId("light")).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(isThemeId("")).toBe(false);
+  });
+
+  it("rejects undefined", () => {
+    expect(isThemeId(undefined)).toBe(false);
+  });
+
+  it("rejects null", () => {
+    expect(isThemeId(null)).toBe(false);
+  });
+});
+
+describe("THEMES — terminalTheme completeness", () => {
+  const ANSI_KEYS = [
+    "black", "red", "green", "yellow", "blue", "magenta", "cyan", "white",
+    "brightBlack", "brightRed", "brightGreen", "brightYellow",
+    "brightBlue", "brightMagenta", "brightCyan", "brightWhite",
+  ] as const;
+
+  const REQUIRED_BASE_KEYS = [
+    "background", "foreground", "cursor", "cursorAccent", "selectionBackground",
+  ] as const;
+
+  const CSS_COLOR_RE = /#[0-9a-fA-F]{3,8}|rgba?\(|oklch\(/;
+
+  for (const id of ["lamplight", "dark"] as const) {
+    describe(`THEMES.${id}.terminalTheme`, () => {
+      it("has all required base keys (background, foreground, cursor, cursorAccent, selectionBackground)", () => {
+        const theme = THEMES[id].terminalTheme;
+        for (const key of REQUIRED_BASE_KEYS) {
+          expect(theme).toHaveProperty(key);
+        }
+      });
+
+      it("has exactly 16 ANSI color keys", () => {
+        const theme = THEMES[id].terminalTheme;
+        const presentAnsi = ANSI_KEYS.filter((k) => k in theme);
+        expect(presentAnsi).toHaveLength(16);
+      });
+
+      it("all color values are valid CSS color strings", () => {
+        const theme = THEMES[id].terminalTheme as Record<string, unknown>;
+        const allKeys = [...REQUIRED_BASE_KEYS, ...ANSI_KEYS];
+        for (const key of allKeys) {
+          const val = theme[key];
+          if (val === undefined) continue; // selectionForeground may be undefined
+          expect(typeof val).toBe("string");
+          expect(CSS_COLOR_RE.test(val as string)).toBe(true);
+        }
+      });
+    });
+  }
+});
+
+describe("parseStoredThemeId", () => {
+  it("parses Zustand persist envelope with dark", () => {
+    const raw = JSON.stringify({ state: { themeId: "dark" }, version: 0 });
+    expect(parseStoredThemeId(raw)).toBe("dark");
+  });
+
+  it("parses Zustand persist envelope with lamplight", () => {
+    const raw = JSON.stringify({ state: { themeId: "lamplight" }, version: 0 });
+    expect(parseStoredThemeId(raw)).toBe("lamplight");
+  });
+
+  it("returns lamplight for null", () => {
+    expect(parseStoredThemeId(null)).toBe("lamplight");
+  });
+
+  it("returns lamplight for garbage string", () => {
+    expect(parseStoredThemeId("not-json")).toBe("lamplight");
+  });
+
+  it("returns lamplight for malformed JSON (missing state)", () => {
+    expect(parseStoredThemeId(JSON.stringify({ themeId: "dark" }))).toBe("lamplight");
+  });
+
+  it("returns lamplight for invalid union value", () => {
+    const raw = JSON.stringify({ state: { themeId: "light" }, version: 0 });
+    expect(parseStoredThemeId(raw)).toBe("lamplight");
+  });
+
+  it("returns lamplight for empty string", () => {
+    expect(parseStoredThemeId("")).toBe("lamplight");
+  });
+});

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -1,0 +1,124 @@
+// src/lib/themes.ts — Theme preset registry (pure module, no DOM side-effects)
+//
+// This module is the single source of truth for:
+//   - The ThemeId union type and its validator
+//   - The xterm.js ITheme for each preset (terminal colors only)
+//   - Label strings for UI controls
+//
+// UI token overrides live in globals.css [data-theme] blocks.
+// The two are intentionally separate: CSS handles ~60 tokens via cascade;
+// this module handles xterm (which has no CSS hook).
+
+import type { ITheme } from "@xterm/xterm";
+
+export type ThemeId = "lamplight" | "dark";
+
+export interface ThemePreset {
+  /** StatusBar toggle label, i18n-key-friendly short id reused as display token */
+  label: string;
+  /** xterm.js theme: bg/fg/cursor/cursorAccent/selection + all 16 ANSI */
+  terminalTheme: ITheme;
+}
+
+export const DEFAULT_THEME_ID: ThemeId = "lamplight";
+export const THEME_IDS: readonly ThemeId[] = ["lamplight", "dark"] as const;
+
+export const THEMES: Record<ThemeId, ThemePreset> = {
+  lamplight: {
+    label: "Lamplight",
+    terminalTheme: {
+      // LAMPLIGHT chrome — bg-abyss canvas, warm foreground, copper cursor
+      // This is the canonical definition; constants.ts re-exports it for back-compat.
+      background: "#0f0b09",       // var(--bg-abyss)
+      foreground: "#eeeae7",       // var(--text-primary)
+      cursor: "#ea9e51",           // var(--accent) copper
+      cursorAccent: "#0f0b09",     // var(--bg-abyss) — text on cursor block
+      // accent-wash at ~65% opacity — copper selection replaces old blue #388bfd33
+      selectionBackground: "#3c2918a6",
+      selectionForeground: undefined,
+      // ANSI 16-color ramp — warmed slightly to sit in the warm field while staying
+      // perceptually correct for `git diff`, `ls --color`, colored logs.
+      black:         "#3e3830",    // warm near-black (replaces cool #484f58)
+      red:           "#e05c4a",    // warm brick-red, still clearly error (was #ff7b72)
+      green:         "#4ec99a",    // jade-family green, readable as "ok" (was #3fb950)
+      yellow:        "#d4a03a",    // warm ochre, distinct from accent (was #d29922)
+      blue:          "#5aabf0",    // stays blue, slightly warmed (was #58a6ff)
+      magenta:       "#b589e8",    // slightly desaturated (was #bc8cff)
+      cyan:          "#3fc9a0",    // jade-tinted cyan (was #39d353)
+      white:         "#b6b0ab",    // var(--text-secondary) warm (was #b1bac4)
+      brightBlack:   "#635c57",    // var(--text-faint) warm (was #6e7681)
+      brightRed:     "#f5897e",    // brighter warm red (was #ffa198)
+      brightGreen:   "#66c7a0",    // var(--connected) jade (was #56d364)
+      brightYellow:  "#e8b84e",    // bright warm ochre (was #e3b341)
+      brightBlue:    "#82c8ff",    // bright warm blue (was #79c0ff)
+      brightMagenta: "#cca8f8",    // bright desaturated magenta (was #d2a8ff)
+      brightCyan:    "#66c7a0",    // jade — consistent with brightGreen (was #56d364)
+      brightWhite:   "#eeeae7",    // var(--text-primary) (was #f0f6fc)
+    },
+  },
+
+  dark: {
+    label: "Dark",
+    terminalTheme: {
+      // DARK cool-slate preset — "cold instrument bay, copper still glints"
+      // Neutrals shift to hue 250 (slate); copper accent retained but desaturated.
+      // ANSI 16-color ramp is IDENTICAL to LAMPLIGHT by design decision D7:
+      // colorized CLI output semantics (git diff, ls --color) must not shift with theme.
+      //
+      // WCAG AA verified (body text vs --bg-panel oklch(0.205 0.012 250)):
+      //   --text-primary  oklch(0.945 0.006 250) → 15.25:1 (AAA)
+      //   --text-secondary oklch(0.770 0.012 250) → 8.65:1  (AAA)
+      //   --text-muted    oklch(0.620 0.014 250) → 4.92:1  (AA body, ≥4.5 required)
+      //   --error         oklch(0.660 0.155  32) → 5.38:1  (AA)
+      background: "#0c0e12",       // var(--bg-abyss) dark — oklch(0.135 0.010 250)
+      foreground: "#eef0f3",       // cool off-white — never pure #fff
+      cursor: "#c49a60",           // copper desaturated ~10% for cold room (oklch(0.770 0.118 64))
+      cursorAccent: "#181c25",     // near-black on cursor (oklch(0.200 0.018 250))
+      // copper accent-wash at ~65% alpha — matches --accent-wash dark override
+      selectionBackground: "#3b2e18a6",
+      selectionForeground: undefined,
+      // ANSI 16-color ramp — SAME AS LAMPLIGHT (design decision D7)
+      black:         "#3e3830",
+      red:           "#e05c4a",
+      green:         "#4ec99a",
+      yellow:        "#d4a03a",
+      blue:          "#5aabf0",
+      magenta:       "#b589e8",
+      cyan:          "#3fc9a0",
+      white:         "#b6b0ab",
+      brightBlack:   "#635c57",
+      brightRed:     "#f5897e",
+      brightGreen:   "#66c7a0",
+      brightYellow:  "#e8b84e",
+      brightBlue:    "#82c8ff",
+      brightMagenta: "#cca8f8",
+      brightCyan:    "#66c7a0",
+      brightWhite:   "#eeeae7",
+    },
+  },
+};
+
+/** Type guard — narrows unknown to ThemeId */
+export function isThemeId(v: unknown): v is ThemeId {
+  return v === "lamplight" || v === "dark";
+}
+
+/**
+ * Parses the Zustand persist envelope stored in localStorage["nexterm-theme"].
+ * Zustand persist writes: {"state":{"themeId":"dark"},"version":0}
+ * The FOUC inline script in index.html shares the same parse logic.
+ *
+ * @param raw - Raw string from localStorage.getItem(), or null
+ * @returns ThemeId — valid id or DEFAULT_THEME_ID ("lamplight") as fallback
+ */
+export function parseStoredThemeId(raw: string | null): ThemeId {
+  try {
+    if (!raw) return DEFAULT_THEME_ID;
+    const parsed = JSON.parse(raw);
+    const v = parsed && parsed.state && parsed.state.themeId;
+    if (isThemeId(v)) return v;
+  } catch {
+    // malformed JSON — fall through
+  }
+  return DEFAULT_THEME_ID;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,12 +2,17 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import { I18nProvider } from "./lib/i18n";
+import { ThemeProvider } from "./lib/theme/ThemeProvider";
 import "./styles/globals.css";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <I18nProvider>
-      <App />
-    </I18nProvider>
+    {/* ThemeProvider is the outermost wrapper so data-theme is applied before
+        any child renders, idempotent with the FOUC inline script in index.html */}
+    <ThemeProvider>
+      <I18nProvider>
+        <App />
+      </I18nProvider>
+    </ThemeProvider>
   </React.StrictMode>,
 );

--- a/src/stores/themeStore.test.ts
+++ b/src/stores/themeStore.test.ts
@@ -90,34 +90,40 @@ describe("themeStore — setTheme", () => {
 });
 
 describe("themeStore — restore from localStorage", () => {
-  it("restores dark when localStorage is pre-seeded with dark envelope", () => {
-    // Simulate what Zustand persist does: read from storage on hydration.
-    // We test this by seeding localStorage and then calling the store's
-    // internal persist rehydration via setState (simulating a page-reload init).
+  it("restores dark when localStorage is pre-seeded with dark envelope", async () => {
     const envelope = JSON.stringify({ state: { themeId: "dark" }, version: 0 });
     localStorageMap.set("nexterm-theme", envelope);
-    // Force rehydration by reading the persisted value directly (as the persist
-    // middleware does) and applying it to the store state.
-    const raw = localStorageMap.get("nexterm-theme");
-    const parsed = JSON.parse(raw!);
-    if (parsed.state?.themeId === "dark") {
-      useThemeStore.setState({ themeId: "dark" });
-    }
+    // Trigger real Zustand persist rehydration (not a setState mock)
+    await useThemeStore.persist.rehydrate();
     expect(useThemeStore.getState().themeId).toBe("dark");
   });
 
-  it("defaults to lamplight when stored value has invalid themeId", () => {
-    const envelope = JSON.stringify({ state: { themeId: "invalid-theme" }, version: 0 });
-    localStorageMap.set("nexterm-theme", envelope);
-    // The persist middleware's merge applies stored state directly; if themeId
-    // were "invalid-theme", isThemeId would reject it in setTheme.
-    // Default state is lamplight.
+  it("MAJOR-3: corrupt persisted themeId falls back to lamplight, no crash", async () => {
+    // Seed localStorage with an invalid themeId (e.g., a future value or corrupt data)
+    const corrupt = JSON.stringify({ state: { themeId: "blue" }, version: 0 });
+    localStorageMap.set("nexterm-theme", corrupt);
+    // Trigger real Zustand persist rehydration
+    await useThemeStore.persist.rehydrate();
+    // Must fall back to lamplight — NOT "blue", and NOT crash
+    expect(useThemeStore.getState().themeId).toBe("lamplight");
+  });
+
+  it("MAJOR-3: malformed JSON in storage falls back to lamplight, no crash", async () => {
+    localStorageMap.set("nexterm-theme", "{{not valid json}}");
+    await expect(useThemeStore.persist.rehydrate()).resolves.not.toThrow();
+    expect(useThemeStore.getState().themeId).toBe("lamplight");
+  });
+
+  it("MAJOR-3: missing themeId in stored state falls back to lamplight", async () => {
+    const corrupt = JSON.stringify({ state: {}, version: 0 });
+    localStorageMap.set("nexterm-theme", corrupt);
+    await useThemeStore.persist.rehydrate();
     expect(useThemeStore.getState().themeId).toBe("lamplight");
   });
 });
 
 describe("applyThemeSideEffects", () => {
-  it("sets document.documentElement.dataset.theme", () => {
+  it("sets document.documentElement.dataset.theme to dark", () => {
     applyThemeSideEffects("dark");
     expect(document.documentElement.dataset.theme).toBe("dark");
   });
@@ -129,8 +135,18 @@ describe("applyThemeSideEffects", () => {
     );
   });
 
-  it("sets lamplight dataset when called with lamplight", () => {
+  it("MINOR-2: lamplight REMOVES the data-theme attribute (not sets it to 'lamplight')", () => {
+    // First set it to dark so the attribute is present
+    document.documentElement.dataset.theme = "dark";
     applyThemeSideEffects("lamplight");
-    expect(document.documentElement.dataset.theme).toBe("lamplight");
+    // Spec: no [data-theme] attribute for LAMPLIGHT (it is the CSS default)
+    expect(document.documentElement.hasAttribute("data-theme")).toBe(false);
+  });
+
+  it("MINOR-2: setTheme(lamplight) removes data-theme attribute", () => {
+    useThemeStore.setState({ themeId: "dark" });
+    document.documentElement.dataset.theme = "dark";
+    useThemeStore.getState().setTheme("lamplight");
+    expect(document.documentElement.hasAttribute("data-theme")).toBe(false);
   });
 });

--- a/src/stores/themeStore.test.ts
+++ b/src/stores/themeStore.test.ts
@@ -1,0 +1,136 @@
+// src/stores/themeStore.test.ts — TDD: Zustand persist + side effects
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { THEMES } from "../lib/themes";
+
+// ── localStorage stub — must be set up via vi.hoisted so it is in place
+// before any module is imported (Zustand persist reads localStorage at store-create time).
+// Reuses the Object.defineProperty pattern from src/lib/i18n/index.test.tsx.
+const { localStorageMap } = vi.hoisted(() => {
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, String(v)),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => void store.clear(),
+      key: (i: number) => [...store.keys()][i] ?? null,
+      get length() { return store.size; },
+    },
+  });
+  return { localStorageMap: store };
+});
+
+// ── Mock useTerminal so applyThemeToAllTerminals is a spy ──
+const { mockApplyThemeToAllTerminals } = vi.hoisted(() => ({
+  mockApplyThemeToAllTerminals: vi.fn(),
+}));
+vi.mock("../features/terminal/useTerminal", () => ({
+  applyThemeToAllTerminals: mockApplyThemeToAllTerminals,
+}));
+
+// ── Import store AFTER mocks/stubs are set up ──
+import { useThemeStore, applyThemeSideEffects } from "./themeStore";
+
+beforeEach(() => {
+  localStorageMap.clear();
+  // Merge-reset themeId to lamplight (do NOT use replace=true or setTheme action is lost)
+  useThemeStore.setState({ themeId: "lamplight" });
+  mockApplyThemeToAllTerminals.mockClear();
+  document.documentElement.removeAttribute("data-theme");
+});
+
+describe("themeStore — initial state", () => {
+  it("has themeId === lamplight by default (no storage)", () => {
+    expect(useThemeStore.getState().themeId).toBe("lamplight");
+  });
+});
+
+describe("themeStore — setTheme", () => {
+  it("setTheme(dark) updates state.themeId to dark", () => {
+    useThemeStore.getState().setTheme("dark");
+    expect(useThemeStore.getState().themeId).toBe("dark");
+  });
+
+  it("setTheme(dark) writes nexterm-theme to localStorage with Zustand envelope shape", () => {
+    useThemeStore.getState().setTheme("dark");
+    const raw = localStorageMap.get("nexterm-theme");
+    expect(raw).toBeDefined();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.state.themeId).toBe("dark");
+    expect(parsed.version).toBe(0);
+  });
+
+  it("setTheme(dark) sets document.documentElement.dataset.theme to dark", () => {
+    useThemeStore.getState().setTheme("dark");
+    expect(document.documentElement.dataset.theme).toBe("dark");
+  });
+
+  it("setTheme with invalid id is a no-op (state unchanged)", () => {
+    // @ts-expect-error — intentional invalid id for test
+    useThemeStore.getState().setTheme("light");
+    expect(useThemeStore.getState().themeId).toBe("lamplight");
+  });
+
+  it("setTheme(dark) calls applyThemeToAllTerminals with THEMES.dark.terminalTheme", () => {
+    useThemeStore.getState().setTheme("dark");
+    expect(mockApplyThemeToAllTerminals).toHaveBeenCalledWith(
+      THEMES.dark.terminalTheme,
+    );
+  });
+
+  it("setTheme(lamplight) calls applyThemeToAllTerminals with THEMES.lamplight.terminalTheme", () => {
+    useThemeStore.setState({ themeId: "dark" });
+    useThemeStore.getState().setTheme("lamplight");
+    expect(mockApplyThemeToAllTerminals).toHaveBeenCalledWith(
+      THEMES.lamplight.terminalTheme,
+    );
+  });
+});
+
+describe("themeStore — restore from localStorage", () => {
+  it("restores dark when localStorage is pre-seeded with dark envelope", () => {
+    // Simulate what Zustand persist does: read from storage on hydration.
+    // We test this by seeding localStorage and then calling the store's
+    // internal persist rehydration via setState (simulating a page-reload init).
+    const envelope = JSON.stringify({ state: { themeId: "dark" }, version: 0 });
+    localStorageMap.set("nexterm-theme", envelope);
+    // Force rehydration by reading the persisted value directly (as the persist
+    // middleware does) and applying it to the store state.
+    const raw = localStorageMap.get("nexterm-theme");
+    const parsed = JSON.parse(raw!);
+    if (parsed.state?.themeId === "dark") {
+      useThemeStore.setState({ themeId: "dark" });
+    }
+    expect(useThemeStore.getState().themeId).toBe("dark");
+  });
+
+  it("defaults to lamplight when stored value has invalid themeId", () => {
+    const envelope = JSON.stringify({ state: { themeId: "invalid-theme" }, version: 0 });
+    localStorageMap.set("nexterm-theme", envelope);
+    // The persist middleware's merge applies stored state directly; if themeId
+    // were "invalid-theme", isThemeId would reject it in setTheme.
+    // Default state is lamplight.
+    expect(useThemeStore.getState().themeId).toBe("lamplight");
+  });
+});
+
+describe("applyThemeSideEffects", () => {
+  it("sets document.documentElement.dataset.theme", () => {
+    applyThemeSideEffects("dark");
+    expect(document.documentElement.dataset.theme).toBe("dark");
+  });
+
+  it("calls applyThemeToAllTerminals with the correct theme", () => {
+    applyThemeSideEffects("dark");
+    expect(mockApplyThemeToAllTerminals).toHaveBeenCalledWith(
+      THEMES.dark.terminalTheme,
+    );
+  });
+
+  it("sets lamplight dataset when called with lamplight", () => {
+    applyThemeSideEffects("lamplight");
+    expect(document.documentElement.dataset.theme).toBe("lamplight");
+  });
+});

--- a/src/stores/themeStore.ts
+++ b/src/stores/themeStore.ts
@@ -1,0 +1,46 @@
+// src/stores/themeStore.ts — Persisted theme selection (Zustand)
+//
+// Dependency direction: themeStore -> useTerminal (one-way, design decision D4).
+// useTerminal NEVER imports themeStore at module top; it reads getState() lazily
+// inside openTerminal (runtime, not module-eval time).
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { type ThemeId, DEFAULT_THEME_ID, THEMES, isThemeId } from "../lib/themes";
+import { applyThemeToAllTerminals } from "../features/terminal/useTerminal";
+
+interface ThemeStoreState {
+  themeId: ThemeId;
+  setTheme: (id: ThemeId) => void;
+}
+
+/**
+ * Applies theme side-effects: updates the CSS [data-theme] attribute on <html>
+ * and re-colors all live xterm terminal instances.
+ *
+ * Exported so ThemeProvider can call it on mount (idempotent with the FOUC inline script).
+ */
+export function applyThemeSideEffects(id: ThemeId): void {
+  document.documentElement.dataset.theme = id;
+  applyThemeToAllTerminals(THEMES[id].terminalTheme);
+}
+
+export const useThemeStore = create<ThemeStoreState>()(
+  persist(
+    (set) => ({
+      themeId: DEFAULT_THEME_ID,
+      setTheme: (id) => {
+        if (!isThemeId(id)) return;
+        set({ themeId: id });
+        applyThemeSideEffects(id);
+      },
+    }),
+    {
+      name: "nexterm-theme",
+      partialize: (s) => ({ themeId: s.themeId }),
+      // version: 0 (Zustand default) — matches workspaceStore convention
+      // INVARIANT: themeId is always at path .state.themeId in the persisted JSON.
+      // The FOUC inline script in index.html reads this path; keep it stable.
+    },
+  ),
+);

--- a/src/stores/themeStore.ts
+++ b/src/stores/themeStore.ts
@@ -18,10 +18,19 @@ interface ThemeStoreState {
  * Applies theme side-effects: updates the CSS [data-theme] attribute on <html>
  * and re-colors all live xterm terminal instances.
  *
+ * LAMPLIGHT is the CSS default — its data-theme attribute is REMOVED rather than set,
+ * so the default :root {} block applies without any attribute selector overhead.
+ *
  * Exported so ThemeProvider can call it on mount (idempotent with the FOUC inline script).
  */
 export function applyThemeSideEffects(id: ThemeId): void {
-  document.documentElement.dataset.theme = id;
+  if (id === DEFAULT_THEME_ID) {
+    // LAMPLIGHT is the CSS default: no [data-theme] attribute needed or wanted.
+    // Spec: "no [data-theme] attribute for LAMPLIGHT"
+    delete document.documentElement.dataset.theme;
+  } else {
+    document.documentElement.dataset.theme = id;
+  }
   applyThemeToAllTerminals(THEMES[id].terminalTheme);
 }
 
@@ -41,6 +50,14 @@ export const useThemeStore = create<ThemeStoreState>()(
       // version: 0 (Zustand default) — matches workspaceStore convention
       // INVARIANT: themeId is always at path .state.themeId in the persisted JSON.
       // The FOUC inline script in index.html reads this path; keep it stable.
+      //
+      // MAJOR-3: validate rehydrated themeId — reject unknown values (e.g., "blue")
+      // and fall back to DEFAULT_THEME_ID so a corrupt store never crashes.
+      merge: (persisted, current) => {
+        const p = persisted as Partial<ThemeStoreState>;
+        const themeId = isThemeId(p?.themeId) ? p.themeId : DEFAULT_THEME_ID;
+        return { ...current, themeId };
+      },
     },
   ),
 );

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -141,7 +141,10 @@
   /* ─── State glow tokens — semantic-state rgba() replaced with theme-aware vars ─── */
   /* Previously hardcoded hue-bearing rgba(); now token-driven so DARK can override.  */
   /* Focus ring / keyboard state */
-  --focus-ring-wash:   oklch(0.760 0.130 var(--hue-accent) / 0.12); /* replaces blue rgba focus glows */
+  --focus-ring-wash:        oklch(0.760 0.130 var(--hue-accent) / 0.12); /* replaces blue rgba focus glows */
+  --focus-ring-wash-subtle: oklch(0.760 0.130 var(--hue-accent) / 0.04); /* ultra-low alpha variant (e.g. cd-add-user-btn:hover was rgba(56,139,253,0.04)) */
+  /* Accent glow — copper-hued box-shadow (replaces stale blue glow on copper controls) */
+  --accent-glow: oklch(0.760 0.130 var(--hue-accent) / 0.30);
   /* Drag-over / drop state */
   --drag-accent-wash:  oklch(0.300 0.040 var(--hue-accent) / 0.85);
   --drag-accent-border: oklch(0.760 0.130 var(--hue-accent) / 0.30);
@@ -149,6 +152,15 @@
   --connected-glow:    oklch(0.760 0.110 var(--hue-live) / 0.50);
   --warning-glow:      oklch(0.780 0.130 var(--hue-warn) / 0.40);
   --error-glow:        oklch(0.640 0.150 var(--hue-error) / 0.40);
+  /* Connected-card tints — LAMPLIGHT pixel-equivalent of original rgba(63,185,80,alpha):
+     base=0.04 alpha, hover=0.07 alpha (distinct hover affordance, MAJOR-2) */
+  --connected-wash-base:  oklch(0.760 0.110 var(--hue-live) / 0.04);
+  --connected-wash-hover: oklch(0.760 0.110 var(--hue-live) / 0.07);
+  /* Error ultra-subtle tint — replaces rgba(248,81,73,0.03~0.04) ghost backgrounds */
+  --error-wash-tint: oklch(0.640 0.150 var(--hue-error) / 0.04);
+  /* Warning translucent match highlight — replaces rgba(210,153,34,0.35) (text must show through).
+     Using the closer OKLCH approximation of rgb(210,153,34): L=0.680 C=0.145 H=75 */
+  --warning-wash-match: oklch(0.680 0.145 75 / 0.35);
   /* Terminal selection highlight — CSS mirror of THEMES[id].terminalTheme.selectionBackground.
      SYNC RULE: when changing selection color, update BOTH this token AND themes.ts.
      LAMPLIGHT: copper accent-wash at ~65% alpha (== old rgba(60,41,24,0.65)) */
@@ -204,24 +216,30 @@
   --accent-on:     oklch(0.200 0.018 250);        /* cool near-black text ON accent fill */
   --accent-wash:   oklch(0.300 0.045 64);
   --focus-ring:    oklch(0.810 0.120 66);
-  --focus-ring-wash: oklch(0.770 0.118 64 / 0.14);
+  --focus-ring-wash:        oklch(0.770 0.118 64 / 0.14);
+  --focus-ring-wash-subtle: oklch(0.770 0.118 64 / 0.04);
+  --accent-glow:            oklch(0.770 0.118 64 / 0.30);
   --drag-accent-wash:   oklch(0.300 0.045 64 / 0.85);
   --drag-accent-border: oklch(0.770 0.118 64 / 0.30);
 
   /* ─── Connected/live — jade kept vivid so LIVE pops on cool field ─── */
-  --connected:      oklch(0.775 0.115 165);       /* 8.8:1 vs bg-panel */
-  --connected-wash: oklch(0.300 0.045 165);
-  --connected-glow: oklch(0.775 0.115 165 / 0.50);
+  --connected:           oklch(0.775 0.115 165);       /* 8.8:1 vs bg-panel */
+  --connected-wash:      oklch(0.300 0.045 165);
+  --connected-glow:      oklch(0.775 0.115 165 / 0.50);
+  --connected-wash-base: oklch(0.775 0.115 165 / 0.04);  /* ultra-subtle card tint */
+  --connected-wash-hover:oklch(0.775 0.115 165 / 0.07);  /* distinct hover affordance */
 
   /* ─── Warning — ochre ─── */
-  --warning:      oklch(0.790 0.130 80);
-  --warning-wash: oklch(0.300 0.060 80);
-  --warning-glow: oklch(0.790 0.130 80 / 0.40);
+  --warning:            oklch(0.790 0.130 80);
+  --warning-wash:       oklch(0.300 0.060 80);
+  --warning-glow:       oklch(0.790 0.130 80 / 0.40);
+  --warning-wash-match: oklch(0.790 0.130 80 / 0.35);    /* translucent match highlight (text reads through) — dark-tuned */
 
   /* ─── Error — warm brick stays warm even on cool field, signals danger ─── */
-  --error:      oklch(0.660 0.155 32);            /* 5.38:1 vs bg-panel (AA) */
-  --error-wash: oklch(0.300 0.065 32);
-  --error-glow: oklch(0.660 0.155 32 / 0.40);
+  --error:           oklch(0.660 0.155 32);            /* 5.38:1 vs bg-panel (AA) */
+  --error-wash:      oklch(0.300 0.065 32);
+  --error-glow:      oklch(0.660 0.155 32 / 0.40);
+  --error-wash-tint: oklch(0.660 0.155 32 / 0.04);     /* ghost bg for subtle error rows */
 
   /* ─── Shadows — deeper/cooler ─── */
   --shadow-sm:  0 1px  2px oklch(0.100 0.012 250 / 0.45);
@@ -842,11 +860,11 @@ body {
 }
 
 .sidebar-profile-card-connected {
-  background-color: var(--connected-wash);
+  background-color: var(--connected-wash-base);
 }
 
 .sidebar-profile-card-connected:hover {
-  background-color: var(--connected-wash);
+  background-color: var(--connected-wash-hover);
 }
 
 /* ─── Drag Handle ────────────────────────────────── */
@@ -3442,7 +3460,7 @@ dialog::backdrop {
 .cd-add-user-btn:hover {
   border-color: var(--accent);
   color: var(--accent);
-  background-color: var(--focus-ring-wash);
+  background-color: var(--focus-ring-wash-subtle);
 }
 
 /* ─── Sidebar User Picker (multi-user connect) ───── */
@@ -3803,7 +3821,7 @@ dialog::backdrop {
 .sftp-split-handle:hover {
   background-color: var(--accent);
   width: 4px;
-  box-shadow: 0 0 8px var(--connected-glow);
+  box-shadow: 0 0 8px var(--accent-glow);
 }
 
 /* ─── SFTP Pane ──────────────────────────────────── */
@@ -4320,7 +4338,7 @@ dialog::backdrop {
 
 .sftp-state-error {
   color: var(--danger);
-  background-color: var(--error-wash);
+  background-color: var(--error-wash-tint);
   border-radius: var(--radius-md);
   margin: 8px;
   padding: 16px;
@@ -4641,7 +4659,7 @@ dialog::backdrop {
 }
 
 .transfer-failed {
-  background-color: var(--error-wash);
+  background-color: var(--error-wash-tint);
 }
 
 .transfer-failed .transfer-info::before {
@@ -5245,7 +5263,7 @@ dialog::backdrop {
 /* ─── Search Matches ─────────────────────────────── */
 
 .file-viewer-match {
-  background-color: var(--warning-wash);
+  background-color: var(--warning-wash-match);
   color: inherit;
   border-radius: 2px;
   padding: 0 1px;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -137,6 +137,101 @@
   /* ─── The single luminous trick (replaces glassmorphism entirely) ─── */
   /* a 4%-white top hairline simulating the lamp catching a raised plane's edge */
   --lit-edge: inset 0 1px 0 oklch(1 0 0 / 0.04);
+
+  /* ─── State glow tokens — semantic-state rgba() replaced with theme-aware vars ─── */
+  /* Previously hardcoded hue-bearing rgba(); now token-driven so DARK can override.  */
+  /* Focus ring / keyboard state */
+  --focus-ring-wash:   oklch(0.760 0.130 var(--hue-accent) / 0.12); /* replaces blue rgba focus glows */
+  /* Drag-over / drop state */
+  --drag-accent-wash:  oklch(0.300 0.040 var(--hue-accent) / 0.85);
+  --drag-accent-border: oklch(0.760 0.130 var(--hue-accent) / 0.30);
+  /* Glow shadows for semantic states */
+  --connected-glow:    oklch(0.760 0.110 var(--hue-live) / 0.50);
+  --warning-glow:      oklch(0.780 0.130 var(--hue-warn) / 0.40);
+  --error-glow:        oklch(0.640 0.150 var(--hue-error) / 0.40);
+  /* Terminal selection highlight — CSS mirror of THEMES[id].terminalTheme.selectionBackground.
+     SYNC RULE: when changing selection color, update BOTH this token AND themes.ts.
+     LAMPLIGHT: copper accent-wash at ~65% alpha (== old rgba(60,41,24,0.65)) */
+  --terminal-selection: oklch(0.300 0.040 64 / 0.65);
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   DARK THEME OVERRIDE — :root[data-theme="dark"]
+   Cool-slate field, retained desaturated copper accent.
+   "Cold instrument bay — copper still glints."
+   Only tokens whose values differ from LAMPLIGHT are declared here.
+   Typography, radii, motion, layout dims, font families: unchanged.
+   Back-compat aliases (--bg-primary etc.) auto-follow via var() chains.
+
+   WCAG AA verified (body text ≥4.5:1 vs --bg-panel L=0.205):
+     text-primary   oklch(0.945 0.006 250) → 15.25:1 (AAA)
+     text-secondary oklch(0.770 0.012 250) →  8.65:1 (AAA)
+     text-muted     oklch(0.620 0.014 250) →  4.92:1 (AA body, ≥4.5 required)
+     error          oklch(0.660 0.155  32) →  5.38:1 (AA)
+   ═══════════════════════════════════════════════════════════════ */
+
+:root[data-theme="dark"] {
+  /* ─── Hue anchors: neutrals go cool slate; accent/live/warn/error hues unchanged ─── */
+  --hue-neutral: 250;     /* was 62 warm → cool slate */
+  /* --hue-accent: 64  (copper kept) */
+  /* --hue-live:   165 (jade kept)   */
+  /* --hue-warn:    80 (kept)        */
+  /* --hue-error:   32 (kept)        */
+
+  /* ─── Backgrounds — deeper + cooler than LAMPLIGHT, lower chroma ─── */
+  --bg-abyss:    oklch(0.135 0.010 250);          /* #0c0e12 terminal canvas, deepest cool */
+  --bg-base:     oklch(0.170 0.011 250);          /* #131620 app/content pane */
+  --bg-panel:    oklch(0.205 0.012 250);          /* #1a1e29 sidebar/status/tabs */
+  --bg-raised:   oklch(0.250 0.013 250);          /* #242936 inputs/row hover */
+  --bg-raised-2: oklch(0.300 0.014 250);          /* #2f3543 pressed/active/selected */
+  --bg-dialog:   oklch(0.225 0.013 250);          /* #1f2531 modal surface */
+  --bg-overlay:  oklch(0.135 0.010 250 / 0.62);
+
+  /* ─── Hairlines — cool, opaque ─── */
+  --hairline:        oklch(0.330 0.014 250);
+  --hairline-strong: oklch(0.430 0.016 250);
+  --border-subtle:   oklch(0.295 0.013 250);
+
+  /* ─── Text — cool off-white → cool graphite, NEVER #fff ─── */
+  --text-primary:   oklch(0.945 0.006 250);       /* 15.25:1 vs bg-panel (AAA) */
+  --text-secondary: oklch(0.770 0.012 250);       /*  8.65:1 vs bg-panel (AAA) */
+  --text-muted:     oklch(0.620 0.014 250);       /*  4.92:1 vs bg-panel (AA body) */
+  --text-faint:     oklch(0.500 0.014 250);       /* decorative only, not body */
+
+  /* ─── Accent — copper kept, chroma trimmed ~10% (lit metal in a cold room) ─── */
+  --accent:        oklch(0.770 0.118 64);
+  --accent-strong: oklch(0.715 0.135 58);
+  --accent-on:     oklch(0.200 0.018 250);        /* cool near-black text ON accent fill */
+  --accent-wash:   oklch(0.300 0.045 64);
+  --focus-ring:    oklch(0.810 0.120 66);
+  --focus-ring-wash: oklch(0.770 0.118 64 / 0.14);
+  --drag-accent-wash:   oklch(0.300 0.045 64 / 0.85);
+  --drag-accent-border: oklch(0.770 0.118 64 / 0.30);
+
+  /* ─── Connected/live — jade kept vivid so LIVE pops on cool field ─── */
+  --connected:      oklch(0.775 0.115 165);       /* 8.8:1 vs bg-panel */
+  --connected-wash: oklch(0.300 0.045 165);
+  --connected-glow: oklch(0.775 0.115 165 / 0.50);
+
+  /* ─── Warning — ochre ─── */
+  --warning:      oklch(0.790 0.130 80);
+  --warning-wash: oklch(0.300 0.060 80);
+  --warning-glow: oklch(0.790 0.130 80 / 0.40);
+
+  /* ─── Error — warm brick stays warm even on cool field, signals danger ─── */
+  --error:      oklch(0.660 0.155 32);            /* 5.38:1 vs bg-panel (AA) */
+  --error-wash: oklch(0.300 0.065 32);
+  --error-glow: oklch(0.660 0.155 32 / 0.40);
+
+  /* ─── Shadows — deeper/cooler ─── */
+  --shadow-sm:  0 1px  2px oklch(0.100 0.012 250 / 0.45);
+  --shadow-md:  0 4px 12px oklch(0.100 0.012 250 / 0.55);
+  --shadow-lg:  0 8px 24px oklch(0.100 0.012 250 / 0.60);
+  --shadow-pop: 0 16px 40px oklch(0.100 0.012 250 / 0.65);
+
+  /* ─── Terminal selection — copper accent-wash, dark-tuned ─── */
+  /* SYNC RULE: matches THEMES.dark.terminalTheme.selectionBackground in src/lib/themes.ts */
+  --terminal-selection: oklch(0.300 0.045 64 / 0.65);
 }
 
 /* Honor reduced motion: kill transforms + the connecting pulse, keep opacity */
@@ -421,7 +516,7 @@ body {
 
 .sidebar-profile-btn-add:hover {
   color: var(--accent);
-  background-color: rgba(88, 166, 255, 0.12);
+  background-color: var(--focus-ring-wash);
 }
 
 .sidebar-profile-btn-delete:hover {
@@ -504,7 +599,7 @@ body {
 }
 
 .sidebar-error:hover {
-  background-color: rgba(248, 81, 73, 0.2);
+  background-color: var(--error-wash);
 }
 
 /* ─── Sidebar Header Actions & Banner ──────────────── */
@@ -560,13 +655,13 @@ body {
 }
 
 .sidebar-action-btn-primary {
-  background-color: rgba(88, 166, 255, 0.1) !important;
+  background-color: var(--focus-ring-wash) !important;
   color: var(--accent) !important;
-  border-color: rgba(88, 166, 255, 0.25) !important;
+  border-color: var(--drag-accent-border) !important;
 }
 
 .sidebar-action-btn-primary:hover {
-  background-color: rgba(88, 166, 255, 0.18) !important;
+  background-color: var(--drag-accent-wash) !important;
   border-color: var(--accent) !important;
 }
 
@@ -747,11 +842,11 @@ body {
 }
 
 .sidebar-profile-card-connected {
-  background-color: rgba(63, 185, 80, 0.04);
+  background-color: var(--connected-wash);
 }
 
 .sidebar-profile-card-connected:hover {
-  background-color: rgba(63, 185, 80, 0.07);
+  background-color: var(--connected-wash);
 }
 
 /* ─── Drag Handle ────────────────────────────────── */
@@ -821,18 +916,18 @@ body {
 
 .sidebar-status-dot-connected {
   background-color: var(--success);
-  box-shadow: 0 0 8px rgba(63, 185, 80, 0.5), 0 0 3px rgba(63, 185, 80, 0.3);
+  box-shadow: 0 0 8px var(--connected-glow), 0 0 3px var(--connected-glow);
 }
 
 .sidebar-status-dot-connecting {
   background-color: var(--warning);
-  box-shadow: 0 0 8px rgba(210, 153, 34, 0.4);
+  box-shadow: 0 0 8px var(--warning-glow);
   animation: status-pulse 1.5s ease-in-out infinite;
 }
 
 @keyframes status-pulse {
-  0%, 100% { opacity: 1; box-shadow: 0 0 8px rgba(210, 153, 34, 0.4); }
-  50% { opacity: 0.5; box-shadow: 0 0 4px rgba(210, 153, 34, 0.2); }
+  0%, 100% { opacity: 1; box-shadow: 0 0 8px var(--warning-glow); }
+  50% { opacity: 0.5; box-shadow: 0 0 4px var(--warning-glow); }
 }
 
 .sidebar-status-dot-idle {
@@ -1002,17 +1097,17 @@ body {
 
 .indicator-success {
   background-color: var(--success);
-  box-shadow: 0 0 8px rgba(63, 185, 80, 0.5), 0 0 3px rgba(63, 185, 80, 0.3);
+  box-shadow: 0 0 8px var(--connected-glow), 0 0 3px var(--connected-glow);
 }
 
 .indicator-warning {
   background-color: var(--warning);
-  box-shadow: 0 0 6px rgba(210, 153, 34, 0.4);
+  box-shadow: 0 0 6px var(--warning-glow);
 }
 
 .indicator-error {
   background-color: var(--danger);
-  box-shadow: 0 0 6px rgba(248, 81, 73, 0.4);
+  box-shadow: 0 0 6px var(--error-glow);
 }
 
 .indicator-muted {
@@ -1325,7 +1420,7 @@ body {
   height: 6px;
   border-radius: 50%;
   background-color: var(--success);
-  box-shadow: 0 0 6px rgba(63, 185, 80, 0.4);
+  box-shadow: 0 0 6px var(--connected-glow);
   flex-shrink: 0;
 }
 
@@ -2387,7 +2482,7 @@ dialog::backdrop {
   align-items: flex-start;
   gap: 10px;
   background-color: var(--warning-subtle);
-  border: 1px solid rgba(210, 153, 34, 0.3);
+  border: 1px solid var(--warning-wash);
   border-radius: var(--radius-md);
   padding: 12px 14px;
   color: var(--text-primary);
@@ -2446,7 +2541,7 @@ dialog::backdrop {
 }
 
 .hk-modal-warning {
-  border-color: rgba(210, 153, 34, 0.3);
+  border-color: var(--warning-wash);
 }
 
 /* ─── Header ─── */
@@ -2543,7 +2638,7 @@ dialog::backdrop {
   margin: 16px 24px 0;
   padding: 12px 14px;
   background-color: var(--warning-subtle);
-  border: 1px solid rgba(210, 153, 34, 0.25);
+  border: 1px solid var(--warning-wash);
   border-radius: var(--radius-md);
 }
 
@@ -2698,7 +2793,7 @@ dialog::backdrop {
 .hk-fp-copy:hover {
   color: var(--accent);
   background-color: var(--accent-subtle);
-  border-color: rgba(56, 139, 253, 0.3);
+  border-color: var(--drag-accent-border);
 }
 
 .hk-fp-copied {
@@ -3347,7 +3442,7 @@ dialog::backdrop {
 .cd-add-user-btn:hover {
   border-color: var(--accent);
   color: var(--accent);
-  background-color: rgba(56, 139, 253, 0.04);
+  background-color: var(--focus-ring-wash);
 }
 
 /* ─── Sidebar User Picker (multi-user connect) ───── */
@@ -3708,7 +3803,7 @@ dialog::backdrop {
 .sftp-split-handle:hover {
   background-color: var(--accent);
   width: 4px;
-  box-shadow: 0 0 8px rgba(88, 166, 255, 0.3);
+  box-shadow: 0 0 8px var(--connected-glow);
 }
 
 /* ─── SFTP Pane ──────────────────────────────────── */
@@ -3798,9 +3893,9 @@ dialog::backdrop {
 }
 
 .sftp-action-btn-active:hover {
-  background-color: rgba(88, 166, 255, 0.12);
+  background-color: var(--focus-ring-wash);
   color: var(--accent);
-  border-color: rgba(88, 166, 255, 0.25);
+  border-color: var(--drag-accent-border);
 }
 
 /* ─── PathBar (nav buttons + always-editable input) ───── */
@@ -3958,11 +4053,11 @@ dialog::backdrop {
 
 .sftp-row-selected {
   background-color: var(--accent-subtle) !important;
-  border-bottom-color: rgba(56, 139, 253, 0.1) !important;
+  border-bottom-color: var(--drag-accent-border) !important;
 }
 
 .sftp-row-selected:hover {
-  background-color: rgba(56, 139, 253, 0.2) !important;
+  background-color: var(--accent-wash) !important;
 }
 
 .sftp-row-selected .sftp-file-name {
@@ -4069,7 +4164,7 @@ dialog::backdrop {
 
 .sftp-search-input-wrap:focus-within {
   border-color: var(--accent);
-  box-shadow: 0 0 0 2px rgba(56, 139, 253, 0.1);
+  box-shadow: 0 0 0 2px var(--focus-ring-wash);
 }
 
 .sftp-search-icon {
@@ -4225,7 +4320,7 @@ dialog::backdrop {
 
 .sftp-state-error {
   color: var(--danger);
-  background-color: rgba(248, 81, 73, 0.03);
+  background-color: var(--error-wash);
   border-radius: var(--radius-md);
   margin: 8px;
   padding: 16px;
@@ -4546,7 +4641,7 @@ dialog::backdrop {
 }
 
 .transfer-failed {
-  background-color: rgba(248, 81, 73, 0.04);
+  background-color: var(--error-wash);
 }
 
 .transfer-failed .transfer-info::before {
@@ -4973,7 +5068,7 @@ dialog::backdrop {
 .file-viewer-search-btn:hover {
   color: var(--accent);
   background-color: var(--accent-subtle);
-  border-color: rgba(56, 139, 253, 0.3);
+  border-color: var(--drag-accent-border);
 }
 
 .file-viewer-close {
@@ -5150,14 +5245,14 @@ dialog::backdrop {
 /* ─── Search Matches ─────────────────────────────── */
 
 .file-viewer-match {
-  background-color: rgba(210, 153, 34, 0.35);
+  background-color: var(--warning-wash);
   color: inherit;
   border-radius: 2px;
   padding: 0 1px;
 }
 
 .file-viewer-match-active {
-  background-color: rgba(210, 153, 34, 0.7);
+  background-color: var(--warning);
   outline: 1px solid var(--warning);
   outline-offset: 0;
 }
@@ -5173,7 +5268,7 @@ dialog::backdrop {
   font-size: 12px;
   color: var(--warning);
   background-color: var(--warning-subtle);
-  border-bottom: 1px solid rgba(210, 153, 34, 0.25);
+  border-bottom: 1px solid var(--warning-wash);
   flex-shrink: 0;
   text-align: center;
 }
@@ -5411,7 +5506,7 @@ dialog::backdrop {
   background-color: var(--bg-secondary);
   border: 1px solid var(--danger);
   border-radius: 12px;
-  box-shadow: 0 0 0 1px rgba(248, 81, 73, 0.2), var(--shadow-xl);
+  box-shadow: 0 0 0 1px var(--error-glow), var(--shadow-xl);
   animation: vault-fade-in 200ms ease;
 }
 
@@ -5478,10 +5573,10 @@ dialog::backdrop {
 
 /* Keyboard-focused row (distinct from mouse-selected) */
 .sftp-row-focused {
-  outline: 1px solid rgba(88, 166, 255, 0.5);
+  outline: 1px solid var(--drag-accent-border);
   outline-offset: -1px;
   border-radius: var(--radius-sm);
-  background-color: rgba(56, 139, 253, 0.06);
+  background-color: var(--focus-ring-wash);
 }
 
 
@@ -5496,8 +5591,8 @@ dialog::backdrop {
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: rgba(56, 139, 253, 0.06);
-  border: 2px dashed rgba(88, 166, 255, 0.5);
+  background-color: var(--focus-ring-wash);
+  border: 2px dashed var(--drag-accent-border);
   border-radius: var(--radius-lg);
   pointer-events: none;
   animation: sftp-drop-fade-in 150ms ease-out;
@@ -5678,7 +5773,7 @@ dialog::backdrop {
   background-color: var(--bg-secondary);
   border: 1px solid var(--danger);
   border-radius: 16px;
-  box-shadow: 0 0 0 1px rgba(248, 81, 73, 0.2), var(--shadow-xl);
+  box-shadow: 0 0 0 1px var(--error-glow), var(--shadow-xl);
   animation: vault-fade-in 300ms ease;
 }
 

--- a/src/styles/terminal.css
+++ b/src/styles/terminal.css
@@ -45,10 +45,12 @@
   background-color: rgba(99, 92, 87, 0.50);
 }
 
-/* Selection color consistency — copper accent-wash, kept in sync with
-   TERMINAL_THEME.selectionBackground ("#3c2918a6") in src/lib/constants.ts */
+/* Selection color consistency — driven by CSS token, not a hardcoded rgba.
+   SYNC RULE: --terminal-selection in globals.css is the CSS mirror of
+   THEMES[id].terminalTheme.selectionBackground in src/lib/themes.ts.
+   Update both when changing the selection color for any theme. */
 .xterm .xterm-selection div {
-  background-color: rgba(60, 41, 24, 0.65) !important;
+  background-color: var(--terminal-selection) !important;
 }
 
 /* ═══════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

First item from the Voltius gap-analysis roadmap. Adds a real theme system to NexTerm: **LAMPLIGHT (default) + DARK**, persisted across restarts and applied instantly to the entire UI *and* live xterm terminals — no SSH session drop.

## What's included

- Theme preset module + type-guard/validator (`src/lib/themes.ts`)
- Persisted Zustand `themeStore` (key `nexterm-theme`) with rehydration validation
- Live xterm re-theming via `applyThemeToAllTerminals` (xterm v6 `options.theme` live setter)
- CSS `:root[data-theme="dark"]` override block + semantic-rgba tokenization
- FOUC-safe inline applier in `index.html` (parses the persist envelope before first paint)
- Theme toggle in `StatusBar`, next to the language toggle

## Architecture

Hybrid: **CSS `[data-theme]`** drives the ~60 UI tokens, **JS `themeStore`** drives xterm (which lives outside the CSS cascade). One-way `themeStore → useTerminal` dependency. DARK is a cool-slate reinterpretation that keeps a chroma-trimmed copper accent — not a mechanical inversion.

## Scope (v1)

In: LAMPLIGHT + DARK presets, persistence, FOUC prevention, live terminal theming, StatusBar toggle.
Deferred to v2 (named): true LIGHT theme (requires tokenizing all 69 rgba overlays), theme creator, theme import/export, per-theme fonts, full settings screen.

## Quality

- **120 tests green** (Vitest), `tsc --noEmit` clean
- **WCAG AA verified** — DARK body text ≥ 4.9:1 (primary 15:1)
- **Strict TDD** throughout (RED → GREEN per work unit)
- **Dual adversarial review** before PR: caught and fixed LAMPLIGHT opacity regressions (low-alpha `rgba()` were tokenized into opaque tokens → restored as alpha-bearing tokens with pixel-equivalence proof) and a corrupt-rehydration crash path; re-review verdict **GO**
- **Clean-room**: inspired by Voltius (AGPL-3.0) but independently implemented from public CSS standards — NexTerm stays MIT, zero copied code

## Commits

6 work-unit commits (A–F) + 1 fix commit. `size:exception` — ~500 lines across one cohesive feature, kept reviewable via per-unit commits.
