### PR TITLE
feat(terminal): GPU rendering via WebGL addon with DOM fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-web-links": "^0.12.0",
+    "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@xterm/addon-web-links':
         specifier: ^0.12.0
         version: 0.12.0
+      '@xterm/addon-webgl':
+        specifier: ^0.19.0
+        version: 0.19.0
       '@xterm/xterm':
         specifier: ^6.0.0
         version: 6.0.0
@@ -795,6 +798,9 @@ packages:
 
   '@xterm/addon-web-links@0.12.0':
     resolution: {integrity: sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==}
+
+  '@xterm/addon-webgl@0.19.0':
+    resolution: {integrity: sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A==}
 
   '@xterm/xterm@6.0.0':
     resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
@@ -1830,6 +1836,8 @@ snapshots:
   '@xterm/addon-search@0.16.0': {}
 
   '@xterm/addon-web-links@0.12.0': {}
+
+  '@xterm/addon-webgl@0.19.0': {}
 
   '@xterm/xterm@6.0.0': {}
 

--- a/src/features/terminal/TerminalTabs.a11y.test.tsx
+++ b/src/features/terminal/TerminalTabs.a11y.test.tsx
@@ -74,6 +74,13 @@ vi.mock("@xterm/addon-search", () => ({
   })),
 }));
 
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: vi.fn().mockImplementation(() => ({
+    onContextLoss: vi.fn(),
+    dispose: vi.fn(),
+  })),
+}));
+
 vi.mock("./TerminalView", () => ({
   TerminalView: ({ active }: { active: boolean }) => (
     <div data-testid="terminal-view" data-active={active} />

--- a/src/features/terminal/TerminalTabs.mount-persistence.test.tsx
+++ b/src/features/terminal/TerminalTabs.mount-persistence.test.tsx
@@ -78,6 +78,13 @@ vi.mock("@xterm/addon-search", () => ({
   })),
 }));
 
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: vi.fn().mockImplementation(() => ({
+    onContextLoss: vi.fn(),
+    dispose: vi.fn(),
+  })),
+}));
+
 vi.mock("./TerminalView", () => ({
   TerminalView: ({ active }: { active: boolean }) => (
     <div data-testid="terminal-view" data-active={active} />

--- a/src/features/terminal/TerminalTabs.test.tsx
+++ b/src/features/terminal/TerminalTabs.test.tsx
@@ -66,6 +66,13 @@ vi.mock("@xterm/addon-search", () => ({
   })),
 }));
 
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: vi.fn().mockImplementation(() => ({
+    onContextLoss: vi.fn(),
+    dispose: vi.fn(),
+  })),
+}));
+
 // Mock TerminalView — we only care about TerminalTabs rendering the shell
 vi.mock("./TerminalView", () => ({
   TerminalView: ({ active }: { active: boolean }) => (

--- a/src/features/terminal/useTerminal.test.ts
+++ b/src/features/terminal/useTerminal.test.ts
@@ -1,6 +1,7 @@
 // src/features/terminal/useTerminal.test.ts — TDD: applyThemeToAllTerminals export
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
 import type { ITheme } from "@xterm/xterm";
 
 // ── localStorage stub so themeStore (imported dynamically by useTerminal) can work ──
@@ -21,38 +22,55 @@ vi.hoisted(() => {
 
 // ── Mock heavy native modules ──
 vi.mock("@xterm/xterm", () => ({
-  Terminal: vi.fn().mockImplementation(() => ({
-    loadAddon: vi.fn(),
-    open: vi.fn(),
-    cols: 80,
-    rows: 24,
-    onData: vi.fn(),
-    onBinary: vi.fn(),
-    focus: vi.fn(),
-    dispose: vi.fn(),
-    write: vi.fn(),
-    writeln: vi.fn(),
-    element: null,
-    options: {},
-  })),
+  Terminal: vi.fn().mockImplementation(function MockTerminal() {
+    return {
+      loadAddon: vi.fn(),
+      open: vi.fn(),
+      cols: 80,
+      rows: 24,
+      onData: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+      onBinary: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+      focus: vi.fn(),
+      dispose: vi.fn(),
+      write: vi.fn(),
+      writeln: vi.fn(),
+      element: null,
+      options: {},
+      attachCustomKeyEventHandler: vi.fn(),
+      hasSelection: vi.fn().mockReturnValue(false),
+      getSelection: vi.fn().mockReturnValue(""),
+    };
+  }),
 }));
 
 vi.mock("@xterm/addon-fit", () => ({
-  FitAddon: vi.fn().mockImplementation(() => ({ fit: vi.fn(), dispose: vi.fn() })),
+  FitAddon: vi.fn().mockImplementation(function MockFitAddon() {
+    return { fit: vi.fn(), dispose: vi.fn() };
+  }),
 }));
 
 vi.mock("@xterm/addon-web-links", () => ({
-  WebLinksAddon: vi.fn().mockImplementation(() => ({ dispose: vi.fn() })),
+  WebLinksAddon: vi.fn().mockImplementation(function MockWebLinksAddon() {
+    return { dispose: vi.fn() };
+  }),
 }));
 
 vi.mock("@xterm/addon-search", () => ({
-  SearchAddon: vi.fn().mockImplementation(() => ({
-    activate: vi.fn(),
-    dispose: vi.fn(),
-    findNext: vi.fn().mockReturnValue(false),
-    findPrevious: vi.fn().mockReturnValue(false),
-    onDidChangeResults: vi.fn(),
-  })),
+  SearchAddon: vi.fn().mockImplementation(function MockSearchAddon() {
+    return {
+      activate: vi.fn(),
+      dispose: vi.fn(),
+      findNext: vi.fn().mockReturnValue(false),
+      findPrevious: vi.fn().mockReturnValue(false),
+      onDidChangeResults: vi.fn(),
+    };
+  }),
+}));
+
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: vi.fn().mockImplementation(function MockWebglAddon() {
+    return { onContextLoss: vi.fn(), dispose: vi.fn() };
+  }),
 }));
 
 vi.mock("../../lib/tauri", () => ({
@@ -60,7 +78,9 @@ vi.mock("../../lib/tauri", () => ({
 }));
 
 vi.mock("@tauri-apps/api/core", () => ({
-  Channel: vi.fn().mockImplementation(() => ({ onmessage: null })),
+  Channel: vi.fn().mockImplementation(function MockChannel() {
+    return { onmessage: null };
+  }),
   invoke: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -369,5 +389,109 @@ describe("_testProcessOnDataChunk — onData history tap", () => {
     const state2 = _testProcessOnDataChunk(state1, "\x03", "sess-1", "host");
     expect(state2.buffer).toBe("");
     expect(mockAddCommand).not.toHaveBeenCalled();
+  });
+});
+
+// ── WebGL addon integration tests ─────────────────────────────────────────────
+// Tests verify: (a) WebglAddon is constructed and loadAddon called after open(),
+// onContextLoss registered, and addon pushed to disposables; (b) when
+// WebglAddon constructor throws (no-WebGL env), openTerminal does NOT crash.
+
+import { WebglAddon } from "@xterm/addon-webgl";
+import { useTerminal } from "./useTerminal";
+
+const MockWebglAddon = vi.mocked(WebglAddon);
+
+// jsdom stubs required by openTerminal
+if (typeof ResizeObserver === "undefined") {
+  (globalThis as Record<string, unknown>).ResizeObserver = vi.fn().mockImplementation(function MockResizeObserver(_cb: ResizeObserverCallback) {
+    return { observe: vi.fn(), disconnect: vi.fn(), unobserve: vi.fn() };
+  });
+}
+if (typeof navigator.clipboard === "undefined") {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+  });
+}
+
+describe("WebglAddon integration — openTerminal", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    // Reset mock constructor state — use function syntax for constructor compatibility
+    MockWebglAddon.mockClear();
+    MockWebglAddon.mockImplementation(function MockWebglAddon() {
+      return { onContextLoss: vi.fn(), dispose: vi.fn() };
+    });
+  });
+
+  it("constructs WebglAddon and calls loadAddon with it after term.open()", async () => {
+    const { result } = renderHook(() => useTerminal());
+    let terminalId: string | undefined;
+    await act(async () => {
+      terminalId = await result.current.openTerminal(container, "sess-webgl-1");
+    });
+
+    // WebglAddon constructor must have been called once
+    expect(MockWebglAddon).toHaveBeenCalledTimes(1);
+
+    // The constructed instance must have been passed to term.loadAddon()
+    const { Terminal } = await import("@xterm/xterm");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const termInstance = vi.mocked(Terminal).mock.results.find(r => r.type === "return")?.value as any;
+    expect(termInstance).toBeDefined();
+    expect(termInstance.loadAddon).toHaveBeenCalledWith(
+      expect.objectContaining({ onContextLoss: expect.any(Function), dispose: expect.any(Function) }),
+    );
+
+    expect(typeof terminalId).toBe("string");
+  });
+
+  it("registers onContextLoss handler on the WebglAddon instance", async () => {
+    const mockOnContextLoss = vi.fn();
+    MockWebglAddon.mockImplementation(function MockWebglAddon() {
+      return { onContextLoss: mockOnContextLoss, dispose: vi.fn() };
+    });
+
+    const { result } = renderHook(() => useTerminal());
+    await act(async () => {
+      await result.current.openTerminal(container, "sess-webgl-2");
+    });
+
+    expect(mockOnContextLoss).toHaveBeenCalledTimes(1);
+    expect(mockOnContextLoss).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it("does not throw when WebglAddon constructor throws (graceful DOM fallback)", async () => {
+    // Simulate no-WebGL environment: constructor throws
+    MockWebglAddon.mockImplementation(function MockWebglAddon() {
+      throw new Error("WebGL2 not available");
+    });
+
+    const { result } = renderHook(() => useTerminal());
+    let terminalId: string | undefined;
+    await act(async () => {
+      terminalId = await result.current.openTerminal(container, "sess-webgl-3");
+    });
+    expect(terminalId).toBeDefined();
+  });
+
+  it("when WebglAddon throws, terminal is still functional (term.open was called)", async () => {
+    MockWebglAddon.mockImplementation(function MockWebglAddon() {
+      throw new Error("WebGL2 not available");
+    });
+
+    const { result } = renderHook(() => useTerminal());
+    await act(async () => {
+      await result.current.openTerminal(container, "sess-webgl-4");
+    });
+
+    const { Terminal } = await import("@xterm/xterm");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const termInstance = vi.mocked(Terminal).mock.results.find(r => r.type === "return")?.value as any;
+    expect(termInstance).toBeDefined();
+    expect(termInstance.open).toHaveBeenCalled();
   });
 });

--- a/src/features/terminal/useTerminal.ts
+++ b/src/features/terminal/useTerminal.ts
@@ -10,6 +10,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { SearchAddon } from "@xterm/addon-search";
 import type { ISearchOptions } from "@xterm/addon-search";
+import { WebglAddon } from "@xterm/addon-webgl";
 import { Channel } from "@tauri-apps/api/core";
 import { tauriInvoke } from "../../lib/tauri";
 import {
@@ -375,6 +376,23 @@ export function useTerminal() {
 
       // Attach mouseup AFTER term.open() so term.element exists
       term.element?.addEventListener("mouseup", handleMouseUp);
+
+      // Load WebGL renderer for GPU-accelerated rendering.
+      // Must come AFTER term.open() — WebglAddon requires a rendered canvas.
+      // Falls back silently to xterm's default DOM renderer when WebGL2 is
+      // unavailable (headless/jsdom, blocked GPU, context lost immediately).
+      try {
+        const webglAddon = new WebglAddon();
+        // If the GPU context is lost at runtime, dispose the addon so xterm
+        // reverts to its DOM renderer automatically.
+        webglAddon.onContextLoss(() => webglAddon.dispose());
+        term.loadAddon(webglAddon);
+        // WebglAddon implements IDisposable directly — include in lifecycle cleanup.
+        disposables.push(webglAddon);
+      } catch {
+        // WebGL2 unavailable (e.g. headless/jsdom, blocked GPU) — xterm keeps
+        // its default DOM renderer. No action needed.
+      }
 
       const instance: TerminalInstance = {
         terminal: term,


### PR DESCRIPTION
## Summary

Fifth item of the Voltius clean-room program. Enables GPU-accelerated terminal rendering via the official MIT `@xterm/addon-webgl`, with a safe automatic fallback to the default DOM renderer when WebGL is unavailable or the GPU context is lost. Standard documented xterm.js pattern; no Voltius (AGPL) code; frontend-only (no Rust).

## How it works

- `WebglAddon` is loaded **after** `term.open()` (it needs a live canvas), inside a `try/catch` so a WebGL failure (headless, blocked GPU) never crashes terminal setup — xterm keeps its DOM renderer.
- `onContextLoss → dispose` drops the addon if the GPU context is lost, reverting to DOM rendering instead of a broken terminal.
- The addon is tracked in the per-terminal `disposables` and disposed on both teardown paths (close + session dispose) — no GPU resource leak.

## Quality

- **361 tests green** (Vitest), `tsc --noEmit` clean
- Strict TDD: tests cover the success path (addon constructed, loaded, onContextLoss wired) and the throw path (graceful fallback, terminal still works)
- Focused review: **GO** — disposal verified on both teardown paths, fallback try/catch correctly scoped, version paired to xterm v6.
- Clean-room verified.