### PR TITLE
feat(terminal): opt-in cross-session command history

### DIFF
--- a/src/components/panel/SidePanel.test.tsx
+++ b/src/components/panel/SidePanel.test.tsx
@@ -28,6 +28,7 @@ vi.mock("../../lib/i18n", () => ({
       const labels: Record<string, string> = {
         "panel.sftp": "Files",
         "panel.tunnels": "Tunnels",
+        "panel.history": "History",
         "panel.close": "Close panel",
         "panel.region": "Session panel",
         "panel.sections": "Panel sections",
@@ -74,6 +75,12 @@ vi.mock("../../features/tunnel/TunnelManager", () => ({
   ),
 }));
 
+vi.mock("../../features/history/HistoryPanel", () => ({
+  HistoryPanel: ({ sessionId }: { sessionId: string }) => (
+    <div data-testid="history-panel" data-session-id={sessionId} />
+  ),
+}));
+
 import { SidePanel } from "./SidePanel";
 import { useSessionStore } from "../../stores/sessionStore";
 
@@ -81,7 +88,7 @@ const mockedUseSessionStore = vi.mocked(useSessionStore);
 
 function makeStoreState(
   panelOpen = false,
-  panelSection: "sftp" | "tunnel" | null = null,
+  panelSection: "sftp" | "tunnel" | "history" | null = null,
 ) {
   return {
     workspaces: {
@@ -285,5 +292,76 @@ describe("SidePanel — close button when open", () => {
     render(<SidePanel />);
     fireEvent.click(screen.getByRole("button", { name: "Close panel" }));
     expect(mockSetPanelOpen).toHaveBeenCalledWith("profile-1:user-1", false);
+  });
+});
+
+// ── History section (new) ─────────────────────────────────────────────────────
+
+describe("SidePanel — History button in rail", () => {
+  it("renders a History toggle button in the rail", () => {
+    render(<SidePanel />);
+    expect(
+      screen.getByRole("button", { name: "History" }),
+    ).toBeInTheDocument();
+  });
+
+  it("History button has aria-pressed=false when panel is closed", () => {
+    render(<SidePanel />);
+    expect(screen.getByRole("button", { name: "History" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("History button has aria-pressed=true when panel is open on history", () => {
+    _workspaceStoreState = makeStoreState(true, "history");
+    render(<SidePanel />);
+    expect(screen.getByRole("button", { name: "History" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
+  it("clicking History button calls setPanelSection(key, 'history') and setPanelOpen(key, true)", () => {
+    render(<SidePanel />);
+    fireEvent.click(screen.getByRole("button", { name: "History" }));
+    expect(mockSetPanelSection).toHaveBeenCalledWith(
+      "profile-1:user-1",
+      "history",
+    );
+    expect(mockSetPanelOpen).toHaveBeenCalledWith("profile-1:user-1", true);
+  });
+
+  it("clicking the already-active History button closes the panel", () => {
+    _workspaceStoreState = makeStoreState(true, "history");
+    render(<SidePanel />);
+    fireEvent.click(screen.getByRole("button", { name: "History" }));
+    expect(mockSetPanelOpen).toHaveBeenCalledWith("profile-1:user-1", false);
+  });
+});
+
+describe("SidePanel — HistoryPanel mount", () => {
+  it("renders HistoryPanel when panel is open on history", () => {
+    _workspaceStoreState = makeStoreState(true, "history");
+    render(<SidePanel />);
+    expect(screen.getByTestId("history-panel")).toBeInTheDocument();
+  });
+
+  it("does NOT render HistoryPanel when panel section is sftp", () => {
+    _workspaceStoreState = makeStoreState(true, "sftp");
+    render(<SidePanel />);
+    expect(screen.queryByTestId("history-panel")).not.toBeInTheDocument();
+  });
+
+  it("does NOT render HistoryPanel when panel section is tunnel", () => {
+    _workspaceStoreState = makeStoreState(true, "tunnel");
+    render(<SidePanel />);
+    expect(screen.queryByTestId("history-panel")).not.toBeInTheDocument();
+  });
+
+  it("panel title shows 'History' when section is history", () => {
+    _workspaceStoreState = makeStoreState(true, "history");
+    render(<SidePanel />);
+    expect(screen.getByText("History")).toBeInTheDocument();
   });
 });

--- a/src/components/panel/SidePanel.tsx
+++ b/src/components/panel/SidePanel.tsx
@@ -13,6 +13,7 @@ import { useWorkspaceStore, buildWorkspaceKey } from "../../stores/workspaceStor
 import { useSessionStore } from "../../stores/sessionStore";
 import { SftpBrowser } from "../../features/sftp/SftpBrowser";
 import { TunnelManager } from "../../features/tunnel/TunnelManager";
+import { HistoryPanel } from "../../features/history/HistoryPanel";
 import type { PanelSection } from "../../stores/workspaceStore";
 
 // ── SVG icons (inline, no external dep) ─────────────────────────────────────
@@ -70,6 +71,33 @@ function TunnelIcon() {
   );
 }
 
+function HistoryIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      aria-hidden="true"
+    >
+      <circle cx="8" cy="8" r="5.5" stroke="currentColor" strokeWidth="1.2" />
+      <path
+        d="M8 5v3.5l2 1.5"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M4.5 4L3 2.5M4.5 4l.5-1.5"
+        stroke="currentColor"
+        strokeWidth="1.1"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
 function CloseIcon() {
   return (
     <svg
@@ -121,7 +149,7 @@ export function SidePanel() {
 
   const sessionId = activeSession?.id ?? "";
 
-  function handleToggle(section: "sftp" | "tunnel") {
+  function handleToggle(section: "sftp" | "tunnel" | "history") {
     if (!workspaceKey) return;
     const isActive = panelOpen && panelSection === section;
     if (isActive) {
@@ -166,6 +194,17 @@ export function SidePanel() {
         >
           <TunnelIcon />
         </button>
+
+        <button
+          type="button"
+          aria-pressed={panelOpen && panelSection === "history"}
+          aria-label={t("panel.history")}
+          className={`side-panel-rail-btn${panelOpen && panelSection === "history" ? " side-panel-rail-btn-active" : ""}`}
+          onClick={() => handleToggle("history")}
+          title={t("panel.history")}
+        >
+          <HistoryIcon />
+        </button>
       </div>
 
       {/* Collapsible content pane */}
@@ -181,7 +220,11 @@ export function SidePanel() {
             {/* Header with close button */}
             <div className="side-panel-header">
               <span className="side-panel-title">
-                {panelSection === "sftp" ? t("panel.sftp") : t("panel.tunnels")}
+                {panelSection === "sftp"
+                  ? t("panel.sftp")
+                  : panelSection === "history"
+                    ? t("panel.history")
+                    : t("panel.tunnels")}
               </span>
               <button
                 type="button"
@@ -200,6 +243,13 @@ export function SidePanel() {
               )}
               {panelSection === "tunnel" && sessionId && (
                 <TunnelManager sessionId={sessionId} />
+              )}
+              {panelSection === "history" && sessionId && (
+                <HistoryPanel
+                  sessionId={sessionId}
+                  terminalId={activeSession?.activeTerminalId ?? null}
+                  host={activeSession?.host ?? ""}
+                />
               )}
             </div>
           </section>

--- a/src/features/history/HistoryPanel.test.tsx
+++ b/src/features/history/HistoryPanel.test.tsx
@@ -1,0 +1,387 @@
+// features/history/HistoryPanel.test.tsx
+// TDD RED phase — RTL tests for the command history side panel.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+// ── localStorage stub ─────────────────────────────────────────────────────────
+vi.hoisted(() => {
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, String(v)),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => void store.clear(),
+      key: (i: number) => [...store.keys()][i] ?? null,
+      get length() {
+        return store.size;
+      },
+    },
+  });
+});
+
+// ── i18n mock ─────────────────────────────────────────────────────────────────
+vi.mock("../../lib/i18n", () => ({
+  useI18n: () => ({
+    t: (k: string) => {
+      const labels: Record<string, string> = {
+        "history.empty": "No commands recorded yet",
+        "history.captureOff": "Command capture is disabled",
+        "history.enableCapture": "Enable capture to start recording commands",
+        "history.filter": "Filter commands...",
+        "history.filterByHost": "Filter to current host",
+        "history.copy": "Copy",
+        "history.insert": "Insert",
+        "history.execute": "Execute",
+        "history.delete": "Delete command",
+        "history.clearAll": "Clear all",
+        "history.captureToggleLabel": "Capture commands",
+        "history.noticeTitle": "Privacy notice",
+        "history.noticeMessage":
+          "Command history captures everything you type. Passwords entered at prompts may be recorded. You can disable capture or clear history at any time.",
+        "history.noticeDismiss": "Got it",
+      };
+      return labels[k] ?? k;
+    },
+  }),
+}));
+
+// ── commandHistoryStore mock ──────────────────────────────────────────────────
+const mockDeleteCommand = vi.fn();
+const mockClearAll = vi.fn();
+const mockToggleCapture = vi.fn();
+const mockDismissNotice = vi.fn();
+
+let _historyStoreState: {
+  entries: Array<{
+    id: string;
+    command: string;
+    timestamp: number;
+    sessionId: string;
+    host: string;
+  }>;
+  captureEnabled: boolean;
+  noticeAcknowledged: boolean;
+  addCommand: ReturnType<typeof vi.fn>;
+  deleteCommand: ReturnType<typeof vi.fn>;
+  clearAll: ReturnType<typeof vi.fn>;
+  toggleCapture: ReturnType<typeof vi.fn>;
+  dismissNotice: ReturnType<typeof vi.fn>;
+};
+
+vi.mock("../../stores/commandHistoryStore", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  useCommandHistoryStore: vi.fn((selector?: (s: any) => unknown) => {
+    if (typeof selector === "function") {
+      return selector(_historyStoreState);
+    }
+    return _historyStoreState;
+  }),
+}));
+
+// ── injectSnippet mock ────────────────────────────────────────────────────────
+const mockInjectSnippet = vi.fn().mockResolvedValue(undefined);
+vi.mock("../snippets/useSnippetInject", () => ({
+  injectSnippet: (...args: unknown[]) => mockInjectSnippet(...args),
+}));
+
+// ── clipboard mock ────────────────────────────────────────────────────────────
+Object.defineProperty(globalThis, "navigator", {
+  configurable: true,
+  value: {
+    ...globalThis.navigator,
+    clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+  },
+});
+
+import { HistoryPanel } from "./HistoryPanel";
+import { useCommandHistoryStore } from "../../stores/commandHistoryStore";
+
+const mockedUseCommandHistoryStore = vi.mocked(useCommandHistoryStore);
+
+function makeEntry(
+  id: string,
+  command: string,
+  host = "10.0.0.1",
+  sessionId = "sess-1",
+  timestamp = Date.now(),
+) {
+  return { id, command, timestamp, sessionId, host };
+}
+
+function makeStoreState(overrides: Partial<typeof _historyStoreState> = {}) {
+  return {
+    entries: [],
+    captureEnabled: false,
+    noticeAcknowledged: true, // suppressed by default in tests unless testing notice
+    addCommand: vi.fn(),
+    deleteCommand: mockDeleteCommand,
+    clearAll: mockClearAll,
+    toggleCapture: mockToggleCapture,
+    dismissNotice: mockDismissNotice,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  _historyStoreState = makeStoreState();
+  mockedUseCommandHistoryStore.mockImplementation(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (selector?: (s: any) => unknown) => {
+      if (typeof selector === "function") return selector(_historyStoreState);
+      return _historyStoreState;
+    },
+  );
+});
+
+// ── Empty state ───────────────────────────────────────────────────────────────
+
+describe("HistoryPanel — empty state", () => {
+  it("shows disabled-state message when captureEnabled is false and entries empty", () => {
+    render(<HistoryPanel sessionId="sess-1" terminalId="term-1" host="10.0.0.1" />);
+    expect(screen.getByText("Command capture is disabled")).toBeInTheDocument();
+  });
+
+  it("shows empty-list message when captureEnabled=true and entries empty", () => {
+    _historyStoreState = makeStoreState({ captureEnabled: true, entries: [] });
+    render(<HistoryPanel sessionId="sess-1" terminalId="term-1" host="10.0.0.1" />);
+    expect(screen.getByText("No commands recorded yet")).toBeInTheDocument();
+  });
+});
+
+// ── Entry list ────────────────────────────────────────────────────────────────
+
+describe("HistoryPanel — entry list", () => {
+  it("renders command text for each entry", () => {
+    _historyStoreState = makeStoreState({
+      captureEnabled: true,
+      entries: [makeEntry("e1", "ls -la"), makeEntry("e2", "git status")],
+    });
+    render(<HistoryPanel sessionId="sess-1" terminalId="term-1" host="10.0.0.1" />);
+    expect(screen.getByText("ls -la")).toBeInTheDocument();
+    expect(screen.getByText("git status")).toBeInTheDocument();
+  });
+});
+
+// ── Filter input ──────────────────────────────────────────────────────────────
+
+describe("HistoryPanel — filter input", () => {
+  it("renders a filter input", () => {
+    _historyStoreState = makeStoreState({
+      captureEnabled: true,
+      entries: [makeEntry("e1", "ls -la"), makeEntry("e2", "git status")],
+    });
+    render(<HistoryPanel sessionId="sess-1" terminalId="term-1" host="10.0.0.1" />);
+    expect(screen.getByPlaceholderText("Filter commands...")).toBeInTheDocument();
+  });
+
+  it("filters entries by command text", () => {
+    _historyStoreState = makeStoreState({
+      captureEnabled: true,
+      entries: [makeEntry("e1", "ls -la"), makeEntry("e2", "git status")],
+    });
+    render(<HistoryPanel sessionId="sess-1" terminalId="term-1" host="10.0.0.1" />);
+    fireEvent.change(screen.getByPlaceholderText("Filter commands..."), {
+      target: { value: "git" },
+    });
+    expect(screen.queryByText("ls -la")).not.toBeInTheDocument();
+    expect(screen.getByText("git status")).toBeInTheDocument();
+  });
+});
+
+// ── Filter by host ────────────────────────────────────────────────────────────
+
+describe("HistoryPanel — filter by current host", () => {
+  it("renders a filter-by-host toggle", () => {
+    _historyStoreState = makeStoreState({
+      captureEnabled: true,
+      entries: [
+        makeEntry("e1", "ls", "10.0.0.1"),
+        makeEntry("e2", "pwd", "10.0.0.2"),
+      ],
+    });
+    render(<HistoryPanel sessionId="sess-1" terminalId="term-1" host="10.0.0.1" />);
+    expect(
+      screen.getByRole("checkbox", { name: "Filter to current host" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows only entries matching the current host when toggle is checked", () => {
+    _historyStoreState = makeStoreState({
+      captureEnabled: true,
+      entries: [
+        makeEntry("e1", "ls", "10.0.0.1"),
+        makeEntry("e2", "pwd", "10.0.0.2"),
+      ],
+    });
+    render(<HistoryPanel sessionId="sess-1" terminalId="term-1" host="10.0.0.1" />);
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "Filter to current host" }),
+    );
+    expect(screen.getByText("ls")).toBeInTheDocument();
+    expect(screen.queryByText("pwd")).not.toBeInTheDocument();
+  });
+});
+
+// ── Copy button ───────────────────────────────────────────────────────────────
+
+describe("HistoryPanel — copy button", () => {
+  it("copies the command text to clipboard when copy button is clicked", async () => {
+    _historyStoreState = makeStoreState({
+      captureEnabled: true,
+      entries: [makeEntry("e1", "ls -la")],
+    });
+    render(<HistoryPanel sessionId="sess-1" terminalId="term-1" host="10.0.0.1" />);
+    fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("ls -la");
+  });
+});
+
+// ── Insert button ─────────────────────────────────────────────────────────────
+
+describe("HistoryPanel — insert button", () => {
+  it("calls injectSnippet with mode 'insert' when insert button is clicked", async () => {
+    _historyStoreState = makeStoreState({
+      captureEnabled: true,
+      entries: [makeEntry("e1", "git pull")],
+    });
+    render(<HistoryPanel sessionId="sess-1" terminalId="term-1" host="10.0.0.1" />);
+    fireEvent.click(screen.getByRole("button", { name: "Insert" }));
+    expect(mockInjectSnippet).toHaveBeenCalledWith(
+      "sess-1",
+      "term-1",
+      "git pull",
+      "insert",
+    );
+  });
+});
+
+// ── Execute button ────────────────────────────────────────────────────────────
+
+describe("HistoryPanel — execute button", () => {
+  it("calls injectSnippet with mode 'execute' when execute button is clicked", async () => {
+    _historyStoreState = makeStoreState({
+      captureEnabled: true,
+      entries: [makeEntry("e1", "make build")],
+    });
+    render(<HistoryPanel sessionId="sess-1" terminalId="term-1" host="10.0.0.1" />);
+    fireEvent.click(screen.getByRole("button", { name: "Execute" }));
+    expect(mockInjectSnippet).toHaveBeenCalledWith(
+      "sess-1",
+      "term-1",
+      "make build",
+      "execute",
+    );
+  });
+});
+
+// ── Delete button ─────────────────────────────────────────────────────────────
+
+describe("HistoryPanel — delete button", () => {
+  it("calls store.deleteCommand(id) when delete button is clicked", () => {
+    _historyStoreState = makeStoreState({
+      captureEnabled: true,
+      entries: [makeEntry("entry-xyz", "rm -rf /tmp/test")],
+    });
+    render(<HistoryPanel sessionId="sess-1" terminalId="term-1" host="10.0.0.1" />);
+    fireEvent.click(screen.getByRole("button", { name: "Delete command" }));
+    expect(mockDeleteCommand).toHaveBeenCalledWith("entry-xyz");
+  });
+});
+
+// ── Clear all button ──────────────────────────────────────────────────────────
+
+describe("HistoryPanel — clear all button", () => {
+  it("renders a clear-all button", () => {
+    _historyStoreState = makeStoreState({
+      captureEnabled: true,
+      entries: [makeEntry("e1", "ls")],
+    });
+    render(<HistoryPanel sessionId="sess-1" terminalId="term-1" host="10.0.0.1" />);
+    expect(screen.getByRole("button", { name: "Clear all" })).toBeInTheDocument();
+  });
+
+  it("calls store.clearAll() when clear-all button is clicked and confirmed", () => {
+    _historyStoreState = makeStoreState({
+      captureEnabled: true,
+      entries: [makeEntry("e1", "ls")],
+    });
+    // Use window.confirm mock
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    render(<HistoryPanel sessionId="sess-1" terminalId="term-1" host="10.0.0.1" />);
+    fireEvent.click(screen.getByRole("button", { name: "Clear all" }));
+    expect(mockClearAll).toHaveBeenCalledOnce();
+    vi.restoreAllMocks();
+  });
+
+  it("does NOT call clearAll when confirmation is cancelled", () => {
+    _historyStoreState = makeStoreState({
+      captureEnabled: true,
+      entries: [makeEntry("e1", "ls")],
+    });
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+    render(<HistoryPanel sessionId="sess-1" terminalId="term-1" host="10.0.0.1" />);
+    fireEvent.click(screen.getByRole("button", { name: "Clear all" }));
+    expect(mockClearAll).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+});
+
+// ── Capture toggle ────────────────────────────────────────────────────────────
+
+describe("HistoryPanel — capture toggle", () => {
+  it("renders a capture toggle switch", () => {
+    render(<HistoryPanel sessionId="sess-1" terminalId="term-1" host="10.0.0.1" />);
+    expect(
+      screen.getByRole("checkbox", { name: "Capture commands" }),
+    ).toBeInTheDocument();
+  });
+
+  it("capture toggle reflects captureEnabled=false", () => {
+    render(<HistoryPanel sessionId="sess-1" terminalId="term-1" host="10.0.0.1" />);
+    const toggle = screen.getByRole("checkbox", { name: "Capture commands" });
+    expect(toggle).not.toBeChecked();
+  });
+
+  it("capture toggle reflects captureEnabled=true", () => {
+    _historyStoreState = makeStoreState({ captureEnabled: true });
+    render(<HistoryPanel sessionId="sess-1" terminalId="term-1" host="10.0.0.1" />);
+    const toggle = screen.getByRole("checkbox", { name: "Capture commands" });
+    expect(toggle).toBeChecked();
+  });
+
+  it("calls store.toggleCapture() when toggle is clicked", () => {
+    render(<HistoryPanel sessionId="sess-1" terminalId="term-1" host="10.0.0.1" />);
+    fireEvent.click(screen.getByRole("checkbox", { name: "Capture commands" }));
+    expect(mockToggleCapture).toHaveBeenCalledOnce();
+  });
+});
+
+// ── First-use privacy notice ──────────────────────────────────────────────────
+
+describe("HistoryPanel — privacy notice", () => {
+  it("shows notice when noticeAcknowledged=false", () => {
+    _historyStoreState = makeStoreState({ noticeAcknowledged: false });
+    render(<HistoryPanel sessionId="sess-1" terminalId="term-1" host="10.0.0.1" />);
+    expect(screen.getByText("Privacy notice")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Command history captures everything/),
+    ).toBeInTheDocument();
+  });
+
+  it("hides notice when noticeAcknowledged=true", () => {
+    // Default makeStoreState has noticeAcknowledged: true
+    render(<HistoryPanel sessionId="sess-1" terminalId="term-1" host="10.0.0.1" />);
+    expect(screen.queryByText("Privacy notice")).not.toBeInTheDocument();
+  });
+
+  it("calls store.dismissNotice() when 'Got it' button is clicked", () => {
+    _historyStoreState = makeStoreState({ noticeAcknowledged: false });
+    render(<HistoryPanel sessionId="sess-1" terminalId="term-1" host="10.0.0.1" />);
+    fireEvent.click(screen.getByRole("button", { name: "Got it" }));
+    expect(mockDismissNotice).toHaveBeenCalledOnce();
+  });
+});

--- a/src/features/history/HistoryPanel.tsx
+++ b/src/features/history/HistoryPanel.tsx
@@ -1,0 +1,181 @@
+// features/history/HistoryPanel.tsx — Command history side panel
+//
+// Displays per-session typed command history with filter, copy, insert,
+// execute (via injectSnippet), per-entry delete, and clear-all actions.
+//
+// SECURITY:
+//   - captureEnabled defaults to FALSE (opt-in). This panel displays an
+//     explicit toggle and a first-use privacy notice explaining the risk.
+//   - When capture is OFF, an explanatory empty state is shown.
+//   - The one-time notice is shown until noticeAcknowledged=true in the store.
+
+import { useState } from "react";
+import { useI18n } from "../../lib/i18n";
+import { useCommandHistoryStore } from "../../stores/commandHistoryStore";
+import { injectSnippet } from "../snippets/useSnippetInject";
+
+// ── Props ─────────────────────────────────────────────────────────────────────
+
+interface HistoryPanelProps {
+  sessionId: string;
+  terminalId: string | null | undefined;
+  host: string;
+}
+
+// ── HistoryPanel ──────────────────────────────────────────────────────────────
+
+export function HistoryPanel({ sessionId, terminalId, host }: HistoryPanelProps) {
+  const { t } = useI18n();
+
+  const entries = useCommandHistoryStore((s) => s.entries);
+  const captureEnabled = useCommandHistoryStore((s) => s.captureEnabled);
+  const noticeAcknowledged = useCommandHistoryStore((s) => s.noticeAcknowledged);
+  const toggleCapture = useCommandHistoryStore((s) => s.toggleCapture);
+  const deleteCommand = useCommandHistoryStore((s) => s.deleteCommand);
+  const clearAll = useCommandHistoryStore((s) => s.clearAll);
+  const dismissNotice = useCommandHistoryStore((s) => s.dismissNotice);
+
+  const [filterText, setFilterText] = useState("");
+  const [filterByHost, setFilterByHost] = useState(false);
+
+  // ── Filtering ───────────────────────────────────────────────────────────────
+  const visible = entries.filter((e) => {
+    if (filterByHost && e.host !== host) return false;
+    if (filterText && !e.command.toLowerCase().includes(filterText.toLowerCase()))
+      return false;
+    return true;
+  });
+
+  // ── Handlers ────────────────────────────────────────────────────────────────
+  function handleCopy(command: string) {
+    void navigator.clipboard.writeText(command);
+  }
+
+  function handleInsert(command: string) {
+    void injectSnippet(sessionId, terminalId, command, "insert");
+  }
+
+  function handleExecute(command: string) {
+    void injectSnippet(sessionId, terminalId, command, "execute");
+  }
+
+  function handleDelete(id: string) {
+    deleteCommand(id);
+  }
+
+  function handleClearAll() {
+    if (window.confirm(t("history.clearAll") + "?")) {
+      clearAll();
+    }
+  }
+
+  // ── Render ──────────────────────────────────────────────────────────────────
+  return (
+    <div className="history-panel">
+      {/* Privacy notice — shown until acknowledged */}
+      {!noticeAcknowledged && (
+        <div className="history-notice" role="alert">
+          <strong>{t("history.noticeTitle")}</strong>
+          <p>{t("history.noticeMessage")}</p>
+          <button type="button" onClick={() => dismissNotice()}>
+            {t("history.noticeDismiss")}
+          </button>
+        </div>
+      )}
+
+      {/* Header toolbar — capture toggle + clear-all */}
+      <div className="history-toolbar">
+        <label className="history-capture-toggle">
+          <input
+            type="checkbox"
+            aria-label={t("history.captureToggleLabel")}
+            checked={captureEnabled}
+            onChange={() => toggleCapture()}
+          />
+          <span>{t("history.captureToggleLabel")}</span>
+        </label>
+
+        <button
+          type="button"
+          className="history-clear-btn"
+          onClick={handleClearAll}
+          aria-label={t("history.clearAll")}
+        >
+          {t("history.clearAll")}
+        </button>
+      </div>
+
+      {/* Filter row */}
+      {captureEnabled && (
+        <div className="history-filters">
+          <input
+            type="text"
+            className="history-filter-input"
+            placeholder={t("history.filter")}
+            value={filterText}
+            onChange={(e) => setFilterText(e.target.value)}
+          />
+          <label className="history-host-filter">
+            <input
+              type="checkbox"
+              aria-label={t("history.filterByHost")}
+              checked={filterByHost}
+              onChange={(e) => setFilterByHost(e.target.checked)}
+            />
+            <span>{t("history.filterByHost")}</span>
+          </label>
+        </div>
+      )}
+
+      {/* Entry list or empty state */}
+      {!captureEnabled ? (
+        <div className="history-empty">
+          <p>{t("history.captureOff")}</p>
+          <p className="history-empty-hint">{t("history.enableCapture")}</p>
+        </div>
+      ) : visible.length === 0 ? (
+        <div className="history-empty">
+          <p>{t("history.empty")}</p>
+        </div>
+      ) : (
+        <ul className="history-list" aria-label="command history">
+          {visible.map((entry) => (
+            <li key={entry.id} className="history-entry">
+              <span className="history-entry-command">{entry.command}</span>
+              <div className="history-entry-actions">
+                <button
+                  type="button"
+                  aria-label={t("history.copy")}
+                  onClick={() => handleCopy(entry.command)}
+                >
+                  {t("history.copy")}
+                </button>
+                <button
+                  type="button"
+                  aria-label={t("history.insert")}
+                  onClick={() => handleInsert(entry.command)}
+                >
+                  {t("history.insert")}
+                </button>
+                <button
+                  type="button"
+                  aria-label={t("history.execute")}
+                  onClick={() => handleExecute(entry.command)}
+                >
+                  {t("history.execute")}
+                </button>
+                <button
+                  type="button"
+                  aria-label={t("history.delete")}
+                  onClick={() => handleDelete(entry.id)}
+                >
+                  {t("history.delete")}
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/features/history/lineBufferReducer.test.ts
+++ b/src/features/history/lineBufferReducer.test.ts
@@ -8,7 +8,6 @@ import { describe, it, expect } from "vitest";
 import {
   reduceLineBuffer,
   makeLineBufferState,
-  type LineBufferState,
 } from "./lineBufferReducer";
 
 // ── Initial state ─────────────────────────────────────────────────────────────
@@ -270,6 +269,49 @@ describe("lineBufferReducer — buffer cap", () => {
     s = reduceLineBuffer(s, "x".repeat(2049));
     s = reduceLineBuffer(s, "ok");
     expect(s.buffer).toBe("ok");
+  });
+});
+
+// ── Cross-chunk escape state (inEscSeq / inSS3 persists between chunks) ──────
+//
+// The reducer carries escape-sequence state across calls. These tests verify
+// that a sequence split across two onData chunks is handled correctly and no
+// char leaks into the buffer.
+
+describe("lineBufferReducer — cross-chunk escape state (MINOR-3)", () => {
+  it("CSI split: feeding 'ls\\x1b' then '[A' keeps buffer as 'ls'", () => {
+    // Simulates an up-arrow split: chunk1 ends with bare ESC, chunk2 has '[A'
+    let s = makeLineBufferState();
+    s = reduceLineBuffer(s, "ls\x1b");
+    // inEscSeq must be true after chunk1
+    expect(s.inEscSeq).toBe(true);
+    s = reduceLineBuffer(s, "[A");
+    // '[' is an intermediate CSI char; 'A' is the letter terminator
+    expect(s.buffer).toBe("ls");
+    expect(s.inEscSeq).toBe(false);
+    expect(s.flushed).toBeUndefined();
+  });
+
+  it("CSI split: buffer flushes correctly on \\r after cross-chunk sequence", () => {
+    let s = makeLineBufferState();
+    s = reduceLineBuffer(s, "ls\x1b");
+    s = reduceLineBuffer(s, "[A\r");
+    // The up-arrow should be eaten; only 'ls' should flush
+    expect(s.flushed).toBe("ls");
+    expect(s.buffer).toBe("");
+  });
+
+  it("SS3 split: feeding 'x\\x1b' then 'OP' (F1) keeps buffer as 'x'", () => {
+    // ESC O is SS3 introducer, P is the F1 terminator — split across two chunks
+    let s = makeLineBufferState();
+    s = reduceLineBuffer(s, "x\x1b");
+    expect(s.inEscSeq).toBe(true);
+    s = reduceLineBuffer(s, "OP");
+    // 'O' transitions to inSS3; 'P' terminates it — 'x' must remain, no leakage
+    expect(s.buffer).toBe("x");
+    expect(s.inEscSeq).toBe(false);
+    expect(s.inSS3).toBe(false);
+    expect(s.flushed).toBeUndefined();
   });
 });
 

--- a/src/features/history/lineBufferReducer.test.ts
+++ b/src/features/history/lineBufferReducer.test.ts
@@ -1,0 +1,296 @@
+// features/history/lineBufferReducer.test.ts
+// TDD RED phase — pure reducer for capturing typed commands from xterm onData stream.
+//
+// The reducer processes raw xterm.js onData chunks and maintains a line buffer
+// that flushes when the user presses Enter (\r).
+
+import { describe, it, expect } from "vitest";
+import {
+  reduceLineBuffer,
+  makeLineBufferState,
+  type LineBufferState,
+} from "./lineBufferReducer";
+
+// ── Initial state ─────────────────────────────────────────────────────────────
+
+describe("lineBufferReducer — makeLineBufferState", () => {
+  it("returns empty buffer and inEscSeq false", () => {
+    const state = makeLineBufferState();
+    expect(state.buffer).toBe("");
+    expect(state.inEscSeq).toBe(false);
+  });
+});
+
+// ── Printable char accumulation ───────────────────────────────────────────────
+
+describe("lineBufferReducer — printable chars", () => {
+  it("appends printable ASCII chars to the buffer", () => {
+    let s = makeLineBufferState();
+    s = reduceLineBuffer(s, "l");
+    s = reduceLineBuffer(s, "s");
+    s = reduceLineBuffer(s, " ");
+    s = reduceLineBuffer(s, "-");
+    s = reduceLineBuffer(s, "l");
+    expect(s.buffer).toBe("ls -l");
+    expect(s.flushed).toBeUndefined();
+  });
+
+  it("handles a whole printable string in one chunk", () => {
+    let s = makeLineBufferState();
+    s = reduceLineBuffer(s, "git status");
+    expect(s.buffer).toBe("git status");
+  });
+
+  it("does not flush on printable input (flushed stays absent)", () => {
+    const s = reduceLineBuffer(makeLineBufferState(), "hello");
+    expect(s.flushed).toBeUndefined();
+  });
+});
+
+// ── Backspace ─────────────────────────────────────────────────────────────────
+
+describe("lineBufferReducer — backspace (\\x7f / \\b)", () => {
+  it("removes the last char on \\x7f (DEL)", () => {
+    let s = makeLineBufferState();
+    s = reduceLineBuffer(s, "abc");
+    s = reduceLineBuffer(s, "\x7f");
+    expect(s.buffer).toBe("ab");
+  });
+
+  it("removes the last char on \\b (BS)", () => {
+    let s = makeLineBufferState();
+    s = reduceLineBuffer(s, "xyz");
+    s = reduceLineBuffer(s, "\b");
+    expect(s.buffer).toBe("xy");
+  });
+
+  it("does nothing on backspace when buffer is empty", () => {
+    const s = reduceLineBuffer(makeLineBufferState(), "\x7f");
+    expect(s.buffer).toBe("");
+  });
+
+  it("handles multiple backspaces correctly", () => {
+    let s = makeLineBufferState();
+    s = reduceLineBuffer(s, "hello");
+    s = reduceLineBuffer(s, "\x7f\x7f\x7f");
+    expect(s.buffer).toBe("he");
+  });
+
+  it("correctly removes multi-byte (emoji/CJK) last char via grapheme-safe slice", () => {
+    let s = makeLineBufferState();
+    s = reduceLineBuffer(s, "hi");
+    // Add an emoji (multi-codepoint)
+    s = reduceLineBuffer(s, "😀");
+    s = reduceLineBuffer(s, "\x7f");
+    // After backspace, emoji should be removed, leaving "hi"
+    expect(s.buffer).toBe("hi");
+  });
+});
+
+// ── Ctrl-C reset ──────────────────────────────────────────────────────────────
+
+describe("lineBufferReducer — Ctrl-C (\\x03)", () => {
+  it("resets buffer to empty (command cancelled)", () => {
+    let s = makeLineBufferState();
+    s = reduceLineBuffer(s, "sudo rm -rf");
+    s = reduceLineBuffer(s, "\x03");
+    expect(s.buffer).toBe("");
+    expect(s.flushed).toBeUndefined();
+  });
+
+  it("does not flush (flushed stays absent)", () => {
+    let s = makeLineBufferState();
+    s = reduceLineBuffer(s, "cmd");
+    s = reduceLineBuffer(s, "\x03");
+    expect(s.flushed).toBeUndefined();
+  });
+});
+
+// ── Ctrl-U reset ──────────────────────────────────────────────────────────────
+
+describe("lineBufferReducer — Ctrl-U (\\x15)", () => {
+  it("resets buffer to empty (line cleared)", () => {
+    let s = makeLineBufferState();
+    s = reduceLineBuffer(s, "partial command");
+    s = reduceLineBuffer(s, "\x15");
+    expect(s.buffer).toBe("");
+    expect(s.flushed).toBeUndefined();
+  });
+});
+
+// ── Enter flush ───────────────────────────────────────────────────────────────
+
+describe("lineBufferReducer — Enter (\\r) flush", () => {
+  it("flushes non-empty buffer and returns flushed command", () => {
+    let s = makeLineBufferState();
+    s = reduceLineBuffer(s, "ls -la");
+    s = reduceLineBuffer(s, "\r");
+    expect(s.flushed).toBe("ls -la");
+    expect(s.buffer).toBe("");
+  });
+
+  it("trims whitespace from the flushed command", () => {
+    let s = makeLineBufferState();
+    s = reduceLineBuffer(s, "  git status  ");
+    s = reduceLineBuffer(s, "\r");
+    expect(s.flushed).toBe("git status");
+  });
+
+  it("does NOT flush when buffer is empty after trim", () => {
+    let s = makeLineBufferState();
+    s = reduceLineBuffer(s, "   ");
+    s = reduceLineBuffer(s, "\r");
+    expect(s.flushed).toBeUndefined();
+    expect(s.buffer).toBe("");
+  });
+
+  it("resets the buffer after flush", () => {
+    let s = makeLineBufferState();
+    s = reduceLineBuffer(s, "cmd1");
+    s = reduceLineBuffer(s, "\r");
+    expect(s.buffer).toBe("");
+    // Next input goes to fresh buffer
+    s = reduceLineBuffer(s, "cmd2");
+    expect(s.buffer).toBe("cmd2");
+  });
+
+  it("flushed is absent when pressing Enter on empty buffer", () => {
+    const s = reduceLineBuffer(makeLineBufferState(), "\r");
+    expect(s.flushed).toBeUndefined();
+  });
+});
+
+// ── Escape sequence skip ──────────────────────────────────────────────────────
+
+describe("lineBufferReducer — ESC sequence skip (\\x1b)", () => {
+  it("does not accumulate up-arrow (\\x1b[A) into buffer", () => {
+    let s = makeLineBufferState();
+    s = reduceLineBuffer(s, "ls");
+    s = reduceLineBuffer(s, "\x1b[A"); // up-arrow
+    expect(s.buffer).toBe("ls");
+    expect(s.inEscSeq).toBe(false);
+  });
+
+  it("does not accumulate delete-key sequence (\\x1b[3~)", () => {
+    let s = makeLineBufferState();
+    s = reduceLineBuffer(s, "ab");
+    s = reduceLineBuffer(s, "\x1b[3~");
+    expect(s.buffer).toBe("ab");
+    expect(s.inEscSeq).toBe(false);
+  });
+
+  it("does not accumulate F1 sequence (\\x1bOP)", () => {
+    let s = makeLineBufferState();
+    s = reduceLineBuffer(s, "abc");
+    s = reduceLineBuffer(s, "\x1bOP");
+    expect(s.buffer).toBe("abc");
+    expect(s.inEscSeq).toBe(false);
+  });
+
+  it("can resume accumulating printable chars after an escape sequence", () => {
+    let s = makeLineBufferState();
+    s = reduceLineBuffer(s, "git");
+    s = reduceLineBuffer(s, "\x1b[A"); // up-arrow
+    s = reduceLineBuffer(s, " status");
+    expect(s.buffer).toBe("git status");
+  });
+
+  it("does not flush on an escape sequence", () => {
+    let s = makeLineBufferState();
+    s = reduceLineBuffer(s, "ls");
+    s = reduceLineBuffer(s, "\x1b[A");
+    expect(s.flushed).toBeUndefined();
+  });
+});
+
+// ── Tab (\\x09) ignored ────────────────────────────────────────────────────────
+
+describe("lineBufferReducer — tab (\\x09)", () => {
+  it("ignores tab character (not accumulated)", () => {
+    let s = makeLineBufferState();
+    s = reduceLineBuffer(s, "git");
+    s = reduceLineBuffer(s, "\x09"); // tab (completion attempt)
+    expect(s.buffer).toBe("git");
+  });
+});
+
+// ── Paste chunk with \\r mid-string ───────────────────────────────────────────
+
+describe("lineBufferReducer — paste with \\r mid-chunk", () => {
+  it("flushes at the \\r in a multi-char chunk", () => {
+    // Simulate pasting "echo hello\r"
+    let s = makeLineBufferState();
+    s = reduceLineBuffer(s, "echo hello\r");
+    expect(s.flushed).toBe("echo hello");
+    expect(s.buffer).toBe("");
+  });
+
+  it("handles chars after \\r going into a new buffer", () => {
+    // "cmd1\rcmd2" — flush cmd1, start cmd2
+    let s = makeLineBufferState();
+    s = reduceLineBuffer(s, "cmd1\rcmd2");
+    expect(s.flushed).toBe("cmd1");
+    // flushed reflects the LAST flush in the chunk
+    // buffer accumulates what came after
+    expect(s.buffer).toBe("cmd2");
+  });
+
+  it("handles multiple \\r in one chunk — returns last flushed", () => {
+    // Two Enter presses in one chunk
+    let s = makeLineBufferState();
+    s = reduceLineBuffer(s, "cmd1\rcmd2\r");
+    // flushed should be "cmd2" (the last flush)
+    expect(s.flushed).toBe("cmd2");
+    expect(s.buffer).toBe("");
+  });
+});
+
+// ── Buffer cap (>2048 chars) ─────────────────────────────────────────────────
+
+describe("lineBufferReducer — buffer cap", () => {
+  it("resets buffer without flush when length exceeds 2048 chars", () => {
+    let s = makeLineBufferState();
+    // Build a string just over the cap
+    const longStr = "a".repeat(2049);
+    s = reduceLineBuffer(s, longStr);
+    expect(s.buffer).toBe("");
+    expect(s.flushed).toBeUndefined();
+  });
+
+  it("exactly 2048 chars does not reset", () => {
+    let s = makeLineBufferState();
+    const exactly2048 = "a".repeat(2048);
+    s = reduceLineBuffer(s, exactly2048);
+    expect(s.buffer).toBe(exactly2048);
+    expect(s.flushed).toBeUndefined();
+  });
+
+  it("after a cap reset, subsequent typing accumulates normally", () => {
+    let s = makeLineBufferState();
+    s = reduceLineBuffer(s, "x".repeat(2049));
+    s = reduceLineBuffer(s, "ok");
+    expect(s.buffer).toBe("ok");
+  });
+});
+
+// ── Other control chars ignored ───────────────────────────────────────────────
+
+describe("lineBufferReducer — other control chars", () => {
+  it("ignores null char (\\x00)", () => {
+    let s = makeLineBufferState();
+    s = reduceLineBuffer(s, "a\x00b");
+    expect(s.buffer).toBe("ab");
+  });
+
+  it("ignores \\x01 (Ctrl-A)", () => {
+    let s = makeLineBufferState();
+    s = reduceLineBuffer(s, "a\x01b");
+    expect(s.buffer).toBe("ab");
+  });
+
+  it("ignores \\n (LF, 0x0a)", () => {
+    let s = makeLineBufferState();
+    s = reduceLineBuffer(s, "a\nb");
+    expect(s.buffer).toBe("ab");
+  });
+});

--- a/src/features/history/lineBufferReducer.ts
+++ b/src/features/history/lineBufferReducer.ts
@@ -1,0 +1,158 @@
+// features/history/lineBufferReducer.ts — Pure line-buffer reducer for xterm onData
+//
+// Processes raw xterm.js onData chunks one at a time, accumulating printable chars
+// into a line buffer and flushing on Enter (\r).
+//
+// DESIGN NOTES:
+// - Pure function — no I/O, no side-effects. Fully unit-testable in isolation.
+// - grapheme-safe backspace via [...buffer].slice(0,-1).join("") — handles CJK/emoji.
+// - Escape sequences (CSI/SS3): on \x1b set inEscSeq=true, skip until letter or ~.
+// - Buffer cap: >2048 chars resets without flush (runaway paste guard).
+// - Flushed command is trimmed; empty-after-trim → no flush.
+
+/** Maximum buffer length. Exceeded → reset without recording. */
+const BUFFER_CAP = 2048;
+
+export interface LineBufferState {
+  /** Accumulated printable chars typed so far (before Enter). */
+  buffer: string;
+  /** True while inside an ANSI escape sequence (skip chars until terminator). */
+  inEscSeq: boolean;
+  /**
+   * True when we saw ESC followed by 'O' (SS3 introducer).
+   * We need to skip one more char (the function-key terminator, e.g. 'P' for F1).
+   */
+  inSS3: boolean;
+  /**
+   * Set to the trimmed command text when a flush occurred on the most recent
+   * reduceLineBuffer call. Absent (undefined) when no flush happened.
+   */
+  flushed?: string;
+}
+
+/** Create a fresh, empty line buffer state. */
+export function makeLineBufferState(): LineBufferState {
+  return { buffer: "", inEscSeq: false, inSS3: false };
+}
+
+/**
+ * Process one raw xterm onData chunk and return the next state.
+ *
+ * Rules per character:
+ *  \r           → flush (if non-empty after trim), reset buffer
+ *  \x03 Ctrl-C  → reset buffer (cancelled)
+ *  \x15 Ctrl-U  → reset buffer (line clear)
+ *  \x7f DEL     → grapheme-safe remove last char
+ *  \b   BS      → grapheme-safe remove last char
+ *  \x1b ESC     → enter escape-sequence mode
+ *  inEscSeq     → skip until letter or ~ (CSI/SS3 terminators), then exit
+ *  \x09 TAB     → ignore (tab-completion side effect; shell handles it)
+ *  < 0x20 other → ignore (other control chars)
+ *  printable    → append to buffer; if buffer > BUFFER_CAP → reset, no flush
+ */
+export function reduceLineBuffer(
+  state: LineBufferState,
+  chunk: string,
+): LineBufferState {
+  let buffer = state.buffer;
+  let inEscSeq = state.inEscSeq;
+  let inSS3 = state.inSS3;
+  let flushed: string | undefined = undefined;
+
+  for (const char of chunk) {
+    // ── Flush on Enter ────────────────────────────────────────────────────────
+    if (char === "\r") {
+      const trimmed = buffer.trim();
+      if (trimmed.length > 0) {
+        flushed = trimmed;
+      }
+      buffer = "";
+      inEscSeq = false;
+      inSS3 = false;
+      continue;
+    }
+
+    // ── Ctrl-C (cancel) ───────────────────────────────────────────────────────
+    if (char === "\x03") {
+      buffer = "";
+      inEscSeq = false;
+      inSS3 = false;
+      continue;
+    }
+
+    // ── Ctrl-U (kill line) ────────────────────────────────────────────────────
+    if (char === "\x15") {
+      buffer = "";
+      inEscSeq = false;
+      inSS3 = false;
+      continue;
+    }
+
+    // ── Backspace / DEL ───────────────────────────────────────────────────────
+    if (char === "\x7f" || char === "\b") {
+      if (buffer.length > 0) {
+        // grapheme-safe: spread to Unicode code points, drop last
+        buffer = [...buffer].slice(0, -1).join("");
+      }
+      continue;
+    }
+
+    // ── ESC — enter escape-sequence mode ──────────────────────────────────────
+    if (char === "\x1b") {
+      inEscSeq = true;
+      inSS3 = false;
+      continue;
+    }
+
+    // ── Inside SS3 sequence (ESC O <letter>) — skip the terminator char ────────
+    if (inSS3) {
+      // The next single char is the SS3 terminator (e.g. P for F1, Q for F2...)
+      inSS3 = false;
+      inEscSeq = false;
+      continue;
+    }
+
+    // ── Inside CSI escape sequence — skip until letter or ~ ──────────────────
+    if (inEscSeq) {
+      // 'O' immediately after ESC = SS3 introducer (e.g. \x1bOP = F1)
+      if (char === "O") {
+        inEscSeq = false;
+        inSS3 = true;
+        continue;
+      }
+      // CSI/other sequence terminators: any letter (a-zA-Z) or tilde (~)
+      const code = char.charCodeAt(0);
+      const isLetter = (code >= 0x41 && code <= 0x5a) || (code >= 0x61 && code <= 0x7a);
+      const isTilde = char === "~";
+      if (isLetter || isTilde) {
+        inEscSeq = false;
+      }
+      // Intermediate CSI chars ([, ?, digits, semicolons) — just skip
+      continue;
+    }
+
+    // ── Tab ───────────────────────────────────────────────────────────────────
+    if (char === "\x09") {
+      continue; // ignore — tab-completion affects server output, not our buffer
+    }
+
+    // ── Other control chars (< 0x20 and not already handled) ─────────────────
+    const code = char.charCodeAt(0);
+    if (code < 0x20 || code === 0x7f) {
+      continue;
+    }
+
+    // ── Printable char — append and check cap ─────────────────────────────────
+    buffer += char;
+    if (buffer.length > BUFFER_CAP) {
+      // Runaway paste or huge line — reset, no flush
+      buffer = "";
+      inEscSeq = false;
+      inSS3 = false;
+      flushed = undefined; // discard any partial flush in this chunk
+      continue;
+    }
+  }
+
+  return { buffer, inEscSeq, inSS3, flushed };
+}

--- a/src/features/history/lineBufferReducer.ts
+++ b/src/features/history/lineBufferReducer.ts
@@ -9,6 +9,25 @@
 // - Escape sequences (CSI/SS3): on \x1b set inEscSeq=true, skip until letter or ~.
 // - Buffer cap: >2048 chars resets without flush (runaway paste guard).
 // - Flushed command is trimmed; empty-after-trim → no flush.
+//
+// ACCEPTED v1 LIMITATIONS (no behavior change planned):
+//
+// MINOR-1 — Bare ESC followed by typing may swallow the next char.
+//   A lone ESC keypress (not part of a CSI/SS3 sequence) sets inEscSeq=true.
+//   The very next character is then treated as a CSI/SS3 byte and skipped
+//   instead of being appended to the buffer. We cannot distinguish a standalone
+//   ESC from the introducer of a two-byte sequence without lookahead, and
+//   xterm.js delivers the ESC in a separate onData chunk when it is part of a
+//   real sequence anyway. Practical impact is negligible — bare ESC at a shell
+//   prompt exits most modes without producing output.
+//
+// MINOR-2 — A single onData chunk containing multiple \r-terminated commands
+//   records only the last one.
+//   reduceLineBuffer processes chars sequentially; each \r flushes and the
+//   `flushed` field is overwritten on every flush within the same chunk. Only
+//   the final flush in the chunk is visible to the caller. This is a v1
+//   simplification: pasting multiple commands at once is unusual, and recording
+//   the last is more useful than recording nothing.
 
 /** Maximum buffer length. Exceeded → reset without recording. */
 const BUFFER_CAP = 2048;

--- a/src/features/terminal/useTerminal.test.ts
+++ b/src/features/terminal/useTerminal.test.ts
@@ -327,7 +327,32 @@ describe("_testProcessOnDataChunk — onData history tap", () => {
     expect(mockAddCommand).not.toHaveBeenCalled();
   });
 
-  it("accumulates chars without flushing when no \\r", () => {
+  // MAJOR-1 (SECURITY): with captureEnabled=false the reducer must NOT accumulate
+  // typed chars — the per-instance lineBuffer.buffer must stay "" so passwords
+  // typed at no-echo prompts are never held in memory.
+  it("does NOT accumulate chars in buffer when captureEnabled=false (SECURITY)", () => {
+    // captureEnabled: false is set by beforeEach
+    const state = _testProcessOnDataChunk(undefined, "secret-password", "sess-1", "host");
+    expect(state.buffer).toBe("");
+    expect(mockAddCommand).not.toHaveBeenCalled();
+  });
+
+  it("returns fresh empty state on every call when captureEnabled=false", () => {
+    // Even when called with an existing non-empty prev state, capture-off must
+    // discard everything and return a clean slate.
+    const fakeNonEmpty = { buffer: "already-accumulated", inEscSeq: false, inSS3: false };
+    const state = _testProcessOnDataChunk(fakeNonEmpty as never, "more", "sess-1", "host");
+    expect(state.buffer).toBe("");
+    expect(mockAddCommand).not.toHaveBeenCalled();
+  });
+
+  it("accumulates chars without flushing when no \\r (captureEnabled=true)", () => {
+    // Accumulation requires capture to be enabled — with capture off the buffer
+    // is always reset to empty (SECURITY, see MAJOR-1 tests above).
+    mockedHistoryStore.getState.mockReturnValue({
+      captureEnabled: true,
+      addCommand: mockAddCommand,
+    } as never);
     const state1 = _testProcessOnDataChunk(undefined, "git", "sess-1", "host");
     const state2 = _testProcessOnDataChunk(state1, " status", "sess-1", "host");
     expect(state2.buffer).toBe("git status");

--- a/src/features/terminal/useTerminal.test.ts
+++ b/src/features/terminal/useTerminal.test.ts
@@ -1,6 +1,6 @@
 // src/features/terminal/useTerminal.test.ts — TDD: applyThemeToAllTerminals export
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { ITheme } from "@xterm/xterm";
 
 // ── localStorage stub so themeStore (imported dynamically by useTerminal) can work ──
@@ -62,6 +62,17 @@ vi.mock("../../lib/tauri", () => ({
 vi.mock("@tauri-apps/api/core", () => ({
   Channel: vi.fn().mockImplementation(() => ({ onmessage: null })),
   invoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+// ── commandHistoryStore mock (for onData tap tests) ───────────────────────────
+const mockAddCommand = vi.fn();
+vi.mock("../../stores/commandHistoryStore", () => ({
+  useCommandHistoryStore: {
+    getState: vi.fn(() => ({
+      captureEnabled: false,
+      addCommand: mockAddCommand,
+    })),
+  },
 }));
 
 import { applyThemeToAllTerminals } from "./useTerminal";
@@ -269,5 +280,69 @@ describe("applyThemeToAllTerminals — live and disposed instances (MINOR-4)", (
     expect(liveOptions2.theme).toBe(theme);
     // disposed instance must NOT be re-themed
     expect(disposedOptions.theme).toBeUndefined();
+  });
+});
+
+// ── onData history tap — _testProcessOnDataChunk ──────────────────────────────
+// Tests that the bridge between the line-buffer reducer and commandHistoryStore
+// works correctly. _testProcessOnDataChunk is a TEST-ONLY export that runs the
+// same logic as the onData handler registered inside openTerminal.
+import { _testProcessOnDataChunk } from "./useTerminal";
+import { useCommandHistoryStore } from "../../stores/commandHistoryStore";
+
+const mockedHistoryStore = vi.mocked(useCommandHistoryStore);
+
+describe("_testProcessOnDataChunk — onData history tap", () => {
+  beforeEach(() => {
+    mockAddCommand.mockReset();
+    // Ensure getState returns a valid object with a fresh mockAddCommand after each reset
+    mockedHistoryStore.getState.mockReturnValue({
+      captureEnabled: false,
+      addCommand: mockAddCommand,
+    } as never);
+  });
+
+  it("is exported as a function", () => {
+    expect(typeof _testProcessOnDataChunk).toBe("function");
+  });
+
+  it("calls addCommand when captureEnabled=true and a command is flushed", () => {
+    mockedHistoryStore.getState.mockReturnValue({
+      captureEnabled: true,
+      addCommand: mockAddCommand,
+    } as never);
+
+    const state = _testProcessOnDataChunk(undefined, "ls -la\r", "sess-1", "host.example.com");
+    expect(mockAddCommand).toHaveBeenCalledWith({
+      command: "ls -la",
+      sessionId: "sess-1",
+      host: "host.example.com",
+    });
+    expect(state.buffer).toBe("");
+  });
+
+  it("does NOT call addCommand when captureEnabled=false", () => {
+    // Default beforeEach sets captureEnabled: false already
+    _testProcessOnDataChunk(undefined, "secret-password\r", "sess-1", "host");
+    expect(mockAddCommand).not.toHaveBeenCalled();
+  });
+
+  it("accumulates chars without flushing when no \\r", () => {
+    const state1 = _testProcessOnDataChunk(undefined, "git", "sess-1", "host");
+    const state2 = _testProcessOnDataChunk(state1, " status", "sess-1", "host");
+    expect(state2.buffer).toBe("git status");
+    expect(mockAddCommand).not.toHaveBeenCalled();
+  });
+
+  it("resets buffer on Ctrl-C without calling addCommand", () => {
+    mockedHistoryStore.getState.mockReturnValue({
+      captureEnabled: true,
+      addCommand: mockAddCommand,
+    } as never);
+
+    const state1 = _testProcessOnDataChunk(undefined, "partial", "sess-1", "host");
+    const state2 = _testProcessOnDataChunk(state1, "\x03", "sess-1", "host");
+    expect(state2.buffer).toBe("");
+    expect(mockAddCommand).not.toHaveBeenCalled();
   });
 });

--- a/src/features/terminal/useTerminal.ts
+++ b/src/features/terminal/useTerminal.ts
@@ -542,11 +542,15 @@ function _processOnDataChunk(
 ): LineBufferState {
   const prev = prevState ?? makeLineBufferState();
 
-  // SECURITY: early return when capture is disabled — do not run the reducer
-  // at all so there is zero processing overhead when the feature is off.
+  // SECURITY: early return when capture is disabled — do NOT run the reducer
+  // and do NOT accumulate any chars. Return a fresh empty state so that typed
+  // characters (including passwords at no-echo prompts) are never held in
+  // memory. Re-enabling capture starts from a clean slate. Keystrokes are
+  // still forwarded to write_terminal by the caller — this tap never affects
+  // normal terminal I/O.
   const { captureEnabled, addCommand } = useCommandHistoryStore.getState();
   if (!captureEnabled) {
-    return reduceLineBuffer(prev, chunk);
+    return makeLineBufferState();
   }
 
   const next = reduceLineBuffer(prev, chunk);

--- a/src/features/terminal/useTerminal.ts
+++ b/src/features/terminal/useTerminal.ts
@@ -20,6 +20,13 @@ import {
 } from "../../lib/constants";
 import { THEMES } from "../../lib/themes";
 import type { SessionId, TerminalId, TerminalEvent } from "../../lib/types";
+import {
+  reduceLineBuffer,
+  makeLineBufferState,
+  type LineBufferState,
+} from "../history/lineBufferReducer";
+import { useCommandHistoryStore } from "../../stores/commandHistoryStore";
+import { useSessionStore } from "../../stores/sessionStore";
 
 /** Result of a search results update from the SearchAddon. */
 export interface SearchResults {
@@ -48,6 +55,12 @@ interface TerminalInstance {
   callbackOnSearchResults: ((r: SearchResults) => void) | null;
   /** Collected IDisposable subscriptions — disposed when the terminal closes. */
   disposables: IDisposable[];
+  /**
+   * Per-instance line buffer for the command-history tap.
+   * Maintained across onData calls; reset on Ctrl-C/U or Enter-flush.
+   * SECURITY: onData tap is guarded by captureEnabled in commandHistoryStore.
+   */
+  lineBuffer: LineBufferState;
 }
 
 // Module-level singleton: all useTerminal() hook instances share the same Map.
@@ -250,8 +263,19 @@ export function useTerminal() {
         onOutput,
       });
 
-      // Forward keystrokes to Rust
+      // Forward keystrokes to Rust + command-history tap
       term.onData((data) => {
+        // Command history tap: process chunk through line buffer reducer.
+        // The store's addCommand guards behind captureEnabled — early-returns
+        // when capture is OFF, so no history is recorded unless user opted in.
+        // SECURITY: We do NOT attempt password-prompt detection (unreliable at
+        // the JS layer). The user controls capture via the History panel toggle.
+        const inst = terminalInstances.get(terminalId);
+        if (inst) {
+          const { host } = _getSessionHost(sessionId);
+          inst.lineBuffer = _processOnDataChunk(inst.lineBuffer, data, sessionId, host);
+        }
+
         const bytes = new TextEncoder().encode(data);
         void tauriInvoke<void>("write_terminal", {
           sessionId,
@@ -364,6 +388,7 @@ export function useTerminal() {
         callbackOnOpenFindBar: null,
         callbackOnSearchResults: null,
         disposables,
+        lineBuffer: makeLineBufferState(),
       };
       terminalInstances.set(terminalId, instance);
 
@@ -486,6 +511,57 @@ export function useTerminal() {
   return { openTerminal, closeTerminal, getTerminal, focusTerminal, reattachTerminal, disposeSessionTerminals };
 }
 
+// ── Command history onData tap helpers ───────────────────────────────────────
+
+/**
+ * Looks up the host string for a session from the session store.
+ * Returns empty string if the session is not found (safe fallback).
+ */
+function _getSessionHost(sessionId: SessionId): { host: string } {
+  const session = useSessionStore.getState().sessions.get(sessionId);
+  return { host: session?.host ?? "" };
+}
+
+/**
+ * Core logic for the onData history tap.
+ * Processes a raw xterm onData chunk through the line-buffer reducer.
+ * When a command is flushed, calls commandHistoryStore.addCommand IF
+ * captureEnabled is true (the store guards this internally).
+ *
+ * @param prevState  - Previous LineBufferState (undefined = fresh start)
+ * @param chunk      - Raw xterm onData string
+ * @param sessionId  - Active session id (for store entry)
+ * @param host       - Remote host (for store entry)
+ * @returns           - Next LineBufferState
+ */
+function _processOnDataChunk(
+  prevState: LineBufferState | undefined,
+  chunk: string,
+  sessionId: string,
+  host: string,
+): LineBufferState {
+  const prev = prevState ?? makeLineBufferState();
+
+  // SECURITY: early return when capture is disabled — do not run the reducer
+  // at all so there is zero processing overhead when the feature is off.
+  const { captureEnabled, addCommand } = useCommandHistoryStore.getState();
+  if (!captureEnabled) {
+    return reduceLineBuffer(prev, chunk);
+  }
+
+  const next = reduceLineBuffer(prev, chunk);
+
+  if (next.flushed !== undefined) {
+    addCommand({
+      command: next.flushed,
+      sessionId,
+      host,
+    });
+  }
+
+  return next;
+}
+
 /**
  * TEST-ONLY helper — seeds a fake TerminalInstance into the module-level Map
  * so unit tests can verify applyThemeToAllTerminals behaves correctly on live
@@ -505,4 +581,17 @@ export function _testSeedTerminalInstance(id: string, instance: TerminalInstance
  */
 export function _testGetFindBarOpener(terminalId: TerminalId): (() => void) | null {
   return terminalInstances.get(terminalId)?.callbackOnOpenFindBar ?? null;
+}
+
+/**
+ * TEST-ONLY helper — exposes _processOnDataChunk for unit testing the
+ * onData history tap logic without going through the full openTerminal flow.
+ */
+export function _testProcessOnDataChunk(
+  prevState: LineBufferState | undefined,
+  chunk: string,
+  sessionId: string,
+  host: string,
+): LineBufferState {
+  return _processOnDataChunk(prevState, chunk, sessionId, host);
 }

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -151,9 +151,26 @@ export const en = {
   // Side panel
   "panel.sftp": "Files",
   "panel.tunnels": "Tunnels",
+  "panel.history": "History",
   "panel.close": "Close panel",
   "panel.region": "Session panel",
   "panel.sections": "Panel sections",
+
+  // Command history panel
+  "history.empty": "No commands recorded yet",
+  "history.captureOff": "Command capture is disabled",
+  "history.enableCapture": "Enable capture to start recording commands",
+  "history.filter": "Filter commands...",
+  "history.filterByHost": "Filter to current host",
+  "history.copy": "Copy",
+  "history.insert": "Insert",
+  "history.execute": "Execute",
+  "history.delete": "Delete command",
+  "history.clearAll": "Clear all",
+  "history.captureToggleLabel": "Capture commands",
+  "history.noticeTitle": "Privacy notice",
+  "history.noticeMessage": "Command history captures everything you type. Passwords entered at prompts may be recorded. You can disable capture or clear history at any time.",
+  "history.noticeDismiss": "Got it",
 
   // Terminal
   "terminal.newTab": "New terminal",

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -153,9 +153,26 @@ export const es: Record<TranslationKey, string> = {
   // Side panel
   "panel.sftp": "Archivos",
   "panel.tunnels": "Túneles",
+  "panel.history": "Historial",
   "panel.close": "Cerrar panel",
   "panel.region": "Panel de sesión",
   "panel.sections": "Secciones del panel",
+
+  // Command history panel
+  "history.empty": "Aún no hay comandos registrados",
+  "history.captureOff": "La captura de comandos está desactivada",
+  "history.enableCapture": "Activá la captura para empezar a registrar comandos",
+  "history.filter": "Filtrar comandos...",
+  "history.filterByHost": "Filtrar por host actual",
+  "history.copy": "Copiar",
+  "history.insert": "Insertar",
+  "history.execute": "Ejecutar",
+  "history.delete": "Eliminar comando",
+  "history.clearAll": "Limpiar todo",
+  "history.captureToggleLabel": "Capturar comandos",
+  "history.noticeTitle": "Aviso de privacidad",
+  "history.noticeMessage": "El historial captura todo lo que escribís. Las contraseñas ingresadas en prompts pueden quedar registradas. Podés desactivar la captura o limpiar el historial en cualquier momento.",
+  "history.noticeDismiss": "Entendido",
 
   // Terminal
   "terminal.newTab": "Nueva terminal",

--- a/src/stores/commandHistoryStore.test.ts
+++ b/src/stores/commandHistoryStore.test.ts
@@ -1,0 +1,344 @@
+// stores/commandHistoryStore.test.ts
+// TDD RED phase — Zustand persist store for command history ring buffer.
+//
+// Pattern mirrors snippetStore.test.ts exactly:
+//   - vi.hoisted() localStorage stub before any import
+//   - resetStore() helper, beforeEach cleanup
+//   - rehydrate() for persistence tests
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── localStorage stub (must be hoisted before any module import) ──────────────
+const { localStorageMap } = vi.hoisted(() => {
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, String(v)),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => void store.clear(),
+      key: (i: number) => [...store.keys()][i] ?? null,
+      get length() {
+        return store.size;
+      },
+    },
+  });
+  return { localStorageMap: store };
+});
+
+import { useCommandHistoryStore, type HistoryEntry } from "./commandHistoryStore";
+
+function resetStore() {
+  useCommandHistoryStore.setState({
+    entries: [],
+    captureEnabled: false,
+    noticeAcknowledged: false,
+  });
+}
+
+beforeEach(() => {
+  localStorageMap.clear();
+  resetStore();
+});
+
+// ── Initial state ─────────────────────────────────────────────────────────────
+
+describe("commandHistoryStore — initial state", () => {
+  it("starts with an empty entries array", () => {
+    expect(useCommandHistoryStore.getState().entries).toEqual([]);
+  });
+
+  it("captureEnabled defaults to FALSE (opt-in security model)", () => {
+    // SECURITY: capture is opt-in — passwords at no-echo prompts would be
+    // recorded in plaintext in localStorage if capture were on by default.
+    expect(useCommandHistoryStore.getState().captureEnabled).toBe(false);
+  });
+
+  it("noticeAcknowledged defaults to false", () => {
+    expect(useCommandHistoryStore.getState().noticeAcknowledged).toBe(false);
+  });
+});
+
+// ── addCommand ────────────────────────────────────────────────────────────────
+
+describe("commandHistoryStore — addCommand", () => {
+  it("appends an entry with all required fields", () => {
+    useCommandHistoryStore.setState({ captureEnabled: true });
+    useCommandHistoryStore.getState().addCommand({
+      command: "ls -la",
+      sessionId: "sess-1",
+      host: "10.0.0.1",
+    });
+    const { entries } = useCommandHistoryStore.getState();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.command).toBe("ls -la");
+    expect(entries[0]!.sessionId).toBe("sess-1");
+    expect(entries[0]!.host).toBe("10.0.0.1");
+    expect(typeof entries[0]!.id).toBe("string");
+    expect(entries[0]!.id.length).toBeGreaterThan(0);
+    expect(typeof entries[0]!.timestamp).toBe("number");
+  });
+
+  it("assigns a UUID-formatted id", () => {
+    useCommandHistoryStore.setState({ captureEnabled: true });
+    useCommandHistoryStore.getState().addCommand({
+      command: "pwd",
+      sessionId: "sess-1",
+      host: "host.example.com",
+    });
+    const id = useCommandHistoryStore.getState().entries[0]!.id;
+    expect(id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("records timestamp as a number close to Date.now()", () => {
+    useCommandHistoryStore.setState({ captureEnabled: true });
+    const before = Date.now();
+    useCommandHistoryStore.getState().addCommand({
+      command: "date",
+      sessionId: "s",
+      host: "h",
+    });
+    const after = Date.now();
+    const ts = useCommandHistoryStore.getState().entries[0]!.timestamp;
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after);
+  });
+
+  it("does NOT add entry when captureEnabled is false", () => {
+    // captureEnabled is false by default (reset in beforeEach)
+    useCommandHistoryStore.getState().addCommand({
+      command: "secret",
+      sessionId: "sess-1",
+      host: "host",
+    });
+    expect(useCommandHistoryStore.getState().entries).toHaveLength(0);
+  });
+
+  it("does not dedupe non-consecutive identical commands", () => {
+    useCommandHistoryStore.setState({ captureEnabled: true });
+    useCommandHistoryStore.getState().addCommand({ command: "ls", sessionId: "s", host: "h" });
+    useCommandHistoryStore.getState().addCommand({ command: "pwd", sessionId: "s", host: "h" });
+    useCommandHistoryStore.getState().addCommand({ command: "ls", sessionId: "s", host: "h" });
+    expect(useCommandHistoryStore.getState().entries).toHaveLength(3);
+  });
+});
+
+// ── Dedupe consecutive identical ──────────────────────────────────────────────
+
+describe("commandHistoryStore — dedupe consecutive identical", () => {
+  it("deduplicates consecutive identical commands on the same sessionId", () => {
+    useCommandHistoryStore.setState({ captureEnabled: true });
+    useCommandHistoryStore.getState().addCommand({ command: "ls", sessionId: "s1", host: "h" });
+    useCommandHistoryStore.getState().addCommand({ command: "ls", sessionId: "s1", host: "h" });
+    expect(useCommandHistoryStore.getState().entries).toHaveLength(1);
+  });
+
+  it("does NOT dedupe when sessionId differs", () => {
+    useCommandHistoryStore.setState({ captureEnabled: true });
+    useCommandHistoryStore.getState().addCommand({ command: "ls", sessionId: "s1", host: "h" });
+    useCommandHistoryStore.getState().addCommand({ command: "ls", sessionId: "s2", host: "h" });
+    expect(useCommandHistoryStore.getState().entries).toHaveLength(2);
+  });
+});
+
+// ── Ring buffer cap ───────────────────────────────────────────────────────────
+
+describe("commandHistoryStore — ring buffer cap (500)", () => {
+  it("holds up to 500 entries without dropping any", () => {
+    useCommandHistoryStore.setState({ captureEnabled: true });
+    for (let i = 0; i < 500; i++) {
+      useCommandHistoryStore.getState().addCommand({
+        command: `cmd-${i}`,
+        sessionId: "s",
+        host: "h",
+      });
+    }
+    expect(useCommandHistoryStore.getState().entries).toHaveLength(500);
+  });
+
+  it("drops the oldest entry when the 501st is added", () => {
+    useCommandHistoryStore.setState({ captureEnabled: true });
+    for (let i = 0; i < 500; i++) {
+      useCommandHistoryStore.getState().addCommand({
+        command: `cmd-${i}`,
+        sessionId: "s",
+        host: "h",
+      });
+    }
+    useCommandHistoryStore.getState().addCommand({
+      command: "cmd-500",
+      sessionId: "s",
+      host: "h",
+    });
+    const entries = useCommandHistoryStore.getState().entries;
+    expect(entries).toHaveLength(500);
+    // Oldest (cmd-0) should be gone, newest (cmd-500) should be present
+    expect(entries.find((e) => e.command === "cmd-0")).toBeUndefined();
+    expect(entries[entries.length - 1]!.command).toBe("cmd-500");
+  });
+});
+
+// ── deleteCommand ─────────────────────────────────────────────────────────────
+
+describe("commandHistoryStore — deleteCommand", () => {
+  it("removes the entry by id", () => {
+    useCommandHistoryStore.setState({ captureEnabled: true });
+    useCommandHistoryStore.getState().addCommand({ command: "rm -rf /tmp/x", sessionId: "s", host: "h" });
+    const { id } = useCommandHistoryStore.getState().entries[0]!;
+    useCommandHistoryStore.getState().deleteCommand(id);
+    expect(useCommandHistoryStore.getState().entries).toHaveLength(0);
+  });
+
+  it("leaves other entries intact", () => {
+    useCommandHistoryStore.setState({ captureEnabled: true });
+    useCommandHistoryStore.getState().addCommand({ command: "cmd-a", sessionId: "s", host: "h" });
+    useCommandHistoryStore.getState().addCommand({ command: "cmd-b", sessionId: "s", host: "h" });
+    const [a, b] = useCommandHistoryStore.getState().entries as [HistoryEntry, HistoryEntry];
+    useCommandHistoryStore.getState().deleteCommand(a.id);
+    const remaining = useCommandHistoryStore.getState().entries;
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]!.id).toBe(b.id);
+  });
+
+  it("is a no-op for unknown id", () => {
+    useCommandHistoryStore.setState({ captureEnabled: true });
+    useCommandHistoryStore.getState().addCommand({ command: "x", sessionId: "s", host: "h" });
+    useCommandHistoryStore.getState().deleteCommand("nonexistent-id");
+    expect(useCommandHistoryStore.getState().entries).toHaveLength(1);
+  });
+});
+
+// ── clearAll ──────────────────────────────────────────────────────────────────
+
+describe("commandHistoryStore — clearAll", () => {
+  it("empties the entries array", () => {
+    useCommandHistoryStore.setState({ captureEnabled: true });
+    useCommandHistoryStore.getState().addCommand({ command: "a", sessionId: "s", host: "h" });
+    useCommandHistoryStore.getState().addCommand({ command: "b", sessionId: "s", host: "h" });
+    useCommandHistoryStore.getState().clearAll();
+    expect(useCommandHistoryStore.getState().entries).toHaveLength(0);
+  });
+});
+
+// ── toggleCapture ─────────────────────────────────────────────────────────────
+
+describe("commandHistoryStore — toggleCapture", () => {
+  it("flips captureEnabled from false to true", () => {
+    useCommandHistoryStore.getState().toggleCapture();
+    expect(useCommandHistoryStore.getState().captureEnabled).toBe(true);
+  });
+
+  it("flips captureEnabled from true to false", () => {
+    useCommandHistoryStore.setState({ captureEnabled: true });
+    useCommandHistoryStore.getState().toggleCapture();
+    expect(useCommandHistoryStore.getState().captureEnabled).toBe(false);
+  });
+});
+
+// ── dismissNotice ─────────────────────────────────────────────────────────────
+
+describe("commandHistoryStore — dismissNotice", () => {
+  it("sets noticeAcknowledged to true", () => {
+    useCommandHistoryStore.getState().dismissNotice();
+    expect(useCommandHistoryStore.getState().noticeAcknowledged).toBe(true);
+  });
+});
+
+// ── Persistence ───────────────────────────────────────────────────────────────
+
+describe("commandHistoryStore — persistence", () => {
+  it("writes to localStorage key 'nexterm-command-history'", () => {
+    useCommandHistoryStore.setState({ captureEnabled: true });
+    useCommandHistoryStore.getState().addCommand({ command: "ls", sessionId: "s", host: "h" });
+    const raw = localStorageMap.get("nexterm-command-history");
+    expect(raw).toBeDefined();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.state.entries).toHaveLength(1);
+    expect(parsed.state.entries[0].command).toBe("ls");
+  });
+
+  it("persists captureEnabled and noticeAcknowledged", () => {
+    useCommandHistoryStore.setState({ captureEnabled: true, noticeAcknowledged: true });
+    // Trigger a write by mutating
+    useCommandHistoryStore.getState().dismissNotice(); // no-op but forces subscription
+    const raw = localStorageMap.get("nexterm-command-history");
+    expect(raw).toBeDefined();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.state.captureEnabled).toBe(true);
+    expect(parsed.state.noticeAcknowledged).toBe(true);
+  });
+});
+
+// ── Rehydration merge validator ───────────────────────────────────────────────
+
+describe("commandHistoryStore — rehydration merge validator", () => {
+  it("restores valid entries from storage", async () => {
+    const valid: HistoryEntry = {
+      id: "abc-123",
+      command: "ls",
+      timestamp: 1000,
+      sessionId: "sess-1",
+      host: "10.0.0.1",
+    };
+    const envelope = JSON.stringify({
+      state: { entries: [valid], captureEnabled: false, noticeAcknowledged: false },
+      version: 0,
+    });
+    localStorageMap.set("nexterm-command-history", envelope);
+    await useCommandHistoryStore.persist.rehydrate();
+    expect(useCommandHistoryStore.getState().entries).toHaveLength(1);
+    expect(useCommandHistoryStore.getState().entries[0]!.id).toBe("abc-123");
+  });
+
+  it("drops entries missing required fields (corrupt entry)", async () => {
+    const bad = { command: "ls" }; // missing id, sessionId, host, timestamp
+    const envelope = JSON.stringify({
+      state: { entries: [bad], captureEnabled: false, noticeAcknowledged: false },
+      version: 0,
+    });
+    localStorageMap.set("nexterm-command-history", envelope);
+    await useCommandHistoryStore.persist.rehydrate();
+    expect(useCommandHistoryStore.getState().entries).toHaveLength(0);
+  });
+
+  it("falls back to empty array when state is corrupt", async () => {
+    localStorageMap.set("nexterm-command-history", "{{invalid json");
+    await expect(
+      useCommandHistoryStore.persist.rehydrate(),
+    ).resolves.not.toThrow();
+    expect(useCommandHistoryStore.getState().entries).toEqual([]);
+  });
+
+  it("keeps valid entries and drops malformed ones", async () => {
+    const good: HistoryEntry = {
+      id: "g1",
+      command: "pwd",
+      timestamp: 2000,
+      sessionId: "s",
+      host: "h",
+    };
+    const bad = { command: "broken" };
+    const envelope = JSON.stringify({
+      state: { entries: [good, bad], captureEnabled: false, noticeAcknowledged: false },
+      version: 0,
+    });
+    localStorageMap.set("nexterm-command-history", envelope);
+    await useCommandHistoryStore.persist.rehydrate();
+    expect(useCommandHistoryStore.getState().entries).toHaveLength(1);
+    expect(useCommandHistoryStore.getState().entries[0]!.id).toBe("g1");
+  });
+
+  it("restores captureEnabled from storage", async () => {
+    const envelope = JSON.stringify({
+      state: { entries: [], captureEnabled: true, noticeAcknowledged: true },
+      version: 0,
+    });
+    localStorageMap.set("nexterm-command-history", envelope);
+    await useCommandHistoryStore.persist.rehydrate();
+    expect(useCommandHistoryStore.getState().captureEnabled).toBe(true);
+    expect(useCommandHistoryStore.getState().noticeAcknowledged).toBe(true);
+  });
+});

--- a/src/stores/commandHistoryStore.ts
+++ b/src/stores/commandHistoryStore.ts
@@ -1,0 +1,147 @@
+// stores/commandHistoryStore.ts — Persisted command history ring buffer
+//
+// Key: "nexterm-command-history"
+// Pattern mirrors snippetStore.ts: persist + partialize + merge validator.
+//
+// SECURITY:
+//   - captureEnabled defaults to FALSE (opt-in). History records NOTHING until
+//     the user explicitly enables capture.
+//   - Rationale: xterm onData captures ALL keystrokes including passwords typed
+//     at no-echo prompts (sudo, ssh). There is no reliable JS-layer way to detect
+//     no-echo state. Defaulting to OFF is the only safe choice.
+//   - When captureEnabled is false, addCommand is a no-op.
+//   - Provides clearAll() and per-entry deleteCommand() so users can remove
+//     sensitive entries at any time.
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+/** Ring buffer capacity — oldest entries are dropped when exceeded. */
+const RING_CAP = 500;
+
+export interface HistoryEntry {
+  id: string;
+  command: string;
+  timestamp: number;
+  sessionId: string;
+  host: string;
+}
+
+interface CommandHistoryStoreState {
+  entries: HistoryEntry[];
+  /** Opt-in capture flag. Defaults to false — see SECURITY comment above. */
+  captureEnabled: boolean;
+  /** Whether the user has seen and dismissed the first-use privacy notice. */
+  noticeAcknowledged: boolean;
+
+  addCommand: (input: Pick<HistoryEntry, "command" | "sessionId" | "host">) => void;
+  deleteCommand: (id: string) => void;
+  clearAll: () => void;
+  toggleCapture: () => void;
+  dismissNotice: () => void;
+}
+
+function isValidEntry(e: unknown): e is HistoryEntry {
+  if (!e || typeof e !== "object") return false;
+  const o = e as Record<string, unknown>;
+  return (
+    typeof o.id === "string" &&
+    o.id.length > 0 &&
+    typeof o.command === "string" &&
+    o.command.length > 0 &&
+    typeof o.timestamp === "number" &&
+    typeof o.sessionId === "string" &&
+    typeof o.host === "string"
+  );
+}
+
+export const useCommandHistoryStore = create<CommandHistoryStoreState>()(
+  persist(
+    (set, get) => ({
+      entries: [],
+      captureEnabled: false, // SECURITY: opt-in, never on by default
+      noticeAcknowledged: false,
+
+      addCommand: ({ command, sessionId, host }) => {
+        const { captureEnabled, entries } = get();
+        // SECURITY: early return when capture is disabled
+        if (!captureEnabled) return;
+
+        // Dedupe consecutive identical commands on the same session
+        const last = entries[entries.length - 1];
+        if (last && last.command === command && last.sessionId === sessionId) {
+          return;
+        }
+
+        const entry: HistoryEntry = {
+          id: crypto.randomUUID(),
+          command,
+          timestamp: Date.now(),
+          sessionId,
+          host,
+        };
+
+        // Ring buffer: if at cap, drop the oldest (index 0)
+        const next =
+          entries.length >= RING_CAP
+            ? [...entries.slice(1), entry]
+            : [...entries, entry];
+
+        set({ entries: next });
+      },
+
+      deleteCommand: (id) => {
+        set((state) => ({
+          entries: state.entries.filter((e) => e.id !== id),
+        }));
+      },
+
+      clearAll: () => {
+        set({ entries: [] });
+      },
+
+      toggleCapture: () => {
+        set((state) => ({ captureEnabled: !state.captureEnabled }));
+      },
+
+      dismissNotice: () => {
+        set({ noticeAcknowledged: true });
+      },
+    }),
+    {
+      name: "nexterm-command-history",
+      partialize: (s) => ({
+        entries: s.entries,
+        captureEnabled: s.captureEnabled,
+        noticeAcknowledged: s.noticeAcknowledged,
+      }),
+      // MAJOR-3 pattern from themeStore/snippetStore: validate rehydrated data.
+      merge: (persisted, current) => {
+        const p = persisted as
+          | {
+              entries?: unknown[];
+              captureEnabled?: unknown;
+              noticeAcknowledged?: unknown;
+            }
+          | null
+          | undefined;
+
+        const raw = Array.isArray(p?.entries) ? p.entries : [];
+        const validEntries = raw.filter(isValidEntry);
+
+        return {
+          ...current,
+          entries: validEntries,
+          captureEnabled:
+            typeof p?.captureEnabled === "boolean"
+              ? p.captureEnabled
+              : current.captureEnabled,
+          noticeAcknowledged:
+            typeof p?.noticeAcknowledged === "boolean"
+              ? p.noticeAcknowledged
+              : current.noticeAcknowledged,
+        };
+      },
+    },
+  ),
+);

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -5,7 +5,7 @@ import { persist } from "zustand/middleware";
 import type { SearchMode } from "../features/sftp/FilePane";
 import type { TerminalId } from "../lib/types";
 
-export type PanelSection = "sftp" | "tunnel" | null;
+export type PanelSection = "sftp" | "tunnel" | "history" | null;
 
 export interface WorkspacePaneSnapshot {
   path: string;


### PR DESCRIPTION
## Summary

Fourth item of the "bring Voltius's value to NexTerm, clean-room" program. Adds NexTerm's **own cross-session command history** — independent of the remote shell's history (which is per-host and lost on disconnect). Surfaced as a **History** section in the terminal side panel, with filter, copy, insert/execute, per-entry delete, and clear-all. Clean-room: original command-detection heuristic, store, and panel; no Voltius (AGPL) code.

## Security — opt-in by design

The history works by tapping the terminal's keystroke stream, which means it can see text typed at no-echo password prompts (`sudo`, `ssh`). For a credentials app that is unacceptable as a default, so:

- **Capture is OPT-IN — it defaults to OFF.** Nothing is recorded, to memory or to disk, until the user explicitly enables it.
- When disabled, the keystroke reducer does not even accumulate typed characters in memory (no transient password retention).
- Enabling shows a one-time privacy notice; capture state is read fresh per keystroke (toggling off is immediate); **Clear all** and per-entry **delete** are always available.

## What's included

- **Pure `reduceLineBuffer`** command detector: accumulates printable input, grapheme-safe backspace, resets on Ctrl-C/Ctrl-U, skips CSI/SS3 escape sequences (incl. across chunks), flushes the trimmed command on Enter, caps at 2048 chars.
- **`commandHistoryStore`** — persisted ring buffer (key `nexterm-command-history`), consecutive-dedupe, 500-entry cap, rehydration validator.
- **`HistoryPanel`** — list, text filter, filter-to-current-host, copy, Insert (no newline, safer default) / Execute (command visible in the row, consistent with snippets), delete, clear-all, capture toggle, privacy notice.

## Quality

- **357 tests green** (Vitest), `tsc --noEmit` clean — the reducer alone has 35 tests
- **Strict TDD** throughout
- **Dual adversarial review**: GO-conditional → fixed MAJOR-1 (reducer accumulated keystrokes in memory even when capture was off — now returns a fresh empty buffer) with a regression test, plus added cross-chunk escape-state coverage. The opt-in model (nothing persisted until enabled) was verified.
- **Clean-room verified**: no AGPL code copied. No Rust changes.

## Accepted v1 limitations (documented)

A bare ESC keypress followed by typing may swallow one character; a single paste containing multiple Enter-terminated commands records only the last. Tab-completion suffixes aren't captured (they arrive via output, not input).
