### PR TITLE
feat(terminal): split panes — multiple live terminals side-by-side

### DIFF
--- a/src/features/terminal/PaneSplitView.a11y.test.tsx
+++ b/src/features/terminal/PaneSplitView.a11y.test.tsx
@@ -1,0 +1,224 @@
+// PaneSplitView.a11y.test.tsx — TDD: accessibility for split panes
+//
+// Verifies:
+// 1. Each pane has role="region" and aria-label
+// 2. Each pane has tabIndex for keyboard navigation
+// 3. Keyboard shortcut (Alt+ArrowRight / Alt+ArrowLeft) moves focus between panes
+// 4. The tablist (tab bar) in TerminalTabs is NOT affected by split pane changes
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { usePaneLayoutStore } from "../../stores/paneLayoutStore";
+import { useSessionStore } from "../../stores/sessionStore";
+import type { SessionEntry } from "../../stores/sessionStore";
+import type { PaneLayout } from "../../stores/paneLayoutStore";
+
+// ── Global stubs ──────────────────────────────────────────────────────────────
+
+vi.hoisted(() => {
+  globalThis.ResizeObserver = class MockResizeObserver {
+    observe = vi.fn();
+    unobserve = vi.fn();
+    disconnect = vi.fn();
+    constructor(_: ResizeObserverCallback) {}
+  };
+});
+
+vi.hoisted(() => {
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, String(v)),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => void store.clear(),
+      key: (i: number) => [...store.keys()][i] ?? null,
+      get length() { return store.size; },
+    },
+  });
+});
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock("../../lib/tauri", () => ({
+  tauriInvoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  Channel: vi.fn().mockImplementation(() => ({ onmessage: null })),
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: vi.fn().mockImplementation(() => ({
+    loadAddon: vi.fn(), open: vi.fn(), cols: 80, rows: 24,
+    onData: vi.fn(), onBinary: vi.fn(), focus: vi.fn(), dispose: vi.fn(),
+    write: vi.fn(), writeln: vi.fn(), element: document.createElement("div"),
+  })),
+}));
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: vi.fn().mockImplementation(() => ({ fit: vi.fn(), dispose: vi.fn() })),
+}));
+vi.mock("@xterm/addon-web-links", () => ({
+  WebLinksAddon: vi.fn().mockImplementation(() => ({ dispose: vi.fn() })),
+}));
+vi.mock("@xterm/addon-search", () => ({
+  SearchAddon: vi.fn().mockImplementation(() => ({
+    activate: vi.fn(), dispose: vi.fn(),
+    findNext: vi.fn().mockReturnValue(false),
+    findPrevious: vi.fn().mockReturnValue(false),
+    onDidChangeResults: vi.fn(),
+  })),
+}));
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: vi.fn().mockImplementation(() => ({
+    onContextLoss: vi.fn(), dispose: vi.fn(),
+  })),
+}));
+
+vi.mock("./TerminalView", () => ({
+  TerminalView: ({ terminalId }: { terminalId: string | null }) => (
+    <div data-testid="terminal-view" data-terminal-id={terminalId ?? "pending"} />
+  ),
+}));
+
+vi.mock("../../lib/i18n", () => ({
+  useI18n: () => ({ t: (k: string) => k }),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function resetStores() {
+  usePaneLayoutStore.setState({ layouts: {} });
+  useSessionStore.setState({ sessions: new Map(), activeSessionId: null });
+}
+
+function makeSession(id: string): SessionEntry {
+  return {
+    id,
+    profileId: "p1",
+    profileName: "Test",
+    host: "host",
+    userId: "u1",
+    username: "user",
+    port: 22,
+    connectedAt: Date.now(),
+    state: "connected",
+    terminals: [
+      { id: "term-1", label: "Terminal 1", sessionId: id, reactKey: "rk-1" },
+      { id: "term-2", label: "Terminal 2", sessionId: id, reactKey: "rk-2" },
+    ],
+    activeTerminalId: "term-1",
+  };
+}
+
+function slotAt(layout: PaneLayout, idx: number) {
+  const s = layout.slots[idx];
+  if (!s) throw new Error(`No slot at index ${idx}`);
+  return s;
+}
+
+function setupTwoPane(sessionId: string) {
+  const session = makeSession(sessionId);
+  useSessionStore.setState({
+    sessions: new Map([[sessionId, session]]),
+    activeSessionId: sessionId,
+  });
+  usePaneLayoutStore.getState().openLayout(sessionId, "term-1");
+  const layout = usePaneLayoutStore.getState().layouts[sessionId]!;
+  const firstId = slotAt(layout, 0).id;
+  usePaneLayoutStore.getState().splitSlot(sessionId, firstId);
+  const layout2 = usePaneLayoutStore.getState().layouts[sessionId]!;
+  usePaneLayoutStore.getState().assignTerminal(sessionId, slotAt(layout2, 1).id, "term-2");
+}
+
+import { PaneSplitView } from "./PaneSplitView";
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("PaneSplitView — a11y: ARIA roles", () => {
+  beforeEach(resetStores);
+
+  it("each pane has role=region", () => {
+    setupTwoPane("sess-roles");
+    render(<PaneSplitView sessionId="sess-roles" />);
+    const regions = screen.getAllByRole("region");
+    expect(regions.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("each pane has a unique aria-label", () => {
+    setupTwoPane("sess-labels");
+    render(<PaneSplitView sessionId="sess-labels" />);
+    const regions = screen.getAllByRole("region");
+    const labels = regions.map((r) => r.getAttribute("aria-label"));
+    const unique = new Set(labels);
+    expect(unique.size).toBe(regions.length);
+  });
+
+  it("each pane is focusable (tabIndex >= 0)", () => {
+    setupTwoPane("sess-tabindex");
+    const { container } = render(<PaneSplitView sessionId="sess-tabindex" />);
+    const panes = container.querySelectorAll(".terminal-split-pane");
+    panes.forEach((pane) => {
+      const tabIndex = parseInt(pane.getAttribute("tabindex") ?? "-1", 10);
+      expect(tabIndex).toBeGreaterThanOrEqual(0);
+    });
+  });
+});
+
+describe("PaneSplitView — a11y: keyboard navigation", () => {
+  beforeEach(resetStores);
+
+  it("Alt+ArrowRight moves focus to the next pane", () => {
+    const sessionId = "sess-kbd-right";
+    setupTwoPane(sessionId);
+    const { container } = render(<PaneSplitView sessionId={sessionId} />);
+    const panes = container.querySelectorAll(".terminal-split-pane");
+
+    // Fire Alt+ArrowRight on the first focused pane
+    fireEvent.keyDown(panes[0]!, { key: "ArrowRight", altKey: true });
+
+    const layout = usePaneLayoutStore.getState().layouts[sessionId]!;
+    const secondSlotId = slotAt(layout, 1).id;
+    expect(layout.focusedSlotId).toBe(secondSlotId);
+  });
+
+  it("Alt+ArrowLeft moves focus to the previous pane", () => {
+    const sessionId = "sess-kbd-left";
+    setupTwoPane(sessionId);
+
+    // Pre-focus the second pane
+    const layout = usePaneLayoutStore.getState().layouts[sessionId]!;
+    const secondId = slotAt(layout, 1).id;
+    usePaneLayoutStore.getState().focusSlot(sessionId, secondId);
+
+    const { container } = render(<PaneSplitView sessionId={sessionId} />);
+    const panes = container.querySelectorAll(".terminal-split-pane");
+
+    fireEvent.keyDown(panes[1]!, { key: "ArrowLeft", altKey: true });
+
+    const layoutAfter = usePaneLayoutStore.getState().layouts[sessionId]!;
+    const firstSlotId = slotAt(layoutAfter, 0).id;
+    expect(layoutAfter.focusedSlotId).toBe(firstSlotId);
+  });
+
+  it("Alt+ArrowRight does not wrap past the last pane", () => {
+    const sessionId = "sess-kbd-nowrap";
+    setupTwoPane(sessionId);
+
+    // Pre-focus the second (last) pane
+    const layout = usePaneLayoutStore.getState().layouts[sessionId]!;
+    const secondId = slotAt(layout, 1).id;
+    usePaneLayoutStore.getState().focusSlot(sessionId, secondId);
+
+    const { container } = render(<PaneSplitView sessionId={sessionId} />);
+    const panes = container.querySelectorAll(".terminal-split-pane");
+
+    fireEvent.keyDown(panes[1]!, { key: "ArrowRight", altKey: true });
+
+    const layoutAfter = usePaneLayoutStore.getState().layouts[sessionId]!;
+    // Should stay on the last pane
+    expect(layoutAfter.focusedSlotId).toBe(secondId);
+  });
+});

--- a/src/features/terminal/PaneSplitView.test.tsx
+++ b/src/features/terminal/PaneSplitView.test.tsx
@@ -139,7 +139,10 @@ import { PaneSplitView } from "./PaneSplitView";
 describe("PaneSplitView — single-pane (slots.length === 1)", () => {
   beforeEach(resetStores);
 
-  it("renders a TerminalView for the single slot", () => {
+  it("renders nothing when layout has only 1 slot (single-pane rendering is TerminalTabs' responsibility)", () => {
+    // Architecture change: PaneSplitView is ONLY rendered for multi-pane (slots >= 2).
+    // Single-pane rendering (all tabs, display:block/none) is handled by TerminalTabs.
+    // PaneSplitView should return null when slots < 2.
     const sessionId = "sess-single";
     const session = makeSession(sessionId);
     useSessionStore.setState({
@@ -151,11 +154,8 @@ describe("PaneSplitView — single-pane (slots.length === 1)", () => {
     const { container } = render(
       <PaneSplitView sessionId={sessionId} />,
     );
-    const views = screen.getAllByTestId("terminal-view");
-    expect(views).toHaveLength(1);
-    // Single pane: isSplitPane should be false (single-terminal mode)
-    expect(views[0]!.dataset.splitPane).toBe("false");
-    // No split container when only 1 slot
+    // Single slot → PaneSplitView renders null (TerminalTabs owns single-pane rendering)
+    expect(container.firstChild).toBeNull();
     expect(container.querySelector(".terminal-split")).toBeNull();
   });
 });

--- a/src/features/terminal/PaneSplitView.test.tsx
+++ b/src/features/terminal/PaneSplitView.test.tsx
@@ -1,0 +1,330 @@
+// PaneSplitView.test.tsx — TDD RED phase
+//
+// Tests for the split-pane container component.
+// Uses mocked TerminalView so we stay pure jsdom (no real xterm).
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { usePaneLayoutStore } from "../../stores/paneLayoutStore";
+import { useSessionStore } from "../../stores/sessionStore";
+import type { SessionEntry } from "../../stores/sessionStore";
+import type { PaneLayout } from "../../stores/paneLayoutStore";
+
+// ── Global stubs ──────────────────────────────────────────────────────────────
+
+vi.hoisted(() => {
+  globalThis.ResizeObserver = class MockResizeObserver {
+    observe = vi.fn();
+    unobserve = vi.fn();
+    disconnect = vi.fn();
+    constructor(_: ResizeObserverCallback) {}
+  };
+});
+
+vi.hoisted(() => {
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, String(v)),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => void store.clear(),
+      key: (i: number) => [...store.keys()][i] ?? null,
+      get length() { return store.size; },
+    },
+  });
+});
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock("../../lib/tauri", () => ({
+  tauriInvoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  Channel: vi.fn().mockImplementation(() => ({ onmessage: null })),
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: vi.fn().mockImplementation(() => ({
+    loadAddon: vi.fn(),
+    open: vi.fn(),
+    cols: 80, rows: 24,
+    onData: vi.fn(), onBinary: vi.fn(),
+    focus: vi.fn(), dispose: vi.fn(),
+    write: vi.fn(), writeln: vi.fn(),
+    element: document.createElement("div"),
+  })),
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: vi.fn().mockImplementation(() => ({ fit: vi.fn(), dispose: vi.fn() })),
+}));
+vi.mock("@xterm/addon-web-links", () => ({
+  WebLinksAddon: vi.fn().mockImplementation(() => ({ dispose: vi.fn() })),
+}));
+vi.mock("@xterm/addon-search", () => ({
+  SearchAddon: vi.fn().mockImplementation(() => ({
+    activate: vi.fn(), dispose: vi.fn(),
+    findNext: vi.fn().mockReturnValue(false),
+    findPrevious: vi.fn().mockReturnValue(false),
+    onDidChangeResults: vi.fn(),
+  })),
+}));
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: vi.fn().mockImplementation(() => ({
+    onContextLoss: vi.fn(), dispose: vi.fn(),
+  })),
+}));
+
+// Mock TerminalView — we only care about layout, not real terminal
+vi.mock("./TerminalView", () => ({
+  TerminalView: ({
+    terminalId,
+    isSplitPane,
+  }: {
+    terminalId: string | null;
+    isSplitPane?: boolean;
+  }) => (
+    <div
+      data-testid="terminal-view"
+      data-terminal-id={terminalId ?? "pending"}
+      data-split-pane={isSplitPane ? "true" : "false"}
+    />
+  ),
+}));
+
+vi.mock("../../lib/i18n", () => ({
+  useI18n: () => ({ t: (k: string) => k }),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function resetStores() {
+  usePaneLayoutStore.setState({ layouts: {} });
+  useSessionStore.setState({ sessions: new Map(), activeSessionId: null });
+}
+
+function makeSession(id: string): SessionEntry {
+  return {
+    id,
+    profileId: "p1",
+    profileName: "Test",
+    host: "host",
+    userId: "u1",
+    username: "user",
+    port: 22,
+    connectedAt: Date.now(),
+    state: "connected",
+    terminals: [
+      { id: "term-1", label: "Terminal 1", sessionId: id, reactKey: "rk-1" },
+    ],
+    activeTerminalId: "term-1",
+  };
+}
+
+// Typed helper to get a slot at index without noUncheckedIndexedAccess errors
+function slotAt(layout: PaneLayout, idx: number) {
+  const s = layout.slots[idx];
+  if (!s) throw new Error(`No slot at index ${idx}`);
+  return s;
+}
+
+import { PaneSplitView } from "./PaneSplitView";
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("PaneSplitView — single-pane (slots.length === 1)", () => {
+  beforeEach(resetStores);
+
+  it("renders a TerminalView for the single slot", () => {
+    const sessionId = "sess-single";
+    const session = makeSession(sessionId);
+    useSessionStore.setState({
+      sessions: new Map([[sessionId, session]]),
+      activeSessionId: sessionId,
+    });
+    usePaneLayoutStore.getState().openLayout(sessionId, "term-1");
+
+    const { container } = render(
+      <PaneSplitView sessionId={sessionId} />,
+    );
+    const views = screen.getAllByTestId("terminal-view");
+    expect(views).toHaveLength(1);
+    // Single pane: isSplitPane should be false (single-terminal mode)
+    expect(views[0]!.dataset.splitPane).toBe("false");
+    // No split container when only 1 slot
+    expect(container.querySelector(".terminal-split")).toBeNull();
+  });
+});
+
+describe("PaneSplitView — multi-pane", () => {
+  beforeEach(resetStores);
+
+  it("renders N TerminalViews for N slots", () => {
+    const sessionId = "sess-multi";
+    const session = {
+      ...makeSession(sessionId),
+      terminals: [
+        { id: "term-1", label: "Terminal 1", sessionId, reactKey: "rk-1" },
+        { id: "term-2", label: "Terminal 2", sessionId, reactKey: "rk-2" },
+      ],
+      activeTerminalId: "term-1",
+    };
+    useSessionStore.setState({
+      sessions: new Map([[sessionId, session]]),
+      activeSessionId: sessionId,
+    });
+
+    usePaneLayoutStore.getState().openLayout(sessionId, "term-1");
+    const layout = usePaneLayoutStore.getState().layouts[sessionId]!;
+    const firstSlotId = slotAt(layout, 0).id;
+    usePaneLayoutStore.getState().splitSlot(sessionId, firstSlotId);
+    const layout2 = usePaneLayoutStore.getState().layouts[sessionId]!;
+    const secondSlotId = slotAt(layout2, 1).id;
+    usePaneLayoutStore.getState().assignTerminal(sessionId, secondSlotId, "term-2");
+
+    render(<PaneSplitView sessionId={sessionId} />);
+    const views = screen.getAllByTestId("terminal-view");
+    expect(views).toHaveLength(2);
+    // All panes in split mode should have isSplitPane=true
+    views.forEach((v) => expect(v.dataset.splitPane).toBe("true"));
+  });
+
+  it("renders the .terminal-split container for multi-pane", () => {
+    const sessionId = "sess-split-container";
+    const session = {
+      ...makeSession(sessionId),
+      terminals: [
+        { id: "term-1", label: "Terminal 1", sessionId, reactKey: "rk-1" },
+        { id: "term-2", label: "Terminal 2", sessionId, reactKey: "rk-2" },
+      ],
+      activeTerminalId: "term-1",
+    };
+    useSessionStore.setState({
+      sessions: new Map([[sessionId, session]]),
+      activeSessionId: sessionId,
+    });
+    usePaneLayoutStore.getState().openLayout(sessionId, "term-1");
+    const layout = usePaneLayoutStore.getState().layouts[sessionId]!;
+    const firstId = slotAt(layout, 0).id;
+    usePaneLayoutStore.getState().splitSlot(sessionId, firstId);
+
+    const { container } = render(<PaneSplitView sessionId={sessionId} />);
+    expect(container.querySelector(".terminal-split")).not.toBeNull();
+  });
+
+  it("renders a SplitHandle between each pair of panes", () => {
+    const sessionId = "sess-handles";
+    const session = {
+      ...makeSession(sessionId),
+      terminals: [
+        { id: "term-1", label: "Terminal 1", sessionId, reactKey: "rk-1" },
+        { id: "term-2", label: "Terminal 2", sessionId, reactKey: "rk-2" },
+        { id: "term-3", label: "Terminal 3", sessionId, reactKey: "rk-3" },
+      ],
+      activeTerminalId: "term-1",
+    };
+    useSessionStore.setState({
+      sessions: new Map([[sessionId, session]]),
+      activeSessionId: sessionId,
+    });
+    usePaneLayoutStore.getState().openLayout(sessionId, "term-1");
+    const l1 = usePaneLayoutStore.getState().layouts[sessionId]!;
+    const s1 = slotAt(l1, 0).id;
+    usePaneLayoutStore.getState().splitSlot(sessionId, s1);
+    const l2 = usePaneLayoutStore.getState().layouts[sessionId]!;
+    const s2 = slotAt(l2, 1).id;
+    usePaneLayoutStore.getState().splitSlot(sessionId, s2);
+
+    const { container } = render(<PaneSplitView sessionId={sessionId} />);
+    // 3 panes = 2 handles
+    const handles = container.querySelectorAll(".terminal-split-handle");
+    expect(handles).toHaveLength(2);
+  });
+
+  it("renders the focused pane with the data-focused attribute", () => {
+    const sessionId = "sess-focused";
+    const session = {
+      ...makeSession(sessionId),
+      terminals: [
+        { id: "term-1", label: "Terminal 1", sessionId, reactKey: "rk-1" },
+        { id: "term-2", label: "Terminal 2", sessionId, reactKey: "rk-2" },
+      ],
+      activeTerminalId: "term-1",
+    };
+    useSessionStore.setState({
+      sessions: new Map([[sessionId, session]]),
+      activeSessionId: sessionId,
+    });
+    usePaneLayoutStore.getState().openLayout(sessionId, "term-1");
+    const layout = usePaneLayoutStore.getState().layouts[sessionId]!;
+    const firstSlotId = slotAt(layout, 0).id;
+    usePaneLayoutStore.getState().splitSlot(sessionId, firstSlotId);
+
+    const { container } = render(<PaneSplitView sessionId={sessionId} />);
+    const panes = container.querySelectorAll(".terminal-split-pane");
+    // First pane focused by default
+    expect(panes[0]!.getAttribute("data-focused")).toBe("true");
+    expect(panes[1]!.getAttribute("data-focused")).toBe("false");
+  });
+});
+
+describe("PaneSplitView — a11y", () => {
+  beforeEach(resetStores);
+
+  it("gives each pane role=region with an aria-label", () => {
+    const sessionId = "sess-a11y";
+    const session = {
+      ...makeSession(sessionId),
+      terminals: [
+        { id: "term-1", label: "Terminal 1", sessionId, reactKey: "rk-1" },
+        { id: "term-2", label: "Terminal 2", sessionId, reactKey: "rk-2" },
+      ],
+      activeTerminalId: "term-1",
+    };
+    useSessionStore.setState({
+      sessions: new Map([[sessionId, session]]),
+      activeSessionId: sessionId,
+    });
+    usePaneLayoutStore.getState().openLayout(sessionId, "term-1");
+    const layout = usePaneLayoutStore.getState().layouts[sessionId]!;
+    const firstId = slotAt(layout, 0).id;
+    usePaneLayoutStore.getState().splitSlot(sessionId, firstId);
+
+    render(<PaneSplitView sessionId={sessionId} />);
+    const regions = screen.getAllByRole("region");
+    expect(regions.length).toBeGreaterThanOrEqual(2);
+    regions.forEach((r) => expect(r.getAttribute("aria-label")).not.toBeNull());
+  });
+
+  it("clicking a pane calls focusSlot", () => {
+    const sessionId = "sess-click";
+    const session = {
+      ...makeSession(sessionId),
+      terminals: [
+        { id: "term-1", label: "Terminal 1", sessionId, reactKey: "rk-1" },
+        { id: "term-2", label: "Terminal 2", sessionId, reactKey: "rk-2" },
+      ],
+      activeTerminalId: "term-1",
+    };
+    useSessionStore.setState({
+      sessions: new Map([[sessionId, session]]),
+      activeSessionId: sessionId,
+    });
+    usePaneLayoutStore.getState().openLayout(sessionId, "term-1");
+    const layout = usePaneLayoutStore.getState().layouts[sessionId]!;
+    const firstId = slotAt(layout, 0).id;
+    usePaneLayoutStore.getState().splitSlot(sessionId, firstId);
+    const layout2 = usePaneLayoutStore.getState().layouts[sessionId]!;
+    const secondId = slotAt(layout2, 1).id;
+
+    const { container } = render(<PaneSplitView sessionId={sessionId} />);
+    const panes = container.querySelectorAll(".terminal-split-pane");
+    fireEvent.click(panes[1]!);
+
+    expect(usePaneLayoutStore.getState().layouts[sessionId]!.focusedSlotId).toBe(secondId);
+  });
+});

--- a/src/features/terminal/PaneSplitView.tsx
+++ b/src/features/terminal/PaneSplitView.tsx
@@ -50,6 +50,35 @@ export function PaneSplitView({ sessionId, onTerminalOpened }: PaneSplitViewProp
     [sessionId, assignTerminal, setActiveTerminal, onTerminalOpened],
   );
 
+  // Alt+Arrow keyboard navigation between panes.
+  // Alt modifier avoids conflicting with terminal arrow keys (used for line navigation).
+  const handlePaneKeyDown = useCallback(
+    (e: React.KeyboardEvent, currentIndex: number) => {
+      if (!e.altKey) return;
+      if (e.key !== "ArrowRight" && e.key !== "ArrowLeft") return;
+
+      const currentLayout = usePaneLayoutStore.getState().layouts[sessionId];
+      if (!currentLayout) return;
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      const targetIdx =
+        e.key === "ArrowRight"
+          ? Math.min(currentIndex + 1, currentLayout.slots.length - 1)
+          : Math.max(currentIndex - 1, 0);
+
+      const targetSlot = currentLayout.slots[targetIdx];
+      if (!targetSlot) return;
+
+      focusSlot(sessionId, targetSlot.id);
+      if (targetSlot.terminalId) {
+        setActiveTerminal(sessionId, targetSlot.terminalId);
+      }
+    },
+    [sessionId, focusSlot, setActiveTerminal],
+  );
+
   const handleDragEnd = useCallback(
     (leftSlotId: string, rightSlotId: string, deltaFraction: number) => {
       if (!layout) return;
@@ -124,6 +153,7 @@ export function PaneSplitView({ sessionId, onTerminalOpened }: PaneSplitViewProp
               tabIndex={0}
               onClick={() => handlePaneClick(slot.id, slot.terminalId)}
               onFocus={() => handlePaneClick(slot.id, slot.terminalId)}
+              onKeyDown={(e) => handlePaneKeyDown(e, i)}
             >
               <TerminalView
                 sessionId={sessionId}

--- a/src/features/terminal/PaneSplitView.tsx
+++ b/src/features/terminal/PaneSplitView.tsx
@@ -1,33 +1,46 @@
 // features/terminal/PaneSplitView.tsx — Split-pane terminal grid
 //
 // Renders a flat 1D ordered list of pane slots, each containing a TerminalView.
-// When only one slot exists: renders the TerminalView directly (no split chrome)
-// so single-terminal behavior is IDENTICAL to today.
+// ONLY rendered when slots.length >= 2 (multi-pane mode).
+// Single-pane rendering is handled directly in TerminalTabs (all tabs visible).
 //
 // Critical invariants (from explore):
-//   1. isSplitPane=false for single-pane: TerminalView keeps its display:none hide/show
+//   1. isSplitPane=true: TerminalView is always display:block
 //   2. Stable React keys: PaneSlot.id (UUID), never terminalId — avoids remount flicker
 //   3. Fit on drag-END only: SplitHandle defers fit until pointer-up
 //   4. MAX_PANE_COUNT = 4 enforced in paneLayoutStore
 //   5. Focus: clicking a pane calls focusSlot → sessionStore.setActiveTerminal
-//   6. a11y: role="region" + aria-label per pane; tabIndex for keyboard focus
+//   6. Only the focused pane gets active=true (drives real xterm focus)
+//   7. a11y: role="region" + aria-label per pane; tabIndex for keyboard focus
 
 import React, { useCallback, useRef } from "react";
 import { usePaneLayoutStore } from "../../stores/paneLayoutStore";
 import { useSessionStore } from "../../stores/sessionStore";
 import { TerminalView } from "./TerminalView";
 import { SplitHandle } from "./SplitHandle";
+import { useI18n } from "../../lib/i18n";
 import type { SessionId } from "../../lib/types";
 
 interface PaneSplitViewProps {
   sessionId: SessionId;
   onTerminalOpened?: (slotId: string, terminalId: string) => void;
+  /** Called when the user clicks the × on a pane. Non-destructive: removes
+   *  the slot from the layout but keeps the terminal tab alive. */
+  onClosePane?: (slotId: string) => void;
+  /** Called when the user clicks the direction-toggle button. */
+  onDirectionToggle?: () => void;
 }
 
-export function PaneSplitView({ sessionId, onTerminalOpened }: PaneSplitViewProps) {
+export function PaneSplitView({
+  sessionId,
+  onTerminalOpened,
+  onClosePane,
+  onDirectionToggle,
+}: PaneSplitViewProps) {
   const layout = usePaneLayoutStore((s) => s.layouts[sessionId]);
   const { focusSlot, setRatio, assignTerminal } = usePaneLayoutStore.getState();
   const { setActiveTerminal, sessions } = useSessionStore();
+  const { t } = useI18n();
 
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -44,7 +57,14 @@ export function PaneSplitView({ sessionId, onTerminalOpened }: PaneSplitViewProp
   const handleTerminalOpened = useCallback(
     (slotId: string, realTerminalId: string) => {
       assignTerminal(sessionId, slotId, realTerminalId);
-      setActiveTerminal(sessionId, realTerminalId);
+
+      // MINOR-2: if this slot is the focused one, update activeTerminalId now
+      // so the session store doesn't lag behind the pane layout.
+      const currentLayout = usePaneLayoutStore.getState().layouts[sessionId];
+      if (currentLayout?.focusedSlotId === slotId) {
+        setActiveTerminal(sessionId, realTerminalId);
+      }
+
       onTerminalOpened?.(slotId, realTerminalId);
     },
     [sessionId, assignTerminal, setActiveTerminal, onTerminalOpened],
@@ -97,35 +117,14 @@ export function PaneSplitView({ sessionId, onTerminalOpened }: PaneSplitViewProp
     [layout, sessionId, setRatio],
   );
 
-  // No layout yet — render nothing (layout is created by TerminalTabs on first open)
-  if (!layout) return null;
+  // No layout yet, or layout is in single-pane mode — render nothing.
+  // Single-pane rendering (all tabs, display:block/none) is TerminalTabs' responsibility.
+  // PaneSplitView is only rendered when slots >= 2.
+  if (!layout || layout.slots.length < 2) return null;
 
   const { slots, direction, focusedSlotId } = layout;
-  const isMultiPane = slots.length > 1;
   const session = sessions.get(sessionId);
 
-  // Single-pane: delegate entirely to TerminalView in its normal mode.
-  // This ensures single-terminal behavior is IDENTICAL to today.
-  if (!isMultiPane) {
-    const slot = slots[0]!; // safe: slots.length >= 1 always (store invariant)
-    const tab = session?.terminals.find(
-      (t) => t.id === slot.terminalId || (slot.terminalId == null && t.id.startsWith("pending-")),
-    );
-    const isActive = slot.terminalId === session?.activeTerminalId;
-    return (
-      <TerminalView
-        key={slot.id}
-        sessionId={sessionId}
-        terminalId={slot.terminalId}
-        onTerminalOpened={(realId) => handleTerminalOpened(slot.id, realId)}
-        active={isActive}
-        isSplitPane={false}
-        reactKey={tab?.reactKey ?? slot.id}
-      />
-    );
-  }
-
-  // Multi-pane: render split grid with handles
   const containerSizePx = containerRef.current
     ? direction === "horizontal"
       ? containerRef.current.offsetWidth
@@ -137,8 +136,27 @@ export function PaneSplitView({ sessionId, onTerminalOpened }: PaneSplitViewProp
       ref={containerRef}
       className={`terminal-split terminal-split-${direction}`}
     >
+      {/* Direction toggle button — visible only in split mode */}
+      {onDirectionToggle && (
+        <button
+          className="terminal-split-direction-toggle"
+          onClick={onDirectionToggle}
+          title={direction === "horizontal"
+            ? t("terminal.splitVertical")
+            : t("terminal.splitHorizontal")}
+          aria-label={direction === "horizontal"
+            ? t("terminal.splitVertical")
+            : t("terminal.splitHorizontal")}
+        >
+          {direction === "horizontal" ? "⊠" : "⊟"}
+        </button>
+      )}
+
       {slots.map((slot, i) => {
+        // MAJOR-2 fix: only the focused pane gets active=true
+        // This ensures only the focused pane's terminal receives real keyboard focus.
         const isFocused = slot.id === focusedSlotId;
+        const isActive = isFocused || slot.terminalId === session?.activeTerminalId;
         const isLast = i === slots.length - 1;
         const flexStyle = { flex: slot.ratio };
 
@@ -155,11 +173,25 @@ export function PaneSplitView({ sessionId, onTerminalOpened }: PaneSplitViewProp
               onFocus={() => handlePaneClick(slot.id, slot.terminalId)}
               onKeyDown={(e) => handlePaneKeyDown(e, i)}
             >
+              {/* Per-pane close button — non-destructive (removes split, keeps tab) */}
+              {onClosePane && (
+                <button
+                  className="terminal-split-pane-close"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onClosePane(slot.id);
+                  }}
+                  title={t("terminal.closePane")}
+                  aria-label={t("terminal.closePane")}
+                >
+                  ×
+                </button>
+              )}
               <TerminalView
                 sessionId={sessionId}
                 terminalId={slot.terminalId}
                 onTerminalOpened={(realId) => handleTerminalOpened(slot.id, realId)}
-                active={true}
+                active={isActive}
                 isSplitPane={true}
               />
             </div>

--- a/src/features/terminal/PaneSplitView.tsx
+++ b/src/features/terminal/PaneSplitView.tsx
@@ -1,0 +1,151 @@
+// features/terminal/PaneSplitView.tsx — Split-pane terminal grid
+//
+// Renders a flat 1D ordered list of pane slots, each containing a TerminalView.
+// When only one slot exists: renders the TerminalView directly (no split chrome)
+// so single-terminal behavior is IDENTICAL to today.
+//
+// Critical invariants (from explore):
+//   1. isSplitPane=false for single-pane: TerminalView keeps its display:none hide/show
+//   2. Stable React keys: PaneSlot.id (UUID), never terminalId — avoids remount flicker
+//   3. Fit on drag-END only: SplitHandle defers fit until pointer-up
+//   4. MAX_PANE_COUNT = 4 enforced in paneLayoutStore
+//   5. Focus: clicking a pane calls focusSlot → sessionStore.setActiveTerminal
+//   6. a11y: role="region" + aria-label per pane; tabIndex for keyboard focus
+
+import React, { useCallback, useRef } from "react";
+import { usePaneLayoutStore } from "../../stores/paneLayoutStore";
+import { useSessionStore } from "../../stores/sessionStore";
+import { TerminalView } from "./TerminalView";
+import { SplitHandle } from "./SplitHandle";
+import type { SessionId } from "../../lib/types";
+
+interface PaneSplitViewProps {
+  sessionId: SessionId;
+  onTerminalOpened?: (slotId: string, terminalId: string) => void;
+}
+
+export function PaneSplitView({ sessionId, onTerminalOpened }: PaneSplitViewProps) {
+  const layout = usePaneLayoutStore((s) => s.layouts[sessionId]);
+  const { focusSlot, setRatio, assignTerminal } = usePaneLayoutStore.getState();
+  const { setActiveTerminal, sessions } = useSessionStore();
+
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handlePaneClick = useCallback(
+    (slotId: string, terminalId: string | null) => {
+      focusSlot(sessionId, slotId);
+      if (terminalId) {
+        setActiveTerminal(sessionId, terminalId);
+      }
+    },
+    [sessionId, focusSlot, setActiveTerminal],
+  );
+
+  const handleTerminalOpened = useCallback(
+    (slotId: string, realTerminalId: string) => {
+      assignTerminal(sessionId, slotId, realTerminalId);
+      setActiveTerminal(sessionId, realTerminalId);
+      onTerminalOpened?.(slotId, realTerminalId);
+    },
+    [sessionId, assignTerminal, setActiveTerminal, onTerminalOpened],
+  );
+
+  const handleDragEnd = useCallback(
+    (leftSlotId: string, rightSlotId: string, deltaFraction: number) => {
+      if (!layout) return;
+      const leftSlot = layout.slots.find((s) => s.id === leftSlotId);
+      const rightSlot = layout.slots.find((s) => s.id === rightSlotId);
+      if (!leftSlot || !rightSlot) return;
+
+      // Redistribute ratio between the two adjacent panes
+      const combined = leftSlot.ratio + rightSlot.ratio;
+      const newLeft = Math.max(0.1, Math.min(combined - 0.1, leftSlot.ratio + deltaFraction));
+      const newRight = combined - newLeft;
+
+      setRatio(sessionId, leftSlotId, newLeft);
+      setRatio(sessionId, rightSlotId, newRight);
+    },
+    [layout, sessionId, setRatio],
+  );
+
+  // No layout yet — render nothing (layout is created by TerminalTabs on first open)
+  if (!layout) return null;
+
+  const { slots, direction, focusedSlotId } = layout;
+  const isMultiPane = slots.length > 1;
+  const session = sessions.get(sessionId);
+
+  // Single-pane: delegate entirely to TerminalView in its normal mode.
+  // This ensures single-terminal behavior is IDENTICAL to today.
+  if (!isMultiPane) {
+    const slot = slots[0]!; // safe: slots.length >= 1 always (store invariant)
+    const tab = session?.terminals.find(
+      (t) => t.id === slot.terminalId || (slot.terminalId == null && t.id.startsWith("pending-")),
+    );
+    const isActive = slot.terminalId === session?.activeTerminalId;
+    return (
+      <TerminalView
+        key={slot.id}
+        sessionId={sessionId}
+        terminalId={slot.terminalId}
+        onTerminalOpened={(realId) => handleTerminalOpened(slot.id, realId)}
+        active={isActive}
+        isSplitPane={false}
+        reactKey={tab?.reactKey ?? slot.id}
+      />
+    );
+  }
+
+  // Multi-pane: render split grid with handles
+  const containerSizePx = containerRef.current
+    ? direction === "horizontal"
+      ? containerRef.current.offsetWidth
+      : containerRef.current.offsetHeight
+    : 0;
+
+  return (
+    <div
+      ref={containerRef}
+      className={`terminal-split terminal-split-${direction}`}
+    >
+      {slots.map((slot, i) => {
+        const isFocused = slot.id === focusedSlotId;
+        const isLast = i === slots.length - 1;
+        const flexStyle = { flex: slot.ratio };
+
+        return (
+          <React.Fragment key={slot.id}>
+            <div
+              className="terminal-split-pane"
+              style={flexStyle}
+              data-focused={isFocused ? "true" : "false"}
+              role="region"
+              aria-label={`Terminal pane ${i + 1}`}
+              tabIndex={0}
+              onClick={() => handlePaneClick(slot.id, slot.terminalId)}
+              onFocus={() => handlePaneClick(slot.id, slot.terminalId)}
+            >
+              <TerminalView
+                sessionId={sessionId}
+                terminalId={slot.terminalId}
+                onTerminalOpened={(realId) => handleTerminalOpened(slot.id, realId)}
+                active={true}
+                isSplitPane={true}
+              />
+            </div>
+            {!isLast && (
+              <SplitHandle
+                direction={direction}
+                containerSize={containerSizePx}
+                onDragEnd={(delta) => {
+                  const nextSlot = slots[i + 1];
+                  if (nextSlot) handleDragEnd(slot.id, nextSlot.id, delta);
+                }}
+              />
+            )}
+          </React.Fragment>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/terminal/PaneSplitView.tsx
+++ b/src/features/terminal/PaneSplitView.tsx
@@ -27,15 +27,12 @@ interface PaneSplitViewProps {
   /** Called when the user clicks the × on a pane. Non-destructive: removes
    *  the slot from the layout but keeps the terminal tab alive. */
   onClosePane?: (slotId: string) => void;
-  /** Called when the user clicks the direction-toggle button. */
-  onDirectionToggle?: () => void;
 }
 
 export function PaneSplitView({
   sessionId,
   onTerminalOpened,
   onClosePane,
-  onDirectionToggle,
 }: PaneSplitViewProps) {
   const layout = usePaneLayoutStore((s) => s.layouts[sessionId]);
   const { focusSlot, setRatio, assignTerminal } = usePaneLayoutStore.getState();
@@ -136,22 +133,6 @@ export function PaneSplitView({
       ref={containerRef}
       className={`terminal-split terminal-split-${direction}`}
     >
-      {/* Direction toggle button — visible only in split mode */}
-      {onDirectionToggle && (
-        <button
-          className="terminal-split-direction-toggle"
-          onClick={onDirectionToggle}
-          title={direction === "horizontal"
-            ? t("terminal.splitVertical")
-            : t("terminal.splitHorizontal")}
-          aria-label={direction === "horizontal"
-            ? t("terminal.splitVertical")
-            : t("terminal.splitHorizontal")}
-        >
-          {direction === "horizontal" ? "⊠" : "⊟"}
-        </button>
-      )}
-
       {slots.map((slot, i) => {
         // MAJOR-2 fix: only the focused pane gets active=true
         // This ensures only the focused pane's terminal receives real keyboard focus.

--- a/src/features/terminal/SplitHandle.tsx
+++ b/src/features/terminal/SplitHandle.tsx
@@ -1,0 +1,66 @@
+// features/terminal/SplitHandle.tsx — Draggable resize handle between split panes
+//
+// Design constraints (from explore):
+//   - During drag: update flex sizing via CSS only (data-ratio on parent pane)
+//   - Call fit ONCE on pointer-up, not on every pointer-move
+//   - The existing per-container ResizeObserver (RESIZE_DEBOUNCE_MS=100ms)
+//     handles add/close re-fit automatically
+
+import { useCallback, useRef } from "react";
+import type { PaneDirection } from "../../stores/paneLayoutStore";
+
+interface SplitHandleProps {
+  direction: PaneDirection;
+  onDragEnd: (deltaFraction: number) => void;
+  /** Total pixel size of the split container (width for horizontal, height for vertical) */
+  containerSize: number;
+}
+
+export function SplitHandle({ direction, onDragEnd, containerSize }: SplitHandleProps) {
+  const startPosRef = useRef<number>(0);
+  const draggingRef = useRef(false);
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      e.currentTarget.setPointerCapture(e.pointerId);
+      draggingRef.current = true;
+      startPosRef.current = direction === "horizontal" ? e.clientX : e.clientY;
+    },
+    [direction],
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!draggingRef.current) return;
+      // No-op during move: CSS flex handles visual update via ratio changes
+      // deferred to pointer-up to avoid ResizeObserver/fit churn
+      e.preventDefault();
+    },
+    [],
+  );
+
+  const handlePointerUp = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!draggingRef.current) return;
+      draggingRef.current = false;
+      e.currentTarget.releasePointerCapture(e.pointerId);
+
+      const endPos = direction === "horizontal" ? e.clientX : e.clientY;
+      const delta = endPos - startPosRef.current;
+      const deltaFraction = containerSize > 0 ? delta / containerSize : 0;
+      onDragEnd(deltaFraction);
+    },
+    [direction, containerSize, onDragEnd],
+  );
+
+  return (
+    <div
+      className="terminal-split-handle"
+      role="separator"
+      aria-orientation={direction === "horizontal" ? "vertical" : "horizontal"}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+    />
+  );
+}

--- a/src/features/terminal/TerminalTabs.fix.test.tsx
+++ b/src/features/terminal/TerminalTabs.fix.test.tsx
@@ -1,0 +1,318 @@
+// TerminalTabs.fix.test.tsx — TDD RED phase: regression tests for FIX PASS
+//
+// CRITICAL-1: single-pane multi-tab renders blank on "+"
+//   - With 2 tabs and NO split (<=1 slot), both TerminalViews must render.
+//   - Active tab has display:block, inactive display:none.
+//   - Clicking "+" keeps a visible active terminal (not blank).
+//
+// CRITICAL-2: closing a tab while split orphans its pane
+//   - With 2 panes (2 slots), closing one tab removes its slot.
+//   - Ratios renormalize. Slots drop below 2 → single-pane mode.
+//
+// MAJOR-1: close-pane button exists and is wired (non-destructive)
+//   - A per-pane close button (× or similar) must exist in split mode.
+//   - Clicking it removes the slot (not the tab). Slots < 2 → single-pane.
+//
+// MAJOR-2: active prop only true for the focused pane in split mode
+//   - Only the focused pane's TerminalView gets active=true.
+//   - Clicking a pane makes it active.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { useSessionStore } from "../../stores/sessionStore";
+import { usePaneLayoutStore } from "../../stores/paneLayoutStore";
+import type { SessionEntry } from "../../stores/sessionStore";
+
+// ── Global stubs ──────────────────────────────────────────────────────────────
+
+vi.hoisted(() => {
+  globalThis.ResizeObserver = class MockResizeObserver {
+    observe = vi.fn();
+    unobserve = vi.fn();
+    disconnect = vi.fn();
+    constructor(_: ResizeObserverCallback) {}
+  };
+});
+
+vi.hoisted(() => {
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, String(v)),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => void store.clear(),
+      key: (i: number) => [...store.keys()][i] ?? null,
+      get length() {
+        return store.size;
+      },
+    },
+  });
+});
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock("../../lib/tauri", () => ({
+  tauriInvoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  Channel: vi.fn().mockImplementation(() => ({ onmessage: null })),
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: vi.fn().mockImplementation(() => ({
+    loadAddon: vi.fn(),
+    open: vi.fn(),
+    cols: 80,
+    rows: 24,
+    onData: vi.fn(),
+    onBinary: vi.fn(),
+    focus: vi.fn(),
+    dispose: vi.fn(),
+    write: vi.fn(),
+    writeln: vi.fn(),
+    element: document.createElement("div"),
+  })),
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: vi.fn().mockImplementation(() => ({ fit: vi.fn(), dispose: vi.fn() })),
+}));
+vi.mock("@xterm/addon-web-links", () => ({
+  WebLinksAddon: vi.fn().mockImplementation(() => ({ dispose: vi.fn() })),
+}));
+vi.mock("@xterm/addon-search", () => ({
+  SearchAddon: vi.fn().mockImplementation(() => ({
+    activate: vi.fn(),
+    dispose: vi.fn(),
+    findNext: vi.fn().mockReturnValue(false),
+    findPrevious: vi.fn().mockReturnValue(false),
+    onDidChangeResults: vi.fn(),
+  })),
+}));
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: vi.fn().mockImplementation(() => ({
+    onContextLoss: vi.fn(),
+    dispose: vi.fn(),
+  })),
+}));
+
+// TerminalView mock that reports active and isSplitPane as attributes
+vi.mock("./TerminalView", () => ({
+  TerminalView: ({
+    active,
+    isSplitPane,
+    terminalId,
+  }: {
+    active: boolean;
+    isSplitPane?: boolean;
+    terminalId?: string | null;
+    sessionId?: string;
+    onTerminalOpened?: (id: string) => void;
+    reactKey?: string;
+  }) => (
+    <div
+      data-testid="terminal-view"
+      data-active={String(active)}
+      data-split-pane={isSplitPane ? "true" : "false"}
+      data-terminal-id={terminalId ?? ""}
+    />
+  ),
+}));
+
+vi.mock("../../lib/i18n", () => ({
+  useI18n: () => ({ t: (k: string) => k }),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeSession(id: string, terminalCount = 1): SessionEntry {
+  const terminals = Array.from({ length: terminalCount }, (_, i) => ({
+    id: `term-${i + 1}`,
+    label: `Terminal ${i + 1}`,
+    sessionId: id,
+    reactKey: `rk-${i + 1}`,
+  }));
+  return {
+    id,
+    profileId: "p1",
+    profileName: "Test",
+    host: "host",
+    userId: "u1",
+    username: "user",
+    port: 22,
+    connectedAt: Date.now(),
+    state: "connected",
+    terminals,
+    activeTerminalId: "term-1",
+  };
+}
+
+function resetStores() {
+  useSessionStore.setState({ sessions: new Map(), activeSessionId: null });
+  usePaneLayoutStore.setState({ layouts: {} });
+}
+
+import { TerminalTabs } from "./TerminalTabs";
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("CRITICAL-1: single-pane multi-tab renders all tabs", () => {
+  beforeEach(resetStores);
+  afterEach(resetStores);
+
+  it("renders TWO TerminalViews when session has 2 tabs and no split (1 slot)", async () => {
+    // Session with 2 real tabs, no split
+    const session = makeSession("sid-multi", 2);
+    useSessionStore.setState({
+      sessions: new Map([["sid-multi", session]]),
+      activeSessionId: "sid-multi",
+    });
+    // Seed layout with 1 slot (unsplit)
+    usePaneLayoutStore.getState().openLayout("sid-multi", "term-1");
+    expect(usePaneLayoutStore.getState().layouts["sid-multi"]?.slots).toHaveLength(1);
+
+    render(<TerminalTabs sessionId="sid-multi" />);
+    await act(async () => {});
+
+    // Both TerminalViews must be in the DOM
+    const views = screen.getAllByTestId("terminal-view");
+    expect(views.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("active tab has data-active=true, inactive tab has data-active=false in single-pane mode", async () => {
+    const session = makeSession("sid-active", 2);
+    // term-1 is active
+    useSessionStore.setState({
+      sessions: new Map([["sid-active", session]]),
+      activeSessionId: "sid-active",
+    });
+    usePaneLayoutStore.getState().openLayout("sid-active", "term-1");
+
+    render(<TerminalTabs sessionId="sid-active" />);
+    await act(async () => {});
+
+    const views = screen.getAllByTestId("terminal-view");
+    const activeViews = views.filter((v) => v.getAttribute("data-active") === "true");
+    const inactiveViews = views.filter((v) => v.getAttribute("data-active") === "false");
+    // Exactly one active, at least one inactive
+    expect(activeViews.length).toBe(1);
+    expect(inactiveViews.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("all TerminalViews in single-pane mode have isSplitPane=false", async () => {
+    const session = makeSession("sid-nosplit", 2);
+    useSessionStore.setState({
+      sessions: new Map([["sid-nosplit", session]]),
+      activeSessionId: "sid-nosplit",
+    });
+    usePaneLayoutStore.getState().openLayout("sid-nosplit", "term-1");
+
+    render(<TerminalTabs sessionId="sid-nosplit" />);
+    await act(async () => {});
+
+    const views = screen.getAllByTestId("terminal-view");
+    for (const v of views) {
+      expect(v.getAttribute("data-split-pane")).toBe("false");
+    }
+  });
+});
+
+describe("CRITICAL-2: closing a tab while split removes its pane slot", () => {
+  beforeEach(resetStores);
+  afterEach(resetStores);
+
+  it("closing one tab in split mode removes its slot and returns to single-pane", async () => {
+    const session = makeSession("sid-close-split", 2);
+    useSessionStore.setState({
+      sessions: new Map([["sid-close-split", session]]),
+      activeSessionId: "sid-close-split",
+    });
+    // Seed layout with 2 slots (split active)
+    usePaneLayoutStore.getState().openLayout("sid-close-split", "term-1");
+    usePaneLayoutStore.getState().splitSlot(
+      "sid-close-split",
+      usePaneLayoutStore.getState().layouts["sid-close-split"]!.slots[0]!.id,
+    );
+    // Assign term-2 to slot-1
+    const slots = usePaneLayoutStore.getState().layouts["sid-close-split"]!.slots;
+    usePaneLayoutStore.getState().assignTerminal("sid-close-split", slots[1]!.id, "term-2");
+
+    expect(usePaneLayoutStore.getState().layouts["sid-close-split"]?.slots).toHaveLength(2);
+
+    render(<TerminalTabs sessionId="sid-close-split" />);
+    await act(async () => {});
+
+    // Close the first tab (term-1) via its × button
+    const closeButtons = document.querySelectorAll(".terminal-tab-close");
+    expect(closeButtons.length).toBeGreaterThanOrEqual(1);
+
+    await act(async () => {
+      (closeButtons[0] as HTMLButtonElement).click();
+    });
+
+    // Slot count must drop below 2 (returns to single-pane)
+    const layoutAfter = usePaneLayoutStore.getState().layouts["sid-close-split"];
+    const slotCount = layoutAfter?.slots.length ?? 0;
+    expect(slotCount).toBeLessThan(2);
+  });
+
+  it("closing a tab in split mode also removes the corresponding tab from session", async () => {
+    const session = makeSession("sid-tab-close", 2);
+    useSessionStore.setState({
+      sessions: new Map([["sid-tab-close", session]]),
+      activeSessionId: "sid-tab-close",
+    });
+    usePaneLayoutStore.getState().openLayout("sid-tab-close", "term-1");
+    usePaneLayoutStore.getState().splitSlot(
+      "sid-tab-close",
+      usePaneLayoutStore.getState().layouts["sid-tab-close"]!.slots[0]!.id,
+    );
+    const slots = usePaneLayoutStore.getState().layouts["sid-tab-close"]!.slots;
+    usePaneLayoutStore.getState().assignTerminal("sid-tab-close", slots[1]!.id, "term-2");
+
+    render(<TerminalTabs sessionId="sid-tab-close" />);
+    await act(async () => {});
+
+    const closeButtons = document.querySelectorAll(".terminal-tab-close");
+    await act(async () => {
+      (closeButtons[0] as HTMLButtonElement).click();
+    });
+
+    // One tab should have been removed
+    const updatedSession = useSessionStore.getState().sessions.get("sid-tab-close");
+    expect(updatedSession?.terminals.length).toBe(1);
+  });
+});
+
+describe("MAJOR-2: active prop only for focused pane in split mode", () => {
+  beforeEach(resetStores);
+  afterEach(resetStores);
+
+  it("only the focused pane's TerminalView gets active=true in split mode", async () => {
+    const session = makeSession("sid-focus", 2);
+    useSessionStore.setState({
+      sessions: new Map([["sid-focus", session]]),
+      activeSessionId: "sid-focus",
+    });
+    usePaneLayoutStore.getState().openLayout("sid-focus", "term-1");
+    usePaneLayoutStore.getState().splitSlot(
+      "sid-focus",
+      usePaneLayoutStore.getState().layouts["sid-focus"]!.slots[0]!.id,
+    );
+    const slots = usePaneLayoutStore.getState().layouts["sid-focus"]!.slots;
+    usePaneLayoutStore.getState().assignTerminal("sid-focus", slots[1]!.id, "term-2");
+
+    render(<TerminalTabs sessionId="sid-focus" />);
+    await act(async () => {});
+
+    // In split mode, active=true must only be on the focused pane
+    const views = screen.getAllByTestId("terminal-view");
+    const activeViews = views.filter((v) => v.getAttribute("data-active") === "true");
+    // Exactly one pane should have active=true
+    expect(activeViews.length).toBe(1);
+  });
+});

--- a/src/features/terminal/TerminalTabs.fix.test.tsx
+++ b/src/features/terminal/TerminalTabs.fix.test.tsx
@@ -316,3 +316,174 @@ describe("MAJOR-2: active prop only for focused pane in split mode", () => {
     expect(activeViews.length).toBe(1);
   });
 });
+
+// ── New regression tests for FINAL POLISH PASS ────────────────────────────────
+
+describe("(a) new-tab when NOT split produces a visible active terminal", () => {
+  beforeEach(resetStores);
+  afterEach(resetStores);
+
+  it("clicking + in single-pane mode results in an active TerminalView being present", async () => {
+    // One tab, no split
+    const session = makeSession("sid-newtab", 1);
+    useSessionStore.setState({
+      sessions: new Map([["sid-newtab", session]]),
+      activeSessionId: "sid-newtab",
+    });
+    usePaneLayoutStore.getState().openLayout("sid-newtab", "term-1");
+
+    render(<TerminalTabs sessionId="sid-newtab" />);
+    await act(async () => {});
+
+    // Click the "+" new-tab button
+    const newTabBtn = document.querySelector<HTMLButtonElement>(".terminal-tab-new");
+    expect(newTabBtn).not.toBeNull();
+    await act(async () => {
+      newTabBtn!.click();
+    });
+
+    // The component must remain in single-pane mode (no split triggered)
+    const layout = usePaneLayoutStore.getState().layouts["sid-newtab"];
+    expect(layout?.slots.length ?? 0).toBeLessThan(2);
+
+    // At least one TerminalView with data-active="true" must be in the DOM
+    const views = screen.getAllByTestId("terminal-view");
+    const activeViews = views.filter((v) => v.getAttribute("data-active") === "true");
+    expect(activeViews.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("(b) tab-switching visibility: clicking inactive tab makes it active/visible", () => {
+  beforeEach(resetStores);
+  afterEach(resetStores);
+
+  it("with 2 tabs in single-pane mode, clicking the inactive tab flips active to it", async () => {
+    // term-1 is initially active
+    const session = makeSession("sid-tabswitch", 2);
+    useSessionStore.setState({
+      sessions: new Map([["sid-tabswitch", session]]),
+      activeSessionId: "sid-tabswitch",
+    });
+    usePaneLayoutStore.getState().openLayout("sid-tabswitch", "term-1");
+
+    render(<TerminalTabs sessionId="sid-tabswitch" />);
+    await act(async () => {});
+
+    // Confirm term-1 is initially active
+    let views = screen.getAllByTestId("terminal-view");
+    const initialActive = views.filter((v) => v.getAttribute("data-active") === "true");
+    expect(initialActive.length).toBe(1);
+    expect(initialActive[0]!.getAttribute("data-terminal-id")).toBe("term-1");
+
+    // Click the second tab (term-2)
+    const tabs = document.querySelectorAll(".terminal-tab");
+    expect(tabs.length).toBeGreaterThanOrEqual(2);
+    await act(async () => {
+      (tabs[1] as HTMLElement).click();
+    });
+
+    // Now term-2 should be the active terminal in the store
+    const updatedSession = useSessionStore.getState().sessions.get("sid-tabswitch");
+    expect(updatedSession?.activeTerminalId).toBe("term-2");
+
+    // The TerminalView for term-2 must now have data-active="true"
+    views = screen.getAllByTestId("terminal-view");
+    const nowActive = views.filter((v) => v.getAttribute("data-active") === "true");
+    expect(nowActive.length).toBe(1);
+    expect(nowActive[0]!.getAttribute("data-terminal-id")).toBe("term-2");
+  });
+});
+
+describe("(c) per-pane close button: calls closeSlot and returns to single-pane", () => {
+  beforeEach(resetStores);
+  afterEach(resetStores);
+
+  it("clicking pane × removes the slot and view returns to single-pane mode", async () => {
+    const session = makeSession("sid-pane-close", 2);
+    useSessionStore.setState({
+      sessions: new Map([["sid-pane-close", session]]),
+      activeSessionId: "sid-pane-close",
+    });
+    usePaneLayoutStore.getState().openLayout("sid-pane-close", "term-1");
+    usePaneLayoutStore.getState().splitSlot(
+      "sid-pane-close",
+      usePaneLayoutStore.getState().layouts["sid-pane-close"]!.slots[0]!.id,
+    );
+    const slots = usePaneLayoutStore.getState().layouts["sid-pane-close"]!.slots;
+    usePaneLayoutStore.getState().assignTerminal("sid-pane-close", slots[1]!.id, "term-2");
+
+    expect(usePaneLayoutStore.getState().layouts["sid-pane-close"]?.slots).toHaveLength(2);
+
+    render(<TerminalTabs sessionId="sid-pane-close" />);
+    await act(async () => {});
+
+    // Find and click the per-pane close button (× on the pane itself, not the tab bar)
+    const paneCloseButtons = document.querySelectorAll(".terminal-split-pane-close");
+    expect(paneCloseButtons.length).toBeGreaterThanOrEqual(1);
+
+    await act(async () => {
+      (paneCloseButtons[0] as HTMLButtonElement).click();
+    });
+
+    // Slot count must drop below 2 (returns to single-pane)
+    const layoutAfter = usePaneLayoutStore.getState().layouts["sid-pane-close"];
+    const slotCount = layoutAfter?.slots.length ?? 0;
+    expect(slotCount).toBeLessThan(2);
+
+    // The tabs must still exist (non-destructive close — only the slot was removed)
+    const updatedSession = useSessionStore.getState().sessions.get("sid-pane-close");
+    expect(updatedSession?.terminals.length).toBe(2);
+  });
+});
+
+describe("(d) mode toggle preserves live terminal: single → split → single", () => {
+  beforeEach(resetStores);
+  afterEach(resetStores);
+
+  it("after splitting and then returning to single-pane, original terminal is still active/visible", async () => {
+    const session = makeSession("sid-roundtrip", 1);
+    useSessionStore.setState({
+      sessions: new Map([["sid-roundtrip", session]]),
+      activeSessionId: "sid-roundtrip",
+    });
+    usePaneLayoutStore.getState().openLayout("sid-roundtrip", "term-1");
+
+    render(<TerminalTabs sessionId="sid-roundtrip" />);
+    await act(async () => {});
+
+    // Verify single-pane: term-1 active
+    {
+      const views = screen.getAllByTestId("terminal-view");
+      expect(views.some((v) => v.getAttribute("data-active") === "true")).toBe(true);
+    }
+
+    // Split → now in multi-pane mode
+    const splitBtn = document.querySelector<HTMLButtonElement>(".terminal-tab-split");
+    expect(splitBtn).not.toBeNull();
+    await act(async () => {
+      splitBtn!.click();
+    });
+
+    expect(usePaneLayoutStore.getState().layouts["sid-roundtrip"]?.slots.length).toBeGreaterThanOrEqual(2);
+
+    // Return to single-pane: close one of the pane slots
+    const paneCloseButtons = document.querySelectorAll(".terminal-split-pane-close");
+    expect(paneCloseButtons.length).toBeGreaterThanOrEqual(1);
+    await act(async () => {
+      (paneCloseButtons[0] as HTMLButtonElement).click();
+    });
+
+    // Back to single-pane
+    const layoutAfter = usePaneLayoutStore.getState().layouts["sid-roundtrip"];
+    expect((layoutAfter?.slots.length ?? 0)).toBeLessThan(2);
+
+    // The original terminal (term-1) must still be present and there must be an active view
+    const updatedSession = useSessionStore.getState().sessions.get("sid-roundtrip");
+    expect(updatedSession?.terminals.some((t) => t.id === "term-1" || t.id.startsWith("pending-"))).toBe(true);
+
+    const views = screen.getAllByTestId("terminal-view");
+    const activeViews = views.filter((v) => v.getAttribute("data-active") === "true");
+    // At least one terminal must be active/visible after round-trip
+    expect(activeViews.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/features/terminal/TerminalTabs.split.test.tsx
+++ b/src/features/terminal/TerminalTabs.split.test.tsx
@@ -1,0 +1,240 @@
+// TerminalTabs.split.test.tsx — TDD: split-pane wiring in TerminalTabs
+//
+// Verifies that TerminalTabs correctly:
+// 1. Renders a split button in the tab bar
+// 2. Initializes the pane layout on first render
+// 3. Invokes PaneSplitView for the terminal area
+// 4. Does NOT break the existing tablist / WAI-ARIA behavior
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { useSessionStore } from "../../stores/sessionStore";
+import { usePaneLayoutStore } from "../../stores/paneLayoutStore";
+import type { SessionEntry } from "../../stores/sessionStore";
+
+// ── Global stubs ──────────────────────────────────────────────────────────────
+
+vi.hoisted(() => {
+  globalThis.ResizeObserver = class MockResizeObserver {
+    observe = vi.fn();
+    unobserve = vi.fn();
+    disconnect = vi.fn();
+    constructor(_: ResizeObserverCallback) {}
+  };
+});
+
+vi.hoisted(() => {
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, String(v)),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => void store.clear(),
+      key: (i: number) => [...store.keys()][i] ?? null,
+      get length() { return store.size; },
+    },
+  });
+});
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock("../../lib/tauri", () => ({
+  tauriInvoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  Channel: vi.fn().mockImplementation(() => ({ onmessage: null })),
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: vi.fn().mockImplementation(() => ({
+    loadAddon: vi.fn(), open: vi.fn(), cols: 80, rows: 24,
+    onData: vi.fn(), onBinary: vi.fn(), focus: vi.fn(), dispose: vi.fn(),
+    write: vi.fn(), writeln: vi.fn(), element: document.createElement("div"),
+  })),
+}));
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: vi.fn().mockImplementation(() => ({ fit: vi.fn(), dispose: vi.fn() })),
+}));
+vi.mock("@xterm/addon-web-links", () => ({
+  WebLinksAddon: vi.fn().mockImplementation(() => ({ dispose: vi.fn() })),
+}));
+vi.mock("@xterm/addon-search", () => ({
+  SearchAddon: vi.fn().mockImplementation(() => ({
+    activate: vi.fn(), dispose: vi.fn(),
+    findNext: vi.fn().mockReturnValue(false),
+    findPrevious: vi.fn().mockReturnValue(false),
+    onDidChangeResults: vi.fn(),
+  })),
+}));
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: vi.fn().mockImplementation(() => ({
+    onContextLoss: vi.fn(), dispose: vi.fn(),
+  })),
+}));
+
+vi.mock("./TerminalView", () => ({
+  TerminalView: ({ active, isSplitPane }: { active: boolean; isSplitPane?: boolean }) => (
+    <div
+      data-testid="terminal-view"
+      data-active={active}
+      data-split-pane={isSplitPane ? "true" : "false"}
+    />
+  ),
+}));
+
+vi.mock("../../lib/i18n", () => ({
+  useI18n: () => ({ t: (k: string) => k }),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeSession(id: string): SessionEntry {
+  return {
+    id,
+    profileId: "p1",
+    profileName: "Test",
+    host: "host",
+    userId: "u1",
+    username: "user",
+    port: 22,
+    connectedAt: Date.now(),
+    state: "connected",
+    terminals: [
+      { id: "term-1", label: "Terminal 1", sessionId: id, reactKey: "rk-1" },
+    ],
+    activeTerminalId: "term-1",
+  };
+}
+
+function resetStores() {
+  useSessionStore.setState({ sessions: new Map(), activeSessionId: null });
+  usePaneLayoutStore.setState({ layouts: {} });
+}
+
+import { TerminalTabs } from "./TerminalTabs";
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("TerminalTabs — split button", () => {
+  beforeEach(resetStores);
+  afterEach(resetStores);
+
+  it("renders a split-horizontal button in the tab bar", () => {
+    const session = makeSession("sid-split-1");
+    useSessionStore.setState({
+      sessions: new Map([["sid-split-1", session]]),
+      activeSessionId: "sid-split-1",
+    });
+    render(<TerminalTabs sessionId="sid-split-1" />);
+    const splitBtn = document.querySelector(".terminal-tab-split");
+    expect(splitBtn).not.toBeNull();
+  });
+
+  it("tablist is still present after mounting with split feature", () => {
+    const session = makeSession("sid-split-2");
+    useSessionStore.setState({
+      sessions: new Map([["sid-split-2", session]]),
+      activeSessionId: "sid-split-2",
+    });
+    render(<TerminalTabs sessionId="sid-split-2" />);
+    expect(screen.getByRole("tablist")).toBeInTheDocument();
+  });
+});
+
+describe("TerminalTabs — pane layout initialization", () => {
+  beforeEach(resetStores);
+  afterEach(resetStores);
+
+  it("initializes a pane layout for the session on first render", async () => {
+    const session = makeSession("sid-init");
+    useSessionStore.setState({
+      sessions: new Map([["sid-init", session]]),
+      activeSessionId: "sid-init",
+    });
+    render(<TerminalTabs sessionId="sid-init" />);
+
+    // After mount + effect, layout should exist
+    await act(async () => {});
+    const layout = usePaneLayoutStore.getState().layouts["sid-init"];
+    expect(layout).toBeDefined();
+  });
+
+  it("layout starts with exactly one slot when session has one terminal", async () => {
+    const session = makeSession("sid-one-slot");
+    useSessionStore.setState({
+      sessions: new Map([["sid-one-slot", session]]),
+      activeSessionId: "sid-one-slot",
+    });
+    render(<TerminalTabs sessionId="sid-one-slot" />);
+
+    await act(async () => {});
+    const layout = usePaneLayoutStore.getState().layouts["sid-one-slot"];
+    expect(layout?.slots).toHaveLength(1);
+  });
+
+  it("removes the layout when session is removed", async () => {
+    const session = makeSession("sid-cleanup");
+    useSessionStore.setState({
+      sessions: new Map([["sid-cleanup", session]]),
+      activeSessionId: "sid-cleanup",
+    });
+    const { unmount } = render(<TerminalTabs sessionId="sid-cleanup" />);
+
+    await act(async () => {});
+    expect(usePaneLayoutStore.getState().layouts["sid-cleanup"]).toBeDefined();
+
+    unmount();
+    expect(usePaneLayoutStore.getState().layouts["sid-cleanup"]).toBeUndefined();
+  });
+});
+
+describe("TerminalTabs — split action creates a new pane", () => {
+  beforeEach(resetStores);
+  afterEach(resetStores);
+
+  it("clicking split adds a slot to the pane layout", async () => {
+    const session = makeSession("sid-click-split");
+    useSessionStore.setState({
+      sessions: new Map([["sid-click-split", session]]),
+      activeSessionId: "sid-click-split",
+    });
+    render(<TerminalTabs sessionId="sid-click-split" />);
+
+    await act(async () => {});
+    const layout = usePaneLayoutStore.getState().layouts["sid-click-split"];
+    expect(layout?.slots).toHaveLength(1);
+
+    const splitBtn = document.querySelector<HTMLButtonElement>(".terminal-tab-split");
+    expect(splitBtn).not.toBeNull();
+    await act(async () => {
+      splitBtn!.click();
+    });
+
+    const layoutAfter = usePaneLayoutStore.getState().layouts["sid-click-split"];
+    expect(layoutAfter?.slots).toHaveLength(2);
+  });
+
+  it("clicking split also adds a new TerminalTab to the session", async () => {
+    const session = makeSession("sid-click-split-tab");
+    useSessionStore.setState({
+      sessions: new Map([["sid-click-split-tab", session]]),
+      activeSessionId: "sid-click-split-tab",
+    });
+    render(<TerminalTabs sessionId="sid-click-split-tab" />);
+
+    await act(async () => {});
+
+    const splitBtn = document.querySelector<HTMLButtonElement>(".terminal-tab-split");
+    await act(async () => {
+      splitBtn!.click();
+    });
+
+    const updatedSession = useSessionStore.getState().sessions.get("sid-click-split-tab");
+    // Should now have 2 terminal tabs (original + new pending)
+    expect(updatedSession!.terminals).toHaveLength(2);
+  });
+});

--- a/src/features/terminal/TerminalTabs.tsx
+++ b/src/features/terminal/TerminalTabs.tsx
@@ -2,10 +2,16 @@
 //
 // Shows tab bar for multiple terminal channels on the same session.
 // Each tab wraps a TerminalView that stays alive when hidden (not destroyed).
+//
+// Split-pane support (v1):
+//   The tab bar gains a split button. Clicking it calls splitSlot on the
+//   paneLayoutStore (adding a new pane) AND adds a pending TerminalTab to
+//   sessionStore. PaneSplitView renders the terminal area for all pane counts.
 
 import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
 import { useSessionStore, type TerminalTab } from "../../stores/sessionStore";
-import { TerminalView } from "./TerminalView";
+import { usePaneLayoutStore, MAX_PANE_COUNT } from "../../stores/paneLayoutStore";
+import { PaneSplitView } from "./PaneSplitView";
 import { useTerminal } from "./useTerminal";
 import { useI18n } from "../../lib/i18n";
 import type { SessionId } from "../../lib/types";
@@ -30,6 +36,13 @@ export function TerminalTabs({ sessionId, onOpenSnippets }: TerminalTabsProps) {
   const { sessions, addTerminalTab, removeTerminalTab, replaceTerminalTab, setActiveTerminal } =
     useSessionStore();
   const { closeTerminal } = useTerminal();
+  const {
+    openLayout,
+    removeLayout,
+    splitSlot,
+    assignTerminal,
+    layouts: paneLayouts,
+  } = usePaneLayoutStore();
 
   // Read session — may be undefined after disconnect/session-switch.
   // ALL hooks must run unconditionally before any early return so the
@@ -39,6 +52,8 @@ export function TerminalTabs({ sessionId, onOpenSnippets }: TerminalTabsProps) {
   // Null-safe derived values — used by hooks below
   const terminals = session?.terminals ?? [];
   const activeTerminalId = session?.activeTerminalId;
+  const paneLayout = paneLayouts[sessionId];
+  const paneCount = paneLayout?.slots.length ?? 0;
 
   // Connection info for the info bar
   const hostLabel = useMemo(
@@ -87,6 +102,28 @@ export function TerminalTabs({ sessionId, onOpenSnippets }: TerminalTabsProps) {
     }
   }, [session, terminals.length, sessionId, addTerminalTab]);
 
+  // Initialize pane layout once the first terminal is present.
+  // This runs after the auto-create effect above, so by the time we look up
+  // terminals[0] it will be the pending tab that was just added.
+  useEffect(() => {
+    if (!session) return;
+    const firstTab = terminals[0];
+    if (!firstTab) return;
+    if (paneLayouts[sessionId]) return; // already initialized
+
+    // Use the current terminalId (or null for pending tabs — assignTerminal
+    // will update it when the xterm opens via the onTerminalOpened callback).
+    const initialTerminalId = firstTab.id.startsWith("pending-") ? null : firstTab.id;
+    openLayout(sessionId, initialTerminalId ?? firstTab.id);
+  }, [session, terminals, sessionId, paneLayouts, openLayout]);
+
+  // Remove the pane layout when this component unmounts (session closed / navigated away)
+  useEffect(() => {
+    return () => {
+      removeLayout(sessionId);
+    };
+  }, [sessionId, removeLayout]);
+
   const handleNewTab = useCallback(async () => {
     const nextNum = getNextTerminalNumber();
     const stableKey = crypto.randomUUID();
@@ -107,6 +144,65 @@ export function TerminalTabs({ sessionId, onOpenSnippets }: TerminalTabsProps) {
       removeTerminalTab(sessionId, tab.id);
     },
     [sessionId, closeTerminal, removeTerminalTab],
+  );
+
+  // Split the active pane: add a new pending tab AND a new pane slot.
+  const handleSplit = useCallback(async () => {
+    const currentLayout = usePaneLayoutStore.getState().layouts[sessionId];
+    if (!currentLayout) return;
+    if (currentLayout.slots.length >= MAX_PANE_COUNT) return;
+
+    // Find the focused slot to split after
+    const focusedSlotId = currentLayout.focusedSlotId;
+
+    // Add a new pending terminal tab (mirrors handleNewTab)
+    const nextNum = getNextTerminalNumber();
+    const stableKey = crypto.randomUUID();
+    const pendingId = `pending-${stableKey}`;
+    addTerminalTab(sessionId, {
+      id: pendingId,
+      label: `Terminal ${nextNum}`,
+      sessionId,
+      reactKey: stableKey,
+    });
+
+    // Add a new pane slot in the layout
+    splitSlot(sessionId, focusedSlotId);
+
+    // Link the pending tab to the new slot (the last slot after split)
+    // assignTerminal will be called again when the real terminal opens via
+    // PaneSplitView's onTerminalOpened → but we pre-link with pending so
+    // PaneSplitView can render the TerminalView immediately
+    const newLayout = usePaneLayoutStore.getState().layouts[sessionId];
+    if (newLayout) {
+      const lastSlot = newLayout.slots[newLayout.slots.length - 1];
+      if (lastSlot) {
+        assignTerminal(sessionId, lastSlot.id, pendingId);
+      }
+    }
+  }, [sessionId, addTerminalTab, splitSlot, assignTerminal, getNextTerminalNumber]);
+
+  // When a terminal opens via PaneSplitView, sync the slot's terminalId with the
+  // real (non-pending) ID. Also handle the tab replacement (M3 fix pattern).
+  const handlePaneSplitTerminalOpened = useCallback(
+    (slotId: string, realId: string) => {
+      // Find the pending tab that corresponds to this slot
+      const currentLayout = usePaneLayoutStore.getState().layouts[sessionId];
+      const slot = currentLayout?.slots.find((s) => s.id === slotId);
+      if (slot?.terminalId?.startsWith("pending-")) {
+        replaceTerminalTab(sessionId, slot.terminalId, {
+          id: realId,
+          label:
+            sessions
+              .get(sessionId)
+              ?.terminals.find((t) => t.id === slot.terminalId)?.label ?? `Terminal`,
+          sessionId,
+          reactKey: slot.terminalId.replace("pending-", ""),
+        });
+        assignTerminal(sessionId, slotId, realId);
+      }
+    },
+    [sessionId, replaceTerminalTab, assignTerminal, sessions],
   );
 
   const tabBarRef = useRef<HTMLDivElement>(null);
@@ -190,6 +286,15 @@ export function TerminalTabs({ sessionId, onOpenSnippets }: TerminalTabsProps) {
         >
           +
         </button>
+        <button
+          className="terminal-tab-split"
+          onClick={() => void handleSplit()}
+          title={t("terminal.splitHorizontal")}
+          disabled={paneCount >= MAX_PANE_COUNT}
+          aria-label={t("terminal.splitHorizontal")}
+        >
+          ⊟
+        </button>
         {onOpenSnippets && (
           <button
             className="terminal-tab-snippets"
@@ -216,7 +321,10 @@ export function TerminalTabs({ sessionId, onOpenSnippets }: TerminalTabsProps) {
         </span>
       </div>
 
-      {/* Terminal views — hidden but alive when not active */}
+      {/* Terminal views — managed by PaneSplitView for all pane counts.
+          Single-slot path: PaneSplitView delegates to TerminalView with
+          isSplitPane=false → display:none/block behavior IDENTICAL to today.
+          Multi-slot path: PaneSplitView renders the split grid. */}
       <div className="terminal-views">
         {terminals.length === 0 ? (
           <div className="terminal-empty">
@@ -224,26 +332,10 @@ export function TerminalTabs({ sessionId, onOpenSnippets }: TerminalTabsProps) {
             <span>{t("terminal.noTerminal")}</span>
           </div>
         ) : (
-          terminals.map((tab) => (
-            <TerminalView
-              key={tab.reactKey}
-              sessionId={sessionId}
-              terminalId={tab.id.startsWith("pending-") ? null : tab.id}
-              onTerminalOpened={(realId) => {
-                // M3 fix: Atomic tab replacement — single state update instead
-                // of remove+add which caused a visual flash and potential leak.
-                // reactKey is preserved so React doesn't remount the component.
-                if (tab.id.startsWith("pending-")) {
-                  replaceTerminalTab(sessionId, tab.id, {
-                    ...tab,
-                    id: realId,
-                    reactKey: tab.reactKey,
-                  });
-                }
-              }}
-              active={tab.id === activeTerminalId}
-            />
-          ))
+          <PaneSplitView
+            sessionId={sessionId}
+            onTerminalOpened={handlePaneSplitTerminalOpened}
+          />
         )}
       </div>
     </div>

--- a/src/features/terminal/TerminalTabs.tsx
+++ b/src/features/terminal/TerminalTabs.tsx
@@ -3,15 +3,25 @@
 // Shows tab bar for multiple terminal channels on the same session.
 // Each tab wraps a TerminalView that stays alive when hidden (not destroyed).
 //
-// Split-pane support (v1):
-//   The tab bar gains a split button. Clicking it calls splitSlot on the
-//   paneLayoutStore (adding a new pane) AND adds a pending TerminalTab to
-//   sessionStore. PaneSplitView renders the terminal area for all pane counts.
+// Rendering model (v2 — correct):
+//   Panes are a VIEW over the existing session tabs.
+//   - Single-pane (slots <= 1): render ALL tabs via TerminalView with isSplitPane=false.
+//     Active tab is display:block, inactive tabs display:none. Pane layout is ignored.
+//     This is IDENTICAL to pre-split behavior and restores multi-tab behavior.
+//   - Multi-pane (slots >= 2): render PaneSplitView, each slot maps to one terminal.
+//
+// Split reconciliation:
+//   - "+" new tab: adds a tab only (does NOT add a slot). Single-pane mode shows it.
+//   - Split button: adds a new terminal + slot. Layout switches to multi-pane.
+//   - Close TAB (× in tab bar): removes tab + if slot found → removes slot too.
+//     When slots drop below 2, view returns to single-pane automatically.
+//   - Close PANE (× on each pane): removes slot only (tab stays alive). Non-destructive.
 
 import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
 import { useSessionStore, type TerminalTab } from "../../stores/sessionStore";
 import { usePaneLayoutStore, MAX_PANE_COUNT } from "../../stores/paneLayoutStore";
 import { PaneSplitView } from "./PaneSplitView";
+import { TerminalView } from "./TerminalView";
 import { useTerminal } from "./useTerminal";
 import { useI18n } from "../../lib/i18n";
 import type { SessionId } from "../../lib/types";
@@ -40,7 +50,9 @@ export function TerminalTabs({ sessionId, onOpenSnippets }: TerminalTabsProps) {
     openLayout,
     removeLayout,
     splitSlot,
+    closeSlot,
     assignTerminal,
+    setDirection,
     layouts: paneLayouts,
   } = usePaneLayoutStore();
 
@@ -142,8 +154,18 @@ export function TerminalTabs({ sessionId, onOpenSnippets }: TerminalTabsProps) {
         await closeTerminal(tab.id, sessionId);
       }
       removeTerminalTab(sessionId, tab.id);
+      // If this tab was assigned to a pane slot, remove that slot too.
+      // This keeps the pane layout and tab list in sync.
+      // When slots drop below 2 the view returns to single-pane mode automatically.
+      const currentLayout = usePaneLayoutStore.getState().layouts[sessionId];
+      if (currentLayout) {
+        const matchingSlot = currentLayout.slots.find((s) => s.terminalId === tab.id);
+        if (matchingSlot && currentLayout.slots.length > 1) {
+          closeSlot(sessionId, matchingSlot.id);
+        }
+      }
     },
-    [sessionId, closeTerminal, removeTerminalTab],
+    [sessionId, closeTerminal, removeTerminalTab, closeSlot],
   );
 
   // Split the active pane: add a new pending tab AND a new pane slot.
@@ -181,6 +203,27 @@ export function TerminalTabs({ sessionId, onOpenSnippets }: TerminalTabsProps) {
       }
     }
   }, [sessionId, addTerminalTab, splitSlot, assignTerminal, getNextTerminalNumber]);
+
+  // Close a pane slot (non-destructive: removes the slot from the split view,
+  // keeps the terminal tab alive and reachable from the tab bar).
+  // When slots drop below 2, the view returns to single-pane mode automatically.
+  const handleClosePane = useCallback(
+    (slotId: string) => {
+      const currentLayout = usePaneLayoutStore.getState().layouts[sessionId];
+      if (!currentLayout) return;
+      if (currentLayout.slots.length <= 1) return; // never remove the last slot
+      closeSlot(sessionId, slotId);
+    },
+    [sessionId, closeSlot],
+  );
+
+  // Toggle split direction between horizontal and vertical.
+  const handleDirectionToggle = useCallback(() => {
+    const currentLayout = usePaneLayoutStore.getState().layouts[sessionId];
+    if (!currentLayout) return;
+    const next = currentLayout.direction === "horizontal" ? "vertical" : "horizontal";
+    setDirection(sessionId, next);
+  }, [sessionId, setDirection]);
 
   // When a terminal opens via PaneSplitView, sync the slot's terminalId with the
   // real (non-pending) ID. Also handle the tab replacement (M3 fix pattern).
@@ -321,21 +364,64 @@ export function TerminalTabs({ sessionId, onOpenSnippets }: TerminalTabsProps) {
         </span>
       </div>
 
-      {/* Terminal views — managed by PaneSplitView for all pane counts.
-          Single-slot path: PaneSplitView delegates to TerminalView with
-          isSplitPane=false → display:none/block behavior IDENTICAL to today.
-          Multi-slot path: PaneSplitView renders the split grid. */}
+      {/* Terminal views — rendering mode depends on split state:
+          - Single-pane (slots <= 1 OR no layout): render ALL tabs via TerminalView
+            with isSplitPane=false → display:block/none active/inactive toggle.
+            This is IDENTICAL to pre-split behavior. The pane layout is IGNORED.
+          - Multi-pane (slots >= 2): render PaneSplitView over the slots.
+            Each slot maps to one TerminalView with isSplitPane=true. */}
       <div className="terminal-views">
         {terminals.length === 0 ? (
           <div className="terminal-empty">
             <span className="terminal-empty-icon">&#9002;</span>
             <span>{t("terminal.noTerminal")}</span>
           </div>
-        ) : (
+        ) : paneCount >= 2 ? (
           <PaneSplitView
             sessionId={sessionId}
             onTerminalOpened={handlePaneSplitTerminalOpened}
+            onClosePane={handleClosePane}
+            onDirectionToggle={handleDirectionToggle}
           />
+        ) : (
+          // Single-pane mode: render all tabs, show only the active one.
+          // This preserves the multi-tab display:block/none behavior exactly
+          // and is NOT affected by the pane layout store at all.
+          terminals.map((tab) => {
+            const isActive = tab.id === activeTerminalId;
+            return (
+              <TerminalView
+                key={tab.reactKey}
+                sessionId={sessionId}
+                terminalId={tab.id.startsWith("pending-") ? null : tab.id}
+                onTerminalOpened={(realId) => {
+                  // Replace the pending tab entry with the real one
+                  if (tab.id.startsWith("pending-")) {
+                    replaceTerminalTab(sessionId, tab.id, {
+                      id: realId,
+                      label: tab.label,
+                      sessionId,
+                      reactKey: tab.reactKey,
+                    });
+                  }
+                  // Keep the pane layout slot[0] in sync with the first real terminal
+                  const currentLayout = usePaneLayoutStore.getState().layouts[sessionId];
+                  if (currentLayout) {
+                    const pendingSlot = currentLayout.slots.find(
+                      (s) => s.terminalId === tab.id || s.terminalId === null,
+                    );
+                    if (pendingSlot) {
+                      assignTerminal(sessionId, pendingSlot.id, realId);
+                    }
+                  }
+                  setActiveTerminal(sessionId, realId);
+                }}
+                active={isActive}
+                isSplitPane={false}
+                reactKey={tab.reactKey}
+              />
+            );
+          })
         )}
       </div>
     </div>

--- a/src/features/terminal/TerminalTabs.tsx
+++ b/src/features/terminal/TerminalTabs.tsx
@@ -338,6 +338,24 @@ export function TerminalTabs({ sessionId, onOpenSnippets }: TerminalTabsProps) {
         >
           ⊟
         </button>
+        {paneCount >= 2 && (
+          <button
+            className="terminal-tab-split-direction"
+            onClick={handleDirectionToggle}
+            title={
+              paneLayout?.direction === "horizontal"
+                ? t("terminal.splitVertical")
+                : t("terminal.splitHorizontal")
+            }
+            aria-label={
+              paneLayout?.direction === "horizontal"
+                ? t("terminal.splitVertical")
+                : t("terminal.splitHorizontal")
+            }
+          >
+            {paneLayout?.direction === "horizontal" ? "⊠" : "⊟"}
+          </button>
+        )}
         {onOpenSnippets && (
           <button
             className="terminal-tab-snippets"
@@ -381,7 +399,6 @@ export function TerminalTabs({ sessionId, onOpenSnippets }: TerminalTabsProps) {
             sessionId={sessionId}
             onTerminalOpened={handlePaneSplitTerminalOpened}
             onClosePane={handleClosePane}
-            onDirectionToggle={handleDirectionToggle}
           />
         ) : (
           // Single-pane mode: render all tabs, show only the active one.

--- a/src/features/terminal/TerminalView.tsx
+++ b/src/features/terminal/TerminalView.tsx
@@ -46,6 +46,23 @@ interface TerminalViewProps {
   onTerminalOpened: (terminalId: TerminalId) => void;
   /** Whether this terminal tab is currently visible */
   active: boolean;
+  /**
+   * When true the terminal is inside a split-pane grid.
+   * Split panes are ALWAYS visible (display:block) — the display:none
+   * hide/show for inactive tabs is disabled. The `active` prop then only
+   * drives focus (the terminal receives focus when it becomes the active pane)
+   * and the focus-ring CSS class.
+   *
+   * When false/absent (default), single-terminal mode is preserved exactly
+   * as today: display:block when active, display:none when inactive.
+   */
+  isSplitPane?: boolean;
+  /**
+   * Stable React key forwarded from the owning component. When provided,
+   * the key is used to avoid unnecessary remounts (same as TerminalTab.reactKey).
+   * If omitted, the parent must ensure stable keying externally.
+   */
+  reactKey?: string;
 }
 
 export function TerminalView({
@@ -53,6 +70,7 @@ export function TerminalView({
   terminalId,
   onTerminalOpened,
   active,
+  isSplitPane = false,
 }: TerminalViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const { openTerminal, focusTerminal, reattachTerminal } = useTerminal();
@@ -190,10 +208,14 @@ export function TerminalView({
     [terminalId, sessionId],
   );
 
+  // Split-pane mode: always display:block (all panes visible simultaneously).
+  // Single-terminal mode: show only the active tab, hide the rest.
+  const displayStyle = isSplitPane ? "block" : active ? "block" : "none";
+
   return (
     <div
       className="terminal-wrapper"
-      style={{ display: active ? "block" : "none" }}
+      style={{ display: displayStyle }}
       onContextMenu={handleContextMenu}
     >
       <div

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -177,6 +177,9 @@ export const en = {
   "terminal.closeTab": "Close terminal",
   "terminal.connected": "Connected",
   "terminal.noTerminal": "No terminal open. Click + to create one.",
+  "terminal.splitHorizontal": "Split pane horizontally",
+  "terminal.splitVertical": "Split pane vertically",
+  "terminal.closePane": "Close pane",
 
   // Terminal find-bar
   "terminal.find.placeholder": "Search in terminal...",

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -179,6 +179,9 @@ export const es: Record<TranslationKey, string> = {
   "terminal.closeTab": "Cerrar terminal",
   "terminal.connected": "Conectado",
   "terminal.noTerminal": "Sin terminal abierta. Hacé clic en + para crear una.",
+  "terminal.splitHorizontal": "Dividir panel horizontalmente",
+  "terminal.splitVertical": "Dividir panel verticalmente",
+  "terminal.closePane": "Cerrar panel",
 
   // Terminal find-bar
   "terminal.find.placeholder": "Buscar en la terminal...",

--- a/src/stores/paneLayoutStore.test.ts
+++ b/src/stores/paneLayoutStore.test.ts
@@ -21,6 +21,13 @@ function getLayout(sessionId: string): PaneLayout | undefined {
   return usePaneLayoutStore.getState().layouts[sessionId];
 }
 
+// Typed helper to avoid noUncheckedIndexedAccess errors in tests
+function slot(layout: PaneLayout, idx: number) {
+  const s = layout.slots[idx];
+  if (!s) throw new Error(`No slot at index ${idx}`);
+  return s;
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe("paneLayoutStore — openLayout", () => {
@@ -31,13 +38,13 @@ describe("paneLayoutStore — openLayout", () => {
     const layout = getLayout("sess-1");
     expect(layout).toBeDefined();
     expect(layout!.slots).toHaveLength(1);
-    expect(layout!.slots[0].terminalId).toBe("term-1");
-    expect(layout!.slots[0].ratio).toBeCloseTo(1);
+    expect(slot(layout!, 0).terminalId).toBe("term-1");
+    expect(slot(layout!, 0).ratio).toBeCloseTo(1);
   });
 
   it("does not clobber an existing layout on re-open", () => {
     usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
-    usePaneLayoutStore.getState().splitSlot("sess-1", usePaneLayoutStore.getState().layouts["sess-1"].slots[0].id);
+    usePaneLayoutStore.getState().splitSlot("sess-1", slot(getLayout("sess-1")!, 0).id);
     const slotsBefore = getLayout("sess-1")!.slots.length;
     usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
     expect(getLayout("sess-1")!.slots.length).toBe(slotsBefore);
@@ -49,21 +56,22 @@ describe("paneLayoutStore — splitSlot", () => {
 
   it("inserts a new slot after the given slot with equal ratios", () => {
     usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
-    const firstSlotId = getLayout("sess-1")!.slots[0].id;
+    const firstSlotId = slot(getLayout("sess-1")!, 0).id;
     usePaneLayoutStore.getState().splitSlot("sess-1", firstSlotId);
     const layout = getLayout("sess-1")!;
     expect(layout.slots).toHaveLength(2);
-    expect(layout.slots[0].ratio).toBeCloseTo(0.5);
-    expect(layout.slots[1].ratio).toBeCloseTo(0.5);
-    expect(layout.slots[1].terminalId).toBeNull();
+    expect(slot(layout, 0).ratio).toBeCloseTo(0.5);
+    expect(slot(layout, 1).ratio).toBeCloseTo(0.5);
+    expect(slot(layout, 1).terminalId).toBeNull();
   });
 
   it("assigns stable UUIDs as slot ids (different from terminalId)", () => {
     usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
-    const firstSlotId = getLayout("sess-1")!.slots[0].id;
+    const firstSlotId = slot(getLayout("sess-1")!, 0).id;
     usePaneLayoutStore.getState().splitSlot("sess-1", firstSlotId);
     const layout = getLayout("sess-1")!;
-    const [a, b] = layout.slots;
+    const a = slot(layout, 0);
+    const b = slot(layout, 1);
     expect(a.id).not.toBe(a.terminalId);
     expect(b.id).not.toBe(b.terminalId);
     expect(a.id).not.toBe(b.id);
@@ -72,21 +80,25 @@ describe("paneLayoutStore — splitSlot", () => {
   it("caps at MAX_PANE_COUNT and ignores further splits", () => {
     usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
     for (let i = 0; i < MAX_PANE_COUNT + 2; i++) {
-      const lastId = getLayout("sess-1")!.slots.at(-1)!.id;
-      usePaneLayoutStore.getState().splitSlot("sess-1", lastId);
+      const slots = getLayout("sess-1")!.slots;
+      const lastSlot = slots[slots.length - 1];
+      if (!lastSlot) break;
+      usePaneLayoutStore.getState().splitSlot("sess-1", lastSlot.id);
     }
     expect(getLayout("sess-1")!.slots.length).toBeLessThanOrEqual(MAX_PANE_COUNT);
   });
 
   it("three-way split redistributes ratios equally", () => {
     usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
-    const firstId = getLayout("sess-1")!.slots[0].id;
+    const firstId = slot(getLayout("sess-1")!, 0).id;
     usePaneLayoutStore.getState().splitSlot("sess-1", firstId);
-    const secondId = getLayout("sess-1")!.slots[1].id;
+    const secondId = slot(getLayout("sess-1")!, 1).id;
     usePaneLayoutStore.getState().splitSlot("sess-1", secondId);
-    const slots = getLayout("sess-1")!.slots;
-    expect(slots).toHaveLength(3);
-    slots.forEach((s) => expect(s.ratio).toBeCloseTo(1 / 3, 5));
+    const layout = getLayout("sess-1")!;
+    expect(layout.slots).toHaveLength(3);
+    for (let i = 0; i < 3; i++) {
+      expect(slot(layout, i).ratio).toBeCloseTo(1 / 3, 5);
+    }
   });
 });
 
@@ -95,18 +107,18 @@ describe("paneLayoutStore — closeSlot", () => {
 
   it("removes the slot and redistributes ratios equally", () => {
     usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
-    const firstId = getLayout("sess-1")!.slots[0].id;
+    const firstId = slot(getLayout("sess-1")!, 0).id;
     usePaneLayoutStore.getState().splitSlot("sess-1", firstId);
-    const slotToClose = getLayout("sess-1")!.slots[1].id;
+    const slotToClose = slot(getLayout("sess-1")!, 1).id;
     usePaneLayoutStore.getState().closeSlot("sess-1", slotToClose);
     const layout = getLayout("sess-1")!;
     expect(layout.slots).toHaveLength(1);
-    expect(layout.slots[0].ratio).toBeCloseTo(1);
+    expect(slot(layout, 0).ratio).toBeCloseTo(1);
   });
 
   it("does not remove the last slot", () => {
     usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
-    const onlyId = getLayout("sess-1")!.slots[0].id;
+    const onlyId = slot(getLayout("sess-1")!, 0).id;
     usePaneLayoutStore.getState().closeSlot("sess-1", onlyId);
     expect(getLayout("sess-1")!.slots).toHaveLength(1);
   });
@@ -123,19 +135,19 @@ describe("paneLayoutStore — setRatio", () => {
 
   it("clamps ratios to [0, 1]", () => {
     usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
-    const id = getLayout("sess-1")!.slots[0].id;
+    const id = slot(getLayout("sess-1")!, 0).id;
     usePaneLayoutStore.getState().setRatio("sess-1", id, -0.5);
-    expect(getLayout("sess-1")!.slots[0].ratio).toBeCloseTo(0);
+    expect(slot(getLayout("sess-1")!, 0).ratio).toBeCloseTo(0);
     usePaneLayoutStore.getState().setRatio("sess-1", id, 1.5);
-    expect(getLayout("sess-1")!.slots[0].ratio).toBeCloseTo(1);
+    expect(slot(getLayout("sess-1")!, 0).ratio).toBeCloseTo(1);
   });
 
   it("updates the ratio of the target slot", () => {
     usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
-    const firstId = getLayout("sess-1")!.slots[0].id;
+    const firstId = slot(getLayout("sess-1")!, 0).id;
     usePaneLayoutStore.getState().splitSlot("sess-1", firstId);
     usePaneLayoutStore.getState().setRatio("sess-1", firstId, 0.3);
-    expect(getLayout("sess-1")!.slots[0].ratio).toBeCloseTo(0.3);
+    expect(slot(getLayout("sess-1")!, 0).ratio).toBeCloseTo(0.3);
   });
 });
 
@@ -144,11 +156,11 @@ describe("paneLayoutStore — assignTerminal", () => {
 
   it("assigns a real terminalId to a pending slot", () => {
     usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
-    const firstId = getLayout("sess-1")!.slots[0].id;
+    const firstId = slot(getLayout("sess-1")!, 0).id;
     usePaneLayoutStore.getState().splitSlot("sess-1", firstId);
-    const pendingSlotId = getLayout("sess-1")!.slots[1].id;
+    const pendingSlotId = slot(getLayout("sess-1")!, 1).id;
     usePaneLayoutStore.getState().assignTerminal("sess-1", pendingSlotId, "term-2");
-    expect(getLayout("sess-1")!.slots[1].terminalId).toBe("term-2");
+    expect(slot(getLayout("sess-1")!, 1).terminalId).toBe("term-2");
   });
 });
 
@@ -157,9 +169,9 @@ describe("paneLayoutStore — focusSlot", () => {
 
   it("updates focusedSlotId in the layout", () => {
     usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
-    const firstId = getLayout("sess-1")!.slots[0].id;
+    const firstId = slot(getLayout("sess-1")!, 0).id;
     usePaneLayoutStore.getState().splitSlot("sess-1", firstId);
-    const secondId = getLayout("sess-1")!.slots[1].id;
+    const secondId = slot(getLayout("sess-1")!, 1).id;
     usePaneLayoutStore.getState().focusSlot("sess-1", secondId);
     expect(getLayout("sess-1")!.focusedSlotId).toBe(secondId);
   });
@@ -167,7 +179,7 @@ describe("paneLayoutStore — focusSlot", () => {
   it("openLayout sets the initial slot as focused", () => {
     usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
     const layout = getLayout("sess-1")!;
-    expect(layout.focusedSlotId).toBe(layout.slots[0].id);
+    expect(layout.focusedSlotId).toBe(slot(layout, 0).id);
   });
 });
 

--- a/src/stores/paneLayoutStore.test.ts
+++ b/src/stores/paneLayoutStore.test.ts
@@ -1,0 +1,187 @@
+// stores/paneLayoutStore.test.ts
+//
+// TDD: RED phase first — tests for the ephemeral pane layout store.
+// All tests run in pure Node (no jsdom needed) because the store
+// is a Zustand reducer with no DOM interaction.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  usePaneLayoutStore,
+  MAX_PANE_COUNT,
+  type PaneLayout,
+} from "./paneLayoutStore";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function resetStore() {
+  usePaneLayoutStore.setState({ layouts: {} });
+}
+
+function getLayout(sessionId: string): PaneLayout | undefined {
+  return usePaneLayoutStore.getState().layouts[sessionId];
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("paneLayoutStore — openLayout", () => {
+  beforeEach(resetStore);
+
+  it("creates a layout with a single slot for a new session", () => {
+    usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
+    const layout = getLayout("sess-1");
+    expect(layout).toBeDefined();
+    expect(layout!.slots).toHaveLength(1);
+    expect(layout!.slots[0].terminalId).toBe("term-1");
+    expect(layout!.slots[0].ratio).toBeCloseTo(1);
+  });
+
+  it("does not clobber an existing layout on re-open", () => {
+    usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
+    usePaneLayoutStore.getState().splitSlot("sess-1", usePaneLayoutStore.getState().layouts["sess-1"].slots[0].id);
+    const slotsBefore = getLayout("sess-1")!.slots.length;
+    usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
+    expect(getLayout("sess-1")!.slots.length).toBe(slotsBefore);
+  });
+});
+
+describe("paneLayoutStore — splitSlot", () => {
+  beforeEach(resetStore);
+
+  it("inserts a new slot after the given slot with equal ratios", () => {
+    usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
+    const firstSlotId = getLayout("sess-1")!.slots[0].id;
+    usePaneLayoutStore.getState().splitSlot("sess-1", firstSlotId);
+    const layout = getLayout("sess-1")!;
+    expect(layout.slots).toHaveLength(2);
+    expect(layout.slots[0].ratio).toBeCloseTo(0.5);
+    expect(layout.slots[1].ratio).toBeCloseTo(0.5);
+    expect(layout.slots[1].terminalId).toBeNull();
+  });
+
+  it("assigns stable UUIDs as slot ids (different from terminalId)", () => {
+    usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
+    const firstSlotId = getLayout("sess-1")!.slots[0].id;
+    usePaneLayoutStore.getState().splitSlot("sess-1", firstSlotId);
+    const layout = getLayout("sess-1")!;
+    const [a, b] = layout.slots;
+    expect(a.id).not.toBe(a.terminalId);
+    expect(b.id).not.toBe(b.terminalId);
+    expect(a.id).not.toBe(b.id);
+  });
+
+  it("caps at MAX_PANE_COUNT and ignores further splits", () => {
+    usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
+    for (let i = 0; i < MAX_PANE_COUNT + 2; i++) {
+      const lastId = getLayout("sess-1")!.slots.at(-1)!.id;
+      usePaneLayoutStore.getState().splitSlot("sess-1", lastId);
+    }
+    expect(getLayout("sess-1")!.slots.length).toBeLessThanOrEqual(MAX_PANE_COUNT);
+  });
+
+  it("three-way split redistributes ratios equally", () => {
+    usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
+    const firstId = getLayout("sess-1")!.slots[0].id;
+    usePaneLayoutStore.getState().splitSlot("sess-1", firstId);
+    const secondId = getLayout("sess-1")!.slots[1].id;
+    usePaneLayoutStore.getState().splitSlot("sess-1", secondId);
+    const slots = getLayout("sess-1")!.slots;
+    expect(slots).toHaveLength(3);
+    slots.forEach((s) => expect(s.ratio).toBeCloseTo(1 / 3, 5));
+  });
+});
+
+describe("paneLayoutStore — closeSlot", () => {
+  beforeEach(resetStore);
+
+  it("removes the slot and redistributes ratios equally", () => {
+    usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
+    const firstId = getLayout("sess-1")!.slots[0].id;
+    usePaneLayoutStore.getState().splitSlot("sess-1", firstId);
+    const slotToClose = getLayout("sess-1")!.slots[1].id;
+    usePaneLayoutStore.getState().closeSlot("sess-1", slotToClose);
+    const layout = getLayout("sess-1")!;
+    expect(layout.slots).toHaveLength(1);
+    expect(layout.slots[0].ratio).toBeCloseTo(1);
+  });
+
+  it("does not remove the last slot", () => {
+    usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
+    const onlyId = getLayout("sess-1")!.slots[0].id;
+    usePaneLayoutStore.getState().closeSlot("sess-1", onlyId);
+    expect(getLayout("sess-1")!.slots).toHaveLength(1);
+  });
+
+  it("removes the layout entry when the session is closed", () => {
+    usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
+    usePaneLayoutStore.getState().removeLayout("sess-1");
+    expect(getLayout("sess-1")).toBeUndefined();
+  });
+});
+
+describe("paneLayoutStore — setRatio", () => {
+  beforeEach(resetStore);
+
+  it("clamps ratios to [0, 1]", () => {
+    usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
+    const id = getLayout("sess-1")!.slots[0].id;
+    usePaneLayoutStore.getState().setRatio("sess-1", id, -0.5);
+    expect(getLayout("sess-1")!.slots[0].ratio).toBeCloseTo(0);
+    usePaneLayoutStore.getState().setRatio("sess-1", id, 1.5);
+    expect(getLayout("sess-1")!.slots[0].ratio).toBeCloseTo(1);
+  });
+
+  it("updates the ratio of the target slot", () => {
+    usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
+    const firstId = getLayout("sess-1")!.slots[0].id;
+    usePaneLayoutStore.getState().splitSlot("sess-1", firstId);
+    usePaneLayoutStore.getState().setRatio("sess-1", firstId, 0.3);
+    expect(getLayout("sess-1")!.slots[0].ratio).toBeCloseTo(0.3);
+  });
+});
+
+describe("paneLayoutStore — assignTerminal", () => {
+  beforeEach(resetStore);
+
+  it("assigns a real terminalId to a pending slot", () => {
+    usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
+    const firstId = getLayout("sess-1")!.slots[0].id;
+    usePaneLayoutStore.getState().splitSlot("sess-1", firstId);
+    const pendingSlotId = getLayout("sess-1")!.slots[1].id;
+    usePaneLayoutStore.getState().assignTerminal("sess-1", pendingSlotId, "term-2");
+    expect(getLayout("sess-1")!.slots[1].terminalId).toBe("term-2");
+  });
+});
+
+describe("paneLayoutStore — focusSlot", () => {
+  beforeEach(resetStore);
+
+  it("updates focusedSlotId in the layout", () => {
+    usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
+    const firstId = getLayout("sess-1")!.slots[0].id;
+    usePaneLayoutStore.getState().splitSlot("sess-1", firstId);
+    const secondId = getLayout("sess-1")!.slots[1].id;
+    usePaneLayoutStore.getState().focusSlot("sess-1", secondId);
+    expect(getLayout("sess-1")!.focusedSlotId).toBe(secondId);
+  });
+
+  it("openLayout sets the initial slot as focused", () => {
+    usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
+    const layout = getLayout("sess-1")!;
+    expect(layout.focusedSlotId).toBe(layout.slots[0].id);
+  });
+});
+
+describe("paneLayoutStore — direction", () => {
+  beforeEach(resetStore);
+
+  it("defaults to horizontal direction", () => {
+    usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
+    expect(getLayout("sess-1")!.direction).toBe("horizontal");
+  });
+
+  it("setDirection updates the direction", () => {
+    usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
+    usePaneLayoutStore.getState().setDirection("sess-1", "vertical");
+    expect(getLayout("sess-1")!.direction).toBe("vertical");
+  });
+});

--- a/src/stores/paneLayoutStore.ts
+++ b/src/stores/paneLayoutStore.ts
@@ -70,14 +70,10 @@ interface PaneLayoutStoreState {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function equalRatios(count: number): number[] {
-  const ratio = 1 / count;
-  return Array.from({ length: count }, () => ratio);
-}
-
 function redistributeRatios(slots: PaneSlot[]): PaneSlot[] {
-  const ratios = equalRatios(slots.length);
-  return slots.map((s, i) => ({ ...s, ratio: ratios[i] }));
+  const count = slots.length;
+  const ratio = count > 0 ? 1 / count : 1;
+  return slots.map((s) => ({ ...s, ratio }));
 }
 
 // ── Store ─────────────────────────────────────────────────────────────────────
@@ -137,9 +133,12 @@ export const usePaneLayoutStore = create<PaneLayoutStoreState>((set, get) => ({
     if (layout.slots.length <= 1) return; // never remove the last slot
 
     const next = layout.slots.filter((s) => s.id !== slotId);
+    const removedIdx = layout.slots.findIndex((s) => s.id === slotId);
+    const fallbackIdx = Math.max(0, removedIdx - 1);
+    const fallbackSlot = next[fallbackIdx] ?? next[0];
     const focusedSlotId =
       layout.focusedSlotId === slotId
-        ? (next[Math.max(0, layout.slots.findIndex((s) => s.id === slotId) - 1)]?.id ?? next[0].id)
+        ? (fallbackSlot?.id ?? layout.focusedSlotId)
         : layout.focusedSlotId;
 
     set((state) => ({

--- a/src/stores/paneLayoutStore.ts
+++ b/src/stores/paneLayoutStore.ts
@@ -1,0 +1,219 @@
+// stores/paneLayoutStore.ts — Ephemeral pane layout store
+//
+// Manages the split-pane layout for each session.
+// NOT persisted in v1 — ephemeral per-session state.
+// Clean-room design: own model, no external tree/layout primitives.
+
+import { create } from "zustand";
+import type { SessionId, TerminalId } from "../lib/types";
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+export type PaneDirection = "horizontal" | "vertical";
+
+/** Hard cap on live pane count per session. Each pane hosts a live xterm + WebGL context. */
+export const MAX_PANE_COUNT = 4;
+
+export interface PaneSlot {
+  /** Stable UUID used as React key — never changes, even when terminalId changes. */
+  id: string;
+  /** Null = pending (terminal not yet opened). Mirrors the TerminalTab pending pattern. */
+  terminalId: TerminalId | null;
+  /** Fraction of total space. All slots in a layout must sum to ~1. */
+  ratio: number;
+}
+
+export interface PaneLayout {
+  /** Direction all panes split in. Uniform in v1 (no per-pane direction). */
+  direction: PaneDirection;
+  /** Ordered list of pane slots. */
+  slots: PaneSlot[];
+  /** Which slot currently holds keyboard focus. Drives the focus ring and
+   *  the sessionStore.activeTerminalId pointer for SidePanel/HistoryPanel. */
+  focusedSlotId: string;
+}
+
+// ── Internal state ────────────────────────────────────────────────────────────
+
+type PaneLayoutMap = Record<SessionId, PaneLayout>;
+
+interface PaneLayoutStoreState {
+  layouts: PaneLayoutMap;
+
+  /** Create a layout with a single slot for `sessionId`.
+   *  No-op if a layout already exists for this session (idempotent). */
+  openLayout: (sessionId: SessionId, terminalId: TerminalId) => void;
+
+  /** Insert a new empty slot immediately after `afterSlotId`.
+   *  Redistributes all ratios equally. Capped at MAX_PANE_COUNT. */
+  splitSlot: (sessionId: SessionId, afterSlotId: string) => void;
+
+  /** Remove a slot. Redistributes ratios equally. Refuses to remove the last slot. */
+  closeSlot: (sessionId: SessionId, slotId: string) => void;
+
+  /** Set the raw ratio for a slot. Clamped to [0, 1]. */
+  setRatio: (sessionId: SessionId, slotId: string, ratio: number) => void;
+
+  /** Assign a real terminalId to a slot (replaces null for pending slots). */
+  assignTerminal: (sessionId: SessionId, slotId: string, terminalId: TerminalId) => void;
+
+  /** Mark a slot as focused (updates focusedSlotId).
+   *  Callers are responsible for also calling sessionStore.setActiveTerminal. */
+  focusSlot: (sessionId: SessionId, slotId: string) => void;
+
+  /** Set the split direction for the whole layout. */
+  setDirection: (sessionId: SessionId, direction: PaneDirection) => void;
+
+  /** Remove the entire layout entry (called on session close). */
+  removeLayout: (sessionId: SessionId) => void;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function equalRatios(count: number): number[] {
+  const ratio = 1 / count;
+  return Array.from({ length: count }, () => ratio);
+}
+
+function redistributeRatios(slots: PaneSlot[]): PaneSlot[] {
+  const ratios = equalRatios(slots.length);
+  return slots.map((s, i) => ({ ...s, ratio: ratios[i] }));
+}
+
+// ── Store ─────────────────────────────────────────────────────────────────────
+
+export const usePaneLayoutStore = create<PaneLayoutStoreState>((set, get) => ({
+  layouts: {},
+
+  openLayout: (sessionId, terminalId) => {
+    if (get().layouts[sessionId]) return; // idempotent
+    const slotId = crypto.randomUUID();
+    set((state) => ({
+      layouts: {
+        ...state.layouts,
+        [sessionId]: {
+          direction: "horizontal",
+          slots: [{ id: slotId, terminalId, ratio: 1 }],
+          focusedSlotId: slotId,
+        },
+      },
+    }));
+  },
+
+  splitSlot: (sessionId, afterSlotId) => {
+    const layout = get().layouts[sessionId];
+    if (!layout) return;
+    if (layout.slots.length >= MAX_PANE_COUNT) return;
+
+    const insertIdx = layout.slots.findIndex((s) => s.id === afterSlotId);
+    if (insertIdx === -1) return;
+
+    const newSlot: PaneSlot = {
+      id: crypto.randomUUID(),
+      terminalId: null,
+      ratio: 0, // will be redistributed
+    };
+
+    const next = [
+      ...layout.slots.slice(0, insertIdx + 1),
+      newSlot,
+      ...layout.slots.slice(insertIdx + 1),
+    ];
+
+    set((state) => ({
+      layouts: {
+        ...state.layouts,
+        [sessionId]: {
+          ...layout,
+          slots: redistributeRatios(next),
+        },
+      },
+    }));
+  },
+
+  closeSlot: (sessionId, slotId) => {
+    const layout = get().layouts[sessionId];
+    if (!layout) return;
+    if (layout.slots.length <= 1) return; // never remove the last slot
+
+    const next = layout.slots.filter((s) => s.id !== slotId);
+    const focusedSlotId =
+      layout.focusedSlotId === slotId
+        ? (next[Math.max(0, layout.slots.findIndex((s) => s.id === slotId) - 1)]?.id ?? next[0].id)
+        : layout.focusedSlotId;
+
+    set((state) => ({
+      layouts: {
+        ...state.layouts,
+        [sessionId]: {
+          ...layout,
+          slots: redistributeRatios(next),
+          focusedSlotId,
+        },
+      },
+    }));
+  },
+
+  setRatio: (sessionId, slotId, ratio) => {
+    const layout = get().layouts[sessionId];
+    if (!layout) return;
+    const clamped = Math.max(0, Math.min(1, ratio));
+    set((state) => ({
+      layouts: {
+        ...state.layouts,
+        [sessionId]: {
+          ...layout,
+          slots: layout.slots.map((s) =>
+            s.id === slotId ? { ...s, ratio: clamped } : s,
+          ),
+        },
+      },
+    }));
+  },
+
+  assignTerminal: (sessionId, slotId, terminalId) => {
+    const layout = get().layouts[sessionId];
+    if (!layout) return;
+    set((state) => ({
+      layouts: {
+        ...state.layouts,
+        [sessionId]: {
+          ...layout,
+          slots: layout.slots.map((s) =>
+            s.id === slotId ? { ...s, terminalId } : s,
+          ),
+        },
+      },
+    }));
+  },
+
+  focusSlot: (sessionId, slotId) => {
+    const layout = get().layouts[sessionId];
+    if (!layout) return;
+    set((state) => ({
+      layouts: {
+        ...state.layouts,
+        [sessionId]: { ...layout, focusedSlotId: slotId },
+      },
+    }));
+  },
+
+  setDirection: (sessionId, direction) => {
+    const layout = get().layouts[sessionId];
+    if (!layout) return;
+    set((state) => ({
+      layouts: {
+        ...state.layouts,
+        [sessionId]: { ...layout, direction },
+      },
+    }));
+  },
+
+  removeLayout: (sessionId) => {
+    set((state) => {
+      const next = { ...state.layouts };
+      delete next[sessionId];
+      return { layouts: next };
+    });
+  },
+}));

--- a/src/styles/terminal.css
+++ b/src/styles/terminal.css
@@ -237,7 +237,8 @@
 
 /* ── Tab bar split button ────────────────────────── */
 
-.terminal-tab-split {
+.terminal-tab-split,
+.terminal-tab-split-direction {
   flex-shrink: 0;
   background: transparent;
   border: none;
@@ -249,11 +250,58 @@
   transition: color var(--transition-fast);
 }
 
-.terminal-tab-split:hover {
+.terminal-tab-split:hover,
+.terminal-tab-split-direction:hover {
   color: var(--text-primary);
 }
 
 .terminal-tab-split:disabled {
   opacity: 0.35;
   cursor: not-allowed;
+}
+
+/* ── Per-pane close button ───────────────────────── */
+
+/* Positioned absolutely in the top-right corner of the pane.
+   The pane (.terminal-split-pane) is already position:relative.
+   Hidden by default; revealed on pane hover or keyboard focus.
+   z-index above the terminal canvas but below dialogs.
+   Does NOT push xterm content — floats as an overlay. */
+.terminal-split-pane-close {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  z-index: 5;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  background: var(--bg-raised);
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1;
+  opacity: 0;
+  transition: opacity var(--transition-fast), color var(--transition-fast),
+    background-color var(--transition-fast);
+  /* pointer-events off when invisible so clicks reach the terminal */
+  pointer-events: none;
+}
+
+/* Reveal on pane hover */
+.terminal-split-pane:hover .terminal-split-pane-close,
+.terminal-split-pane:focus-within .terminal-split-pane-close {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Emphasize on button hover */
+.terminal-split-pane-close:hover {
+  background: var(--bg-raised-2);
+  color: var(--text-primary);
+  border-color: var(--hairline-strong);
 }

--- a/src/styles/terminal.css
+++ b/src/styles/terminal.css
@@ -167,8 +167,9 @@
 }
 
 /* ═══════════════════════════════════════════════════
-   Split Terminal Layout (prep — CSS only)
-   Future: split-pane terminal layout
+   Split Terminal Layout
+   Flat 1D pane grid — horizontal or vertical.
+   Focus ring driven by data-focused attr.
    ═══════════════════════════════════════════════════ */
 
 .terminal-split {
@@ -191,24 +192,68 @@
   min-height: 0;
   overflow: hidden;
   position: relative;
+  /* Smooth transition when ratios change on drag end */
+  transition: flex var(--transition-fast);
+  /* Subtle border to visually separate panes */
+  outline: none;
 }
+
+/* Focus ring on the focused pane.
+   data-focused="true" is set by PaneSplitView via focusedSlotId. */
+.terminal-split-pane[data-focused="true"] {
+  box-shadow: inset 0 0 0 1px var(--focus-ring);
+}
+
+/* Keyboard focus visible ring (distinct from mouse focus ring) */
+.terminal-split-pane:focus-visible {
+  box-shadow: inset 0 0 0 2px var(--focus-ring);
+}
+
+/* ── Resize handle ──────────────────────────────── */
 
 .terminal-split-handle {
   flex-shrink: 0;
-  background-color: var(--border);
+  background-color: var(--border-subtle);
   transition: background-color var(--transition-fast);
+  /* Touch-friendly hit area without changing the visual gap */
+  padding: 0 2px;
+  box-sizing: content-box;
 }
 
-.terminal-split-handle:hover {
+.terminal-split-handle:hover,
+.terminal-split-handle:active {
   background-color: var(--accent);
 }
 
 .terminal-split-horizontal > .terminal-split-handle {
-  width: 3px;
+  width: 1px;
   cursor: col-resize;
 }
 
 .terminal-split-vertical > .terminal-split-handle {
-  height: 3px;
+  height: 1px;
   cursor: row-resize;
+}
+
+/* ── Tab bar split button ────────────────────────── */
+
+.terminal-tab-split {
+  flex-shrink: 0;
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 14px;
+  padding: 0 6px;
+  line-height: 1;
+  transition: color var(--transition-fast);
+}
+
+.terminal-tab-split:hover {
+  color: var(--text-primary);
+}
+
+.terminal-tab-split:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
 }


### PR DESCRIPTION
## Summary

The marquee terminal feature of the Voltius clean-room program: **split panes** — view multiple live terminals side-by-side in one tab. Flat 1D split (horizontal or vertical), up to 4 panes. Clean-room: an original flat slot model (`PaneLayout { direction, slots }`), no Voltius (AGPL) layout-tree code, frontend-only (no Rust).

## How it works

- An ephemeral `paneLayoutStore` holds a flat ordered list of pane slots (each referencing a terminal) with normalized ratios.
- **Panes are a view over the existing tabs.** When unsplit (≤1 slot), the terminal area renders **exactly like before** — all tabs, `display` toggled by the active tab — so the existing multi-tab behavior is untouched. The split layout engages only at ≥2 panes.
- The reattach model already supports N concurrent terminal containers, so panes reuse live xterm instances (no remount / scrollback loss).
- Focus follows the focused pane (clicking a pane moves real keyboard focus + the focus ring), and `activeTerminalId` tracks it so the side panel, snippets, and command-history all target the focused pane with no changes.
- Drag-to-resize (fit fires on drag-end, not mid-drag); per-pane close (non-destructive un-split); horizontal/vertical direction toggle; Alt+Arrow pane navigation; `role="region"` per pane.

## Quality

- **407 tests green** (Vitest), `tsc --noEmit` clean (under `noUncheckedIndexedAccess`)
- **Strict TDD** throughout
- **Dual adversarial review**: first pass was **NO-GO** — it caught two CRITICAL regressions (the forked tabs/slots model blanked the screen on "+" for unsplit multi-tab, and closing a tab while split orphaned its pane). Both fixed by making single-pane render all tabs and reconciling tab-close ↔ slot-close; focus and pane-control styling also fixed. Re-review **GO**, plus a polish pass for the control styling and the regression-test gaps the criticals exposed.
- **Clean-room verified**: original flat-slot model, no AGPL/layout-library code.

## Deferred

Arbitrary nested splits, layout persistence, and input-broadcast across panes (the natural next feature this unlocks).
