### PR TITLE
feat(terminal): input broadcast across split panes (safety-gated)

### DIFF
--- a/src/features/terminal/BroadcastBanner.test.tsx
+++ b/src/features/terminal/BroadcastBanner.test.tsx
@@ -1,0 +1,50 @@
+// features/terminal/BroadcastBanner.test.tsx — TDD: WU-4 RED phase
+//
+// Tests for the BroadcastBanner indicator component.
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { BroadcastBanner } from "./BroadcastBanner";
+
+vi.mock("../../lib/i18n", () => ({
+  useI18n: () => ({ t: (k: string) => k }),
+}));
+
+describe("BroadcastBanner", () => {
+  it("renders nothing when broadcastEnabled is false", () => {
+    const { container } = render(<BroadcastBanner broadcastEnabled={false} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the banner when broadcastEnabled is true", () => {
+    render(<BroadcastBanner broadcastEnabled={true} />);
+    const banner = document.querySelector(".terminal-broadcast-banner");
+    expect(banner).not.toBeNull();
+  });
+
+  it("displays the broadcast banner i18n key text", () => {
+    render(<BroadcastBanner broadcastEnabled={true} />);
+    // The mock returns the key itself — check the key is rendered
+    expect(screen.getByText("terminal.broadcastBanner")).toBeInTheDocument();
+  });
+
+  it("has role='status' for a11y", () => {
+    render(<BroadcastBanner broadcastEnabled={true} />);
+    const banner = screen.getByRole("status");
+    expect(banner).toBeInTheDocument();
+  });
+
+  it("has aria-live='polite' on the banner element", () => {
+    render(<BroadcastBanner broadcastEnabled={true} />);
+    const banner = screen.getByRole("status");
+    expect(banner).toHaveAttribute("aria-live", "polite");
+  });
+
+  it("contains a text element that is NOT icon-only (explicit text present)", () => {
+    render(<BroadcastBanner broadcastEnabled={true} />);
+    const banner = document.querySelector(".terminal-broadcast-banner");
+    expect(banner?.textContent).toBeTruthy();
+    // Must have more than just an icon glyph — text content should be non-empty string
+    expect((banner?.textContent?.trim().length ?? 0)).toBeGreaterThan(0);
+  });
+});

--- a/src/features/terminal/BroadcastBanner.tsx
+++ b/src/features/terminal/BroadcastBanner.tsx
@@ -1,0 +1,33 @@
+// features/terminal/BroadcastBanner.tsx — Broadcast mode indicator
+//
+// Full-width strip rendered at the top of .terminal-split when broadcastEnabled.
+// Uses LAMPLIGHT --warning / --warning-wash tokens.
+// a11y: role="status" aria-live="polite" — NOT color-only (explicit text).
+// Clean-room design — no external broadcast library code referenced.
+
+import { useI18n } from "../../lib/i18n";
+
+interface BroadcastBannerProps {
+  broadcastEnabled: boolean;
+}
+
+export function BroadcastBanner({ broadcastEnabled }: BroadcastBannerProps) {
+  const { t } = useI18n();
+
+  if (!broadcastEnabled) return null;
+
+  return (
+    <div
+      className="terminal-broadcast-banner"
+      role="status"
+      aria-live="polite"
+    >
+      <span className="terminal-broadcast-banner-icon" aria-hidden="true">
+        ⊕
+      </span>
+      <span className="terminal-broadcast-banner-text">
+        {t("terminal.broadcastBanner")}
+      </span>
+    </div>
+  );
+}

--- a/src/features/terminal/PaneSplitView.tsx
+++ b/src/features/terminal/PaneSplitView.tsx
@@ -18,6 +18,7 @@ import { usePaneLayoutStore } from "../../stores/paneLayoutStore";
 import { useSessionStore } from "../../stores/sessionStore";
 import { TerminalView } from "./TerminalView";
 import { SplitHandle } from "./SplitHandle";
+import { BroadcastBanner } from "./BroadcastBanner";
 import { useI18n } from "../../lib/i18n";
 import type { SessionId } from "../../lib/types";
 
@@ -133,6 +134,7 @@ export function PaneSplitView({
       ref={containerRef}
       className={`terminal-split terminal-split-${direction}`}
     >
+      <BroadcastBanner broadcastEnabled={layout.broadcastEnabled} />
       {slots.map((slot, i) => {
         // MAJOR-2 fix: only the focused pane gets active=true
         // This ensures only the focused pane's terminal receives real keyboard focus.

--- a/src/features/terminal/PaneSplitView.tsx
+++ b/src/features/terminal/PaneSplitView.tsx
@@ -133,6 +133,7 @@ export function PaneSplitView({
     <div
       ref={containerRef}
       className={`terminal-split terminal-split-${direction}`}
+      data-broadcast={layout.broadcastEnabled ? "true" : "false"}
     >
       <BroadcastBanner broadcastEnabled={layout.broadcastEnabled} />
       {slots.map((slot, i) => {

--- a/src/features/terminal/TerminalTabs.split.test.tsx
+++ b/src/features/terminal/TerminalTabs.split.test.tsx
@@ -192,6 +192,144 @@ describe("TerminalTabs — pane layout initialization", () => {
   });
 });
 
+// ── WU-5: Broadcast toggle button ─────────────────────────────────────────────
+
+describe("TerminalTabs — broadcast toggle button", () => {
+  beforeEach(resetStores);
+  afterEach(resetStores);
+
+  it("broadcast toggle button is NOT rendered when paneCount < 2", async () => {
+    const session = makeSession("sid-bcast-1");
+    useSessionStore.setState({
+      sessions: new Map([["sid-bcast-1", session]]),
+      activeSessionId: "sid-bcast-1",
+    });
+    render(<TerminalTabs sessionId="sid-bcast-1" />);
+    await act(async () => {});
+
+    // Only 1 slot → paneCount < 2 → toggle must not render
+    const broadcastBtn = document.querySelector(".terminal-tab-broadcast");
+    expect(broadcastBtn).toBeNull();
+  });
+
+  it("broadcast toggle button IS rendered when paneCount >= 2", async () => {
+    const session = makeSession("sid-bcast-2");
+    useSessionStore.setState({
+      sessions: new Map([["sid-bcast-2", session]]),
+      activeSessionId: "sid-bcast-2",
+    });
+    render(<TerminalTabs sessionId="sid-bcast-2" />);
+    await act(async () => {});
+
+    // Manually seed a 2-slot layout
+    const layout = usePaneLayoutStore.getState().layouts["sid-bcast-2"];
+    if (layout) {
+      usePaneLayoutStore.getState().splitSlot("sid-bcast-2", layout.slots[0]!.id);
+    }
+
+    // Re-render to pick up new paneCount
+    const { rerender } = render(<TerminalTabs sessionId="sid-bcast-2" />);
+    await act(async () => {});
+    rerender(<TerminalTabs sessionId="sid-bcast-2" />);
+
+    const broadcastBtn = document.querySelector(".terminal-tab-broadcast");
+    expect(broadcastBtn).not.toBeNull();
+  });
+
+  it("broadcast toggle button has aria-pressed='false' when broadcastEnabled is false", async () => {
+    const session = makeSession("sid-bcast-3");
+    useSessionStore.setState({
+      sessions: new Map([["sid-bcast-3", session]]),
+      activeSessionId: "sid-bcast-3",
+    });
+
+    // Pre-seed a 2-slot layout with broadcastEnabled: false
+    usePaneLayoutStore.setState({
+      layouts: {
+        "sid-bcast-3": {
+          direction: "horizontal",
+          slots: [
+            { id: "s1", terminalId: "term-1", ratio: 0.5 },
+            { id: "s2", terminalId: "term-2", ratio: 0.5 },
+          ],
+          focusedSlotId: "s1",
+          broadcastEnabled: false,
+        },
+      },
+    });
+
+    render(<TerminalTabs sessionId="sid-bcast-3" />);
+    await act(async () => {});
+
+    const broadcastBtn = document.querySelector<HTMLButtonElement>(".terminal-tab-broadcast");
+    expect(broadcastBtn).not.toBeNull();
+    expect(broadcastBtn?.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("clicking broadcast toggle calls toggleBroadcast in the store", async () => {
+    const session = makeSession("sid-bcast-4");
+    useSessionStore.setState({
+      sessions: new Map([["sid-bcast-4", session]]),
+      activeSessionId: "sid-bcast-4",
+    });
+
+    usePaneLayoutStore.setState({
+      layouts: {
+        "sid-bcast-4": {
+          direction: "horizontal",
+          slots: [
+            { id: "s1", terminalId: "term-1", ratio: 0.5 },
+            { id: "s2", terminalId: "term-2", ratio: 0.5 },
+          ],
+          focusedSlotId: "s1",
+          broadcastEnabled: false,
+        },
+      },
+    });
+
+    render(<TerminalTabs sessionId="sid-bcast-4" />);
+    await act(async () => {});
+
+    const broadcastBtn = document.querySelector<HTMLButtonElement>(".terminal-tab-broadcast");
+    expect(broadcastBtn).not.toBeNull();
+
+    await act(async () => {
+      broadcastBtn!.click();
+    });
+
+    const layout = usePaneLayoutStore.getState().layouts["sid-bcast-4"];
+    expect(layout?.broadcastEnabled).toBe(true);
+  });
+
+  it("aria-pressed reflects broadcastEnabled state in the store", async () => {
+    const session = makeSession("sid-bcast-5");
+    useSessionStore.setState({
+      sessions: new Map([["sid-bcast-5", session]]),
+      activeSessionId: "sid-bcast-5",
+    });
+
+    usePaneLayoutStore.setState({
+      layouts: {
+        "sid-bcast-5": {
+          direction: "horizontal",
+          slots: [
+            { id: "s1", terminalId: "term-1", ratio: 0.5 },
+            { id: "s2", terminalId: "term-2", ratio: 0.5 },
+          ],
+          focusedSlotId: "s1",
+          broadcastEnabled: true,
+        },
+      },
+    });
+
+    render(<TerminalTabs sessionId="sid-bcast-5" />);
+    await act(async () => {});
+
+    const broadcastBtn = document.querySelector<HTMLButtonElement>(".terminal-tab-broadcast");
+    expect(broadcastBtn?.getAttribute("aria-pressed")).toBe("true");
+  });
+});
+
 describe("TerminalTabs — split action creates a new pane", () => {
   beforeEach(resetStores);
   afterEach(resetStores);

--- a/src/features/terminal/TerminalTabs.tsx
+++ b/src/features/terminal/TerminalTabs.tsx
@@ -26,6 +26,7 @@ import { useTerminal } from "./useTerminal";
 import { useI18n } from "../../lib/i18n";
 import type { SessionId } from "../../lib/types";
 
+
 interface TerminalTabsProps {
   sessionId: SessionId;
   onOpenSnippets?: () => void;
@@ -53,6 +54,7 @@ export function TerminalTabs({ sessionId, onOpenSnippets }: TerminalTabsProps) {
     closeSlot,
     assignTerminal,
     setDirection,
+    toggleBroadcast,
     layouts: paneLayouts,
   } = usePaneLayoutStore();
 
@@ -354,6 +356,27 @@ export function TerminalTabs({ sessionId, onOpenSnippets }: TerminalTabsProps) {
             }
           >
             {paneLayout?.direction === "horizontal" ? "⊠" : "⊟"}
+          </button>
+        )}
+        {paneCount >= 2 && (
+          <button
+            className="terminal-tab-broadcast"
+            onClick={() => toggleBroadcast(sessionId)}
+            aria-pressed={paneLayout?.broadcastEnabled ?? false}
+            title={
+              paneLayout?.broadcastEnabled
+                ? t("terminal.broadcastAriaOn")
+                : t("terminal.broadcastAriaOff")
+            }
+            aria-label={
+              paneLayout?.broadcastEnabled
+                ? t("terminal.broadcastAriaOn")
+                : t("terminal.broadcastAriaOff")
+            }
+          >
+            {paneLayout?.broadcastEnabled
+              ? t("terminal.broadcastToggleOn")
+              : t("terminal.broadcastToggleOff")}
           </button>
         )}
         {onOpenSnippets && (

--- a/src/features/terminal/broadcastUtils.test.ts
+++ b/src/features/terminal/broadcastUtils.test.ts
@@ -1,0 +1,92 @@
+// features/terminal/broadcastUtils.test.ts — TDD: WU-1 RED phase
+//
+// Pure unit tests for getBroadcastTargets.
+// No DOM, no React — pure Node. No mocks needed.
+
+import { describe, it, expect } from "vitest";
+import { getBroadcastTargets } from "./broadcastUtils";
+import type { PaneSlot } from "../../stores/paneLayoutStore";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeSlot(terminalId: string | null): PaneSlot {
+  return { id: crypto.randomUUID(), terminalId, ratio: 0.5 };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("getBroadcastTargets", () => {
+  it("returns [] when session is not connected (disconnected)", () => {
+    const slots = [makeSlot("term-1"), makeSlot("term-2")];
+    expect(getBroadcastTargets(slots, "term-1", "disconnected")).toEqual([]);
+  });
+
+  it("returns [] when session is connecting", () => {
+    const slots = [makeSlot("term-1"), makeSlot("term-2")];
+    expect(getBroadcastTargets(slots, "term-1", "connecting")).toEqual([]);
+  });
+
+  it("returns [] when session is authenticating", () => {
+    const slots = [makeSlot("term-1"), makeSlot("term-2")];
+    expect(getBroadcastTargets(slots, "term-1", "authenticating")).toEqual([]);
+  });
+
+  it("returns [] when session state is an error object", () => {
+    const slots = [makeSlot("term-1"), makeSlot("term-2")];
+    expect(
+      getBroadcastTargets(slots, "term-1", { error: { message: "connection reset" } }),
+    ).toEqual([]);
+  });
+
+  it("excludes the source terminalId from targets", () => {
+    const slots = [makeSlot("term-1"), makeSlot("term-2"), makeSlot("term-3")];
+    const result = getBroadcastTargets(slots, "term-1", "connected");
+    expect(result).not.toContain("term-1");
+  });
+
+  it("includes all other live (non-source) terminalIds when connected", () => {
+    const slots = [makeSlot("term-1"), makeSlot("term-2"), makeSlot("term-3")];
+    const result = getBroadcastTargets(slots, "term-1", "connected");
+    expect(result).toContain("term-2");
+    expect(result).toContain("term-3");
+    expect(result).toHaveLength(2);
+  });
+
+  it("excludes slots with null terminalId (pending slots)", () => {
+    const slots = [makeSlot("term-1"), makeSlot(null), makeSlot("term-3")];
+    const result = getBroadcastTargets(slots, "term-1", "connected");
+    expect(result).toEqual(["term-3"]);
+  });
+
+  it("excludes slots whose terminalId starts with 'pending-'", () => {
+    const slots = [makeSlot("term-1"), makeSlot("pending-abc123"), makeSlot("term-3")];
+    const result = getBroadcastTargets(slots, "term-1", "connected");
+    expect(result).toEqual(["term-3"]);
+  });
+
+  it("returns [] when only the source slot exists (no other panes)", () => {
+    const slots = [makeSlot("term-1")];
+    const result = getBroadcastTargets(slots, "term-1", "connected");
+    expect(result).toEqual([]);
+  });
+
+  it("returns [] when all other slots are null or pending", () => {
+    const slots = [makeSlot("term-1"), makeSlot(null), makeSlot("pending-xyz")];
+    const result = getBroadcastTargets(slots, "term-1", "connected");
+    expect(result).toEqual([]);
+  });
+
+  it("handles 4 panes correctly — returns 3 targets", () => {
+    const slots = [
+      makeSlot("term-1"),
+      makeSlot("term-2"),
+      makeSlot("term-3"),
+      makeSlot("term-4"),
+    ];
+    const result = getBroadcastTargets(slots, "term-1", "connected");
+    expect(result).toHaveLength(3);
+    expect(result).toContain("term-2");
+    expect(result).toContain("term-3");
+    expect(result).toContain("term-4");
+  });
+});

--- a/src/features/terminal/broadcastUtils.ts
+++ b/src/features/terminal/broadcastUtils.ts
@@ -1,0 +1,37 @@
+// features/terminal/broadcastUtils.ts — Pure broadcast fan-out utility
+//
+// Clean-room design. No store imports — takes already-resolved values as args.
+// Fully testable in pure Node with no DOM or React required.
+
+import type { PaneSlot } from "../../stores/paneLayoutStore";
+import type { SessionState, TerminalId } from "../../lib/types";
+
+/**
+ * Computes the set of target terminalIds for a broadcast write.
+ *
+ * Rules:
+ * - Session must be "connected" (string equality — not an object error state).
+ * - Excludes the source terminalId (no double-write).
+ * - Excludes slots with null terminalId (pending/not-yet-opened).
+ * - Excludes slots whose terminalId starts with "pending-" (race: assigned but not real yet).
+ *
+ * @param slots            All slots in the current layout.
+ * @param sourceTerminalId The terminalId that produced the keystroke (must be excluded).
+ * @param sessionState     The session's current connection state.
+ * @returns Array of target terminalIds (may be empty — caller handles empty gracefully).
+ */
+export function getBroadcastTargets(
+  slots: PaneSlot[],
+  sourceTerminalId: TerminalId,
+  sessionState: SessionState,
+): TerminalId[] {
+  if (sessionState !== "connected") return [];
+  return slots
+    .filter(
+      (s): s is PaneSlot & { terminalId: TerminalId } =>
+        s.terminalId !== null &&
+        s.terminalId !== sourceTerminalId &&
+        !s.terminalId.startsWith("pending-"),
+    )
+    .map((s) => s.terminalId);
+}

--- a/src/features/terminal/useTerminal.broadcast.test.ts
+++ b/src/features/terminal/useTerminal.broadcast.test.ts
@@ -348,6 +348,73 @@ describe("useTerminal — broadcast fan-out (onData)", () => {
   });
 });
 
+describe("useTerminal — broadcast fan-out (disconnected session)", () => {
+  beforeEach(resetAll);
+
+  it("does NOT fan out when session state is 'disconnected' (getBroadcastTargets disconnected branch)", async () => {
+    // Seed session as disconnected — getBroadcastTargets must return [] for any non-"connected" state
+    useSessionStore.setState({
+      sessions: new Map([
+        [
+          SESSION_ID,
+          {
+            id: SESSION_ID,
+            profileId: "p1",
+            profileName: "Test",
+            host: "host",
+            userId: "u1",
+            username: "user",
+            port: 22,
+            connectedAt: Date.now(),
+            state: "disconnected" as const,
+            terminals: [],
+            activeTerminalId: null,
+          } as never,
+        ],
+      ]),
+      activeSessionId: SESSION_ID,
+    });
+
+    mockTauriInvoke.mockResolvedValueOnce("term-disconnected-src");
+
+    const container = document.createElement("div");
+    const { result } = renderHook(() => useTerminal());
+
+    let sourceId: string | undefined;
+    await act(async () => {
+      sourceId = await result.current.openTerminal(container, SESSION_ID);
+    });
+
+    usePaneLayoutStore.setState({
+      layouts: {
+        [SESSION_ID]: {
+          direction: "horizontal",
+          slots: [
+            { id: "slot-1", terminalId: sourceId ?? "term-disconnected-src", ratio: 0.5 },
+            { id: "slot-2", terminalId: "term-target-disc", ratio: 0.5 },
+          ],
+          focusedSlotId: "slot-1",
+          broadcastEnabled: true,
+        },
+      },
+    });
+
+    mockTauriInvoke.mockReset();
+    mockTauriInvoke.mockResolvedValue(undefined);
+
+    await act(async () => {
+      capturedOnData?.("ls");
+    });
+
+    const writeCalls = mockTauriInvoke.mock.calls.filter(
+      (c) => c[0] === "write_terminal",
+    );
+    // Session disconnected → getBroadcastTargets returns [] → only source write fires
+    expect(writeCalls).toHaveLength(1);
+    expect((writeCalls[0]![1] as Record<string, unknown>).terminalId).toBe(sourceId);
+  });
+});
+
 describe("useTerminal — broadcast fan-out (onBinary / paste)", () => {
   beforeEach(resetAll);
 

--- a/src/features/terminal/useTerminal.broadcast.test.ts
+++ b/src/features/terminal/useTerminal.broadcast.test.ts
@@ -1,0 +1,438 @@
+// features/terminal/useTerminal.broadcast.test.ts — TDD: WU-3 RED phase
+//
+// Tests for the broadcast fan-out injected in useTerminal's onData + onBinary.
+// Verifies that write_terminal is called for target panes when broadcastEnabled,
+// and NOT called for the source, pending slots, or when broadcast is off.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { usePaneLayoutStore } from "../../stores/paneLayoutStore";
+import { useSessionStore } from "../../stores/sessionStore";
+
+// ── localStorage stub ─────────────────────────────────────────────────────────
+
+vi.hoisted(() => {
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, String(v)),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => void store.clear(),
+      key: (i: number) => [...store.keys()][i] ?? null,
+      get length() { return store.size; },
+    },
+  });
+});
+
+// ── Mock heavy native modules ─────────────────────────────────────────────────
+
+// Capture onData / onBinary callbacks so we can invoke them directly in tests
+type DataCallback = (data: string) => void;
+type BinaryCallback = (data: string) => void;
+
+let capturedOnData: DataCallback | null = null;
+let capturedOnBinary: BinaryCallback | null = null;
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: vi.fn().mockImplementation(function MockTerminal() {
+    return {
+      loadAddon: vi.fn(),
+      open: vi.fn(),
+      cols: 80,
+      rows: 24,
+      onData: vi.fn().mockImplementation((cb: DataCallback) => {
+        capturedOnData = cb;
+        return { dispose: vi.fn() };
+      }),
+      onBinary: vi.fn().mockImplementation((cb: BinaryCallback) => {
+        capturedOnBinary = cb;
+        return { dispose: vi.fn() };
+      }),
+      focus: vi.fn(),
+      dispose: vi.fn(),
+      write: vi.fn(),
+      writeln: vi.fn(),
+      element: null,
+      options: {},
+      attachCustomKeyEventHandler: vi.fn(),
+      hasSelection: vi.fn().mockReturnValue(false),
+      getSelection: vi.fn().mockReturnValue(""),
+    };
+  }),
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: vi.fn().mockImplementation(function MockFitAddon() {
+    return { fit: vi.fn(), dispose: vi.fn() };
+  }),
+}));
+
+vi.mock("@xterm/addon-web-links", () => ({
+  WebLinksAddon: vi.fn().mockImplementation(function MockWebLinksAddon() {
+    return { dispose: vi.fn() };
+  }),
+}));
+
+vi.mock("@xterm/addon-search", () => ({
+  SearchAddon: vi.fn().mockImplementation(function MockSearchAddon() {
+    return {
+      activate: vi.fn(),
+      dispose: vi.fn(),
+      findNext: vi.fn().mockReturnValue(false),
+      findPrevious: vi.fn().mockReturnValue(false),
+      onDidChangeResults: vi.fn(),
+    };
+  }),
+}));
+
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: vi.fn().mockImplementation(function MockWebglAddon() {
+    return { onContextLoss: vi.fn(), dispose: vi.fn() };
+  }),
+}));
+
+// tauriInvoke is what we'll assert against for fan-out calls
+const mockTauriInvoke = vi.fn();
+vi.mock("../../lib/tauri", () => ({
+  tauriInvoke: (...args: unknown[]) => mockTauriInvoke(...args),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  Channel: vi.fn().mockImplementation(function MockChannel() {
+    return { onmessage: null };
+  }),
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../stores/commandHistoryStore", () => ({
+  useCommandHistoryStore: {
+    getState: vi.fn(() => ({
+      captureEnabled: false,
+      addCommand: vi.fn(),
+    })),
+  },
+}));
+
+// ── ResizeObserver + navigator.clipboard stubs ────────────────────────────────
+
+if (typeof ResizeObserver === "undefined") {
+  (globalThis as Record<string, unknown>).ResizeObserver = vi.fn().mockImplementation(
+    function MockResizeObserver(_cb: ResizeObserverCallback) {
+      return { observe: vi.fn(), disconnect: vi.fn(), unobserve: vi.fn() };
+    },
+  );
+}
+if (typeof navigator.clipboard === "undefined") {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+  });
+}
+
+import { useTerminal } from "./useTerminal";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const SESSION_ID = "broadcast-test-sess";
+const SESSION_STATE = "connected" as const;
+
+function seedSession() {
+  useSessionStore.setState({
+    sessions: new Map([
+      [
+        SESSION_ID,
+        {
+          id: SESSION_ID,
+          profileId: "p1",
+          profileName: "Test",
+          host: "host",
+          userId: "u1",
+          username: "user",
+          port: 22,
+          connectedAt: Date.now(),
+          state: SESSION_STATE,
+          terminals: [],
+          activeTerminalId: null,
+        } as never,
+      ],
+    ]),
+    activeSessionId: SESSION_ID,
+  });
+}
+
+function resetAll() {
+  capturedOnData = null;
+  capturedOnBinary = null;
+  mockTauriInvoke.mockReset();
+  usePaneLayoutStore.setState({ layouts: {} });
+  useSessionStore.setState({ sessions: new Map(), activeSessionId: null });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("useTerminal — broadcast fan-out (onData)", () => {
+  beforeEach(resetAll);
+
+  it("writes to source pane only when broadcastEnabled is false", async () => {
+    seedSession();
+    // tauriInvoke for open_terminal returns a terminalId string
+    mockTauriInvoke.mockResolvedValueOnce("term-src");
+
+    const container = document.createElement("div");
+    const { result } = renderHook(() => useTerminal());
+
+    let sourceId: string | undefined;
+    await act(async () => {
+      sourceId = await result.current.openTerminal(container, SESSION_ID);
+    });
+
+    // Seed layout with broadcastEnabled: false (default)
+    usePaneLayoutStore.setState({
+      layouts: {
+        [SESSION_ID]: {
+          direction: "horizontal",
+          slots: [
+            { id: "slot-1", terminalId: sourceId ?? "term-src", ratio: 0.5 },
+            { id: "slot-2", terminalId: "term-target", ratio: 0.5 },
+          ],
+          focusedSlotId: "slot-1",
+          broadcastEnabled: false,
+        },
+      },
+    });
+
+    // Reset mock to count only the fan-out invocations
+    mockTauriInvoke.mockReset();
+    mockTauriInvoke.mockResolvedValue(undefined);
+
+    // Fire onData
+    await act(async () => {
+      capturedOnData?.("ls");
+    });
+
+    // Only write_terminal for the source — exactly 1 call
+    const writeCalls = mockTauriInvoke.mock.calls.filter(
+      (c) => c[0] === "write_terminal",
+    );
+    expect(writeCalls).toHaveLength(1);
+    expect(writeCalls[0]![1]).toMatchObject({ terminalId: sourceId });
+  });
+
+  it("fans out to target pane when broadcastEnabled is true (onData)", async () => {
+    seedSession();
+    mockTauriInvoke.mockResolvedValueOnce("term-src");
+
+    const container = document.createElement("div");
+    const { result } = renderHook(() => useTerminal());
+
+    let sourceId: string | undefined;
+    await act(async () => {
+      sourceId = await result.current.openTerminal(container, SESSION_ID);
+    });
+
+    usePaneLayoutStore.setState({
+      layouts: {
+        [SESSION_ID]: {
+          direction: "horizontal",
+          slots: [
+            { id: "slot-1", terminalId: sourceId ?? "term-src", ratio: 0.5 },
+            { id: "slot-2", terminalId: "term-target", ratio: 0.5 },
+          ],
+          focusedSlotId: "slot-1",
+          broadcastEnabled: true,
+        },
+      },
+    });
+
+    mockTauriInvoke.mockReset();
+    mockTauriInvoke.mockResolvedValue(undefined);
+
+    await act(async () => {
+      capturedOnData?.("echo hi");
+    });
+
+    const writeCalls = mockTauriInvoke.mock.calls.filter(
+      (c) => c[0] === "write_terminal",
+    );
+    // Source + 1 target = 2 calls
+    expect(writeCalls).toHaveLength(2);
+    const termIds = writeCalls.map((c) => (c[1] as Record<string, unknown>).terminalId);
+    expect(termIds).toContain(sourceId);
+    expect(termIds).toContain("term-target");
+  });
+
+  it("does NOT double-write to source (source appears exactly once)", async () => {
+    seedSession();
+    mockTauriInvoke.mockResolvedValueOnce("term-src");
+
+    const container = document.createElement("div");
+    const { result } = renderHook(() => useTerminal());
+
+    let sourceId: string | undefined;
+    await act(async () => {
+      sourceId = await result.current.openTerminal(container, SESSION_ID);
+    });
+
+    usePaneLayoutStore.setState({
+      layouts: {
+        [SESSION_ID]: {
+          direction: "horizontal",
+          slots: [
+            { id: "slot-1", terminalId: sourceId ?? "term-src", ratio: 0.5 },
+            { id: "slot-2", terminalId: "term-target", ratio: 0.5 },
+          ],
+          focusedSlotId: "slot-1",
+          broadcastEnabled: true,
+        },
+      },
+    });
+
+    mockTauriInvoke.mockReset();
+    mockTauriInvoke.mockResolvedValue(undefined);
+
+    await act(async () => {
+      capturedOnData?.("pwd");
+    });
+
+    const writeCalls = mockTauriInvoke.mock.calls.filter(
+      (c) => c[0] === "write_terminal",
+    );
+    const sourceWrites = writeCalls.filter(
+      (c) => (c[1] as Record<string, unknown>).terminalId === sourceId,
+    );
+    // Source written exactly once — never twice
+    expect(sourceWrites).toHaveLength(1);
+  });
+
+  it("does NOT fan out to pending slots (terminalId starts with 'pending-')", async () => {
+    seedSession();
+    mockTauriInvoke.mockResolvedValueOnce("term-src");
+
+    const container = document.createElement("div");
+    const { result } = renderHook(() => useTerminal());
+
+    let sourceId: string | undefined;
+    await act(async () => {
+      sourceId = await result.current.openTerminal(container, SESSION_ID);
+    });
+
+    usePaneLayoutStore.setState({
+      layouts: {
+        [SESSION_ID]: {
+          direction: "horizontal",
+          slots: [
+            { id: "slot-1", terminalId: sourceId ?? "term-src", ratio: 0.5 },
+            { id: "slot-2", terminalId: "pending-abc123", ratio: 0.5 },
+          ],
+          focusedSlotId: "slot-1",
+          broadcastEnabled: true,
+        },
+      },
+    });
+
+    mockTauriInvoke.mockReset();
+    mockTauriInvoke.mockResolvedValue(undefined);
+
+    await act(async () => {
+      capturedOnData?.("ls");
+    });
+
+    const writeCalls = mockTauriInvoke.mock.calls.filter(
+      (c) => c[0] === "write_terminal",
+    );
+    // Only source — pending slot excluded
+    expect(writeCalls).toHaveLength(1);
+    expect((writeCalls[0]![1] as Record<string, unknown>).terminalId).toBe(sourceId);
+  });
+});
+
+describe("useTerminal — broadcast fan-out (onBinary / paste)", () => {
+  beforeEach(resetAll);
+
+  it("fans out to target pane when broadcastEnabled is true (onBinary)", async () => {
+    seedSession();
+    mockTauriInvoke.mockResolvedValueOnce("term-src-bin");
+
+    const container = document.createElement("div");
+    const { result } = renderHook(() => useTerminal());
+
+    let sourceId: string | undefined;
+    await act(async () => {
+      sourceId = await result.current.openTerminal(container, SESSION_ID);
+    });
+
+    usePaneLayoutStore.setState({
+      layouts: {
+        [SESSION_ID]: {
+          direction: "horizontal",
+          slots: [
+            { id: "slot-1", terminalId: sourceId ?? "term-src-bin", ratio: 0.5 },
+            { id: "slot-2", terminalId: "term-target-bin", ratio: 0.5 },
+          ],
+          focusedSlotId: "slot-1",
+          broadcastEnabled: true,
+        },
+      },
+    });
+
+    mockTauriInvoke.mockReset();
+    mockTauriInvoke.mockResolvedValue(undefined);
+
+    // Simulate a paste (binary data)
+    await act(async () => {
+      capturedOnBinary?.("pasted text");
+    });
+
+    const writeCalls = mockTauriInvoke.mock.calls.filter(
+      (c) => c[0] === "write_terminal",
+    );
+    // Source + 1 target = 2 calls for paste
+    expect(writeCalls).toHaveLength(2);
+    const termIds = writeCalls.map((c) => (c[1] as Record<string, unknown>).terminalId);
+    expect(termIds).toContain(sourceId);
+    expect(termIds).toContain("term-target-bin");
+  });
+
+  it("does NOT fan out on paste when broadcastEnabled is false", async () => {
+    seedSession();
+    mockTauriInvoke.mockResolvedValueOnce("term-src-bin2");
+
+    const container = document.createElement("div");
+    const { result } = renderHook(() => useTerminal());
+
+    let sourceId: string | undefined;
+    await act(async () => {
+      sourceId = await result.current.openTerminal(container, SESSION_ID);
+    });
+
+    usePaneLayoutStore.setState({
+      layouts: {
+        [SESSION_ID]: {
+          direction: "horizontal",
+          slots: [
+            { id: "slot-1", terminalId: sourceId ?? "term-src-bin2", ratio: 0.5 },
+            { id: "slot-2", terminalId: "term-target-bin2", ratio: 0.5 },
+          ],
+          focusedSlotId: "slot-1",
+          broadcastEnabled: false,
+        },
+      },
+    });
+
+    mockTauriInvoke.mockReset();
+    mockTauriInvoke.mockResolvedValue(undefined);
+
+    await act(async () => {
+      capturedOnBinary?.("paste data");
+    });
+
+    const writeCalls = mockTauriInvoke.mock.calls.filter(
+      (c) => c[0] === "write_terminal",
+    );
+    // Only source
+    expect(writeCalls).toHaveLength(1);
+    expect((writeCalls[0]![1] as Record<string, unknown>).terminalId).toBe(sourceId);
+  });
+});

--- a/src/features/terminal/useTerminal.ts
+++ b/src/features/terminal/useTerminal.ts
@@ -28,6 +28,8 @@ import {
 } from "../history/lineBufferReducer";
 import { useCommandHistoryStore } from "../../stores/commandHistoryStore";
 import { useSessionStore } from "../../stores/sessionStore";
+import { usePaneLayoutStore } from "../../stores/paneLayoutStore";
+import { getBroadcastTargets } from "./broadcastUtils";
 
 /** Result of a search results update from the SearchAddon. */
 export interface SearchResults {
@@ -283,6 +285,12 @@ export function useTerminal() {
           terminalId,
           data: Array.from(bytes),
         });
+
+        // Broadcast fan-out: mirror keystrokes to all other live panes.
+        // Reads store at call time (not captured at open time) so toggle changes
+        // take effect immediately without reopening the terminal.
+        // SAFETY: source is excluded by getBroadcastTargets — no double-write.
+        _broadcastFanOut(sessionId, terminalId, Array.from(bytes));
       });
 
       // Handle binary data (e.g., from paste)
@@ -296,6 +304,12 @@ export function useTerminal() {
           terminalId,
           data: Array.from(bytes),
         });
+
+        // Broadcast fan-out for paste (onBinary) — same logic as onData.
+        // Critical: paste MUST get the same fan-out or pasted content is
+        // sent to the source pane only. getBroadcastTargets guarantees no
+        // double-write to source.
+        _broadcastFanOut(sessionId, terminalId, Array.from(bytes));
       });
 
       // Resize handler with debounce
@@ -603,6 +617,41 @@ export function _testSeedTerminalInstance(id: string, instance: TerminalInstance
  */
 export function _testGetFindBarOpener(terminalId: TerminalId): (() => void) | null {
   return terminalInstances.get(terminalId)?.callbackOnOpenFindBar ?? null;
+}
+
+/**
+ * Broadcast fan-out helper.
+ *
+ * Reads the paneLayoutStore and sessionStore at call time to get the current
+ * broadcastEnabled state and session connection state. This deliberately avoids
+ * closure-capture so toggling broadcast takes effect on the very next keystroke.
+ *
+ * SAFETY INVARIANTS (enforced here and by getBroadcastTargets):
+ * 1. Source pane is never written a second time (excluded by getBroadcastTargets).
+ * 2. Pending slots (null or "pending-*" terminalIds) are excluded.
+ * 3. Only fires when session is "connected" string state.
+ * 4. write_terminal errors are silently ignored (void) — target PTY closing
+ *    mid-broadcast is handled gracefully by Rust; the pane shows PTY-closed msg.
+ */
+function _broadcastFanOut(
+  sessionId: SessionId,
+  sourceTerminalId: TerminalId,
+  bytes: number[],
+): void {
+  const layout = usePaneLayoutStore.getState().layouts[sessionId];
+  if (!layout?.broadcastEnabled) return;
+
+  const session = useSessionStore.getState().sessions.get(sessionId);
+  const sessionState = session?.state ?? "disconnected";
+
+  const targets = getBroadcastTargets(layout.slots, sourceTerminalId, sessionState);
+  for (const targetId of targets) {
+    void tauriInvoke<void>("write_terminal", {
+      sessionId,
+      terminalId: targetId,
+      data: bytes,
+    });
+  }
 }
 
 /**

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -180,6 +180,12 @@ export const en = {
   "terminal.splitHorizontal": "Split pane horizontally",
   "terminal.splitVertical": "Split pane vertically",
   "terminal.closePane": "Close pane",
+  "terminal.broadcastToggle": "Broadcast",
+  "terminal.broadcastToggleOn": "Broadcast ON",
+  "terminal.broadcastToggleOff": "Broadcast OFF",
+  "terminal.broadcastBanner": "Broadcast ON — keystrokes sent to all panes",
+  "terminal.broadcastAriaOn": "Disable input broadcast",
+  "terminal.broadcastAriaOff": "Enable input broadcast",
 
   // Terminal find-bar
   "terminal.find.placeholder": "Search in terminal...",

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -182,6 +182,12 @@ export const es: Record<TranslationKey, string> = {
   "terminal.splitHorizontal": "Dividir panel horizontalmente",
   "terminal.splitVertical": "Dividir panel verticalmente",
   "terminal.closePane": "Cerrar panel",
+  "terminal.broadcastToggle": "Difundir",
+  "terminal.broadcastToggleOn": "Difusión ACTIVA",
+  "terminal.broadcastToggleOff": "Difusión inactiva",
+  "terminal.broadcastBanner": "Difusión ACTIVA — teclas enviadas a todos los paneles",
+  "terminal.broadcastAriaOn": "Desactivar difusión de teclado",
+  "terminal.broadcastAriaOff": "Activar difusión de teclado",
 
   // Terminal find-bar
   "terminal.find.placeholder": "Buscar en la terminal...",

--- a/src/lib/i18n/index.test.tsx
+++ b/src/lib/i18n/index.test.tsx
@@ -36,6 +36,32 @@ function LocaleProbe() {
   );
 }
 
+// ── WU-6: Broadcast i18n keys present in both locales ─────────────────────────
+
+import { en } from "./en";
+import { es } from "./es";
+
+const BROADCAST_KEYS = [
+  "terminal.broadcastToggle",
+  "terminal.broadcastToggleOn",
+  "terminal.broadcastToggleOff",
+  "terminal.broadcastBanner",
+  "terminal.broadcastAriaOn",
+  "terminal.broadcastAriaOff",
+] as const;
+
+describe("i18n — broadcast keys", () => {
+  for (const key of BROADCAST_KEYS) {
+    it(`en.ts has key: ${key}`, () => {
+      expect(en[key]).toBeTruthy();
+    });
+
+    it(`es.ts has key: ${key}`, () => {
+      expect(es[key]).toBeTruthy();
+    });
+  }
+});
+
 describe("I18nProvider — html lang sync", () => {
   beforeEach(() => {
     localStorage.clear();

--- a/src/stores/paneLayoutStore.test.ts
+++ b/src/stores/paneLayoutStore.test.ts
@@ -197,3 +197,83 @@ describe("paneLayoutStore — direction", () => {
     expect(getLayout("sess-1")!.direction).toBe("vertical");
   });
 });
+
+// ── WU-2: broadcastEnabled + toggleBroadcast ───────────────────────────────────
+
+describe("paneLayoutStore — broadcastEnabled", () => {
+  beforeEach(resetStore);
+
+  it("broadcastEnabled defaults to false on openLayout", () => {
+    usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
+    expect(getLayout("sess-1")!.broadcastEnabled).toBe(false);
+  });
+
+  it("toggleBroadcast flips broadcastEnabled from false to true", () => {
+    usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
+    usePaneLayoutStore.getState().toggleBroadcast("sess-1");
+    expect(getLayout("sess-1")!.broadcastEnabled).toBe(true);
+  });
+
+  it("toggleBroadcast flips broadcastEnabled from true back to false", () => {
+    usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
+    usePaneLayoutStore.getState().toggleBroadcast("sess-1");
+    usePaneLayoutStore.getState().toggleBroadcast("sess-1");
+    expect(getLayout("sess-1")!.broadcastEnabled).toBe(false);
+  });
+
+  it("toggleBroadcast is a no-op when the layout does not exist", () => {
+    // Should not throw
+    expect(() => {
+      usePaneLayoutStore.getState().toggleBroadcast("nonexistent-sess");
+    }).not.toThrow();
+    expect(getLayout("nonexistent-sess")).toBeUndefined();
+  });
+
+  it("removeLayout destroys the layout (broadcastEnabled resets on next openLayout)", () => {
+    usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
+    usePaneLayoutStore.getState().toggleBroadcast("sess-1");
+    expect(getLayout("sess-1")!.broadcastEnabled).toBe(true);
+
+    usePaneLayoutStore.getState().removeLayout("sess-1");
+    expect(getLayout("sess-1")).toBeUndefined();
+
+    // Re-open — must start with broadcastEnabled: false (never persisted)
+    usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
+    expect(getLayout("sess-1")!.broadcastEnabled).toBe(false);
+  });
+
+  it("closeSlot resets broadcastEnabled to false when slots drop below 2", () => {
+    usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
+    const firstSlotId = slot(getLayout("sess-1")!, 0).id;
+    usePaneLayoutStore.getState().splitSlot("sess-1", firstSlotId);
+
+    // Enable broadcast with 2 panes
+    usePaneLayoutStore.getState().toggleBroadcast("sess-1");
+    expect(getLayout("sess-1")!.broadcastEnabled).toBe(true);
+    expect(getLayout("sess-1")!.slots).toHaveLength(2);
+
+    // Close one pane → drops to 1
+    const secondSlotId = slot(getLayout("sess-1")!, 1).id;
+    usePaneLayoutStore.getState().closeSlot("sess-1", secondSlotId);
+
+    expect(getLayout("sess-1")!.slots).toHaveLength(1);
+    expect(getLayout("sess-1")!.broadcastEnabled).toBe(false);
+  });
+
+  it("closeSlot does NOT reset broadcastEnabled when 2+ panes remain", () => {
+    usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
+    const s1 = slot(getLayout("sess-1")!, 0).id;
+    usePaneLayoutStore.getState().splitSlot("sess-1", s1);
+    const s2 = slot(getLayout("sess-1")!, 1).id;
+    usePaneLayoutStore.getState().splitSlot("sess-1", s2);
+    expect(getLayout("sess-1")!.slots).toHaveLength(3);
+
+    usePaneLayoutStore.getState().toggleBroadcast("sess-1");
+    expect(getLayout("sess-1")!.broadcastEnabled).toBe(true);
+
+    // Close one pane → 2 remain, broadcast stays ON
+    usePaneLayoutStore.getState().closeSlot("sess-1", s2);
+    expect(getLayout("sess-1")!.slots).toHaveLength(2);
+    expect(getLayout("sess-1")!.broadcastEnabled).toBe(true);
+  });
+});

--- a/src/stores/paneLayoutStore.test.ts
+++ b/src/stores/paneLayoutStore.test.ts
@@ -208,16 +208,38 @@ describe("paneLayoutStore — broadcastEnabled", () => {
     expect(getLayout("sess-1")!.broadcastEnabled).toBe(false);
   });
 
-  it("toggleBroadcast flips broadcastEnabled from false to true", () => {
+  it("toggleBroadcast flips broadcastEnabled from false to true (2-slot layout)", () => {
     usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
+    const s1 = slot(getLayout("sess-1")!, 0).id;
+    usePaneLayoutStore.getState().splitSlot("sess-1", s1);
     usePaneLayoutStore.getState().toggleBroadcast("sess-1");
     expect(getLayout("sess-1")!.broadcastEnabled).toBe(true);
   });
 
-  it("toggleBroadcast flips broadcastEnabled from true back to false", () => {
+  it("toggleBroadcast flips broadcastEnabled from true back to false (2-slot layout)", () => {
     usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
+    const s1 = slot(getLayout("sess-1")!, 0).id;
+    usePaneLayoutStore.getState().splitSlot("sess-1", s1);
     usePaneLayoutStore.getState().toggleBroadcast("sess-1");
     usePaneLayoutStore.getState().toggleBroadcast("sess-1");
+    expect(getLayout("sess-1")!.broadcastEnabled).toBe(false);
+  });
+
+  // MINOR-1: store-level guard — enabling broadcast requires >=2 slots
+  it("toggleBroadcast is a no-op (cannot enable) on a 1-slot layout", () => {
+    usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
+    expect(getLayout("sess-1")!.slots).toHaveLength(1);
+    usePaneLayoutStore.getState().toggleBroadcast("sess-1");
+    // Guard: cannot enable with <2 panes
+    expect(getLayout("sess-1")!.broadcastEnabled).toBe(false);
+  });
+
+  it("toggleBroadcast (disable) is allowed on a 1-slot layout when already off (no-op stays false)", () => {
+    // Disabling from false is trivially fine — stays false
+    usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
+    usePaneLayoutStore.getState().toggleBroadcast("sess-1"); // no-op: enable blocked
+    expect(getLayout("sess-1")!.broadcastEnabled).toBe(false);
+    usePaneLayoutStore.getState().toggleBroadcast("sess-1"); // toggle off false → still false
     expect(getLayout("sess-1")!.broadcastEnabled).toBe(false);
   });
 
@@ -231,6 +253,8 @@ describe("paneLayoutStore — broadcastEnabled", () => {
 
   it("removeLayout destroys the layout (broadcastEnabled resets on next openLayout)", () => {
     usePaneLayoutStore.getState().openLayout("sess-1", "term-1");
+    const s1 = slot(getLayout("sess-1")!, 0).id;
+    usePaneLayoutStore.getState().splitSlot("sess-1", s1);
     usePaneLayoutStore.getState().toggleBroadcast("sess-1");
     expect(getLayout("sess-1")!.broadcastEnabled).toBe(true);
 

--- a/src/stores/paneLayoutStore.ts
+++ b/src/stores/paneLayoutStore.ts
@@ -31,6 +31,9 @@ export interface PaneLayout {
   /** Which slot currently holds keyboard focus. Drives the focus ring and
    *  the sessionStore.activeTerminalId pointer for SidePanel/HistoryPanel. */
   focusedSlotId: string;
+  /** When true, keystrokes from the focused pane are mirrored to all other
+   *  live panes. Defaults to false. NEVER persisted — ephemeral safety default. */
+  broadcastEnabled: boolean;
 }
 
 // ── Internal state ────────────────────────────────────────────────────────────
@@ -64,6 +67,10 @@ interface PaneLayoutStoreState {
   /** Set the split direction for the whole layout. */
   setDirection: (sessionId: SessionId, direction: PaneDirection) => void;
 
+  /** Toggle the broadcast mode for the given session's layout.
+   *  No-op if the layout doesn't exist. */
+  toggleBroadcast: (sessionId: SessionId) => void;
+
   /** Remove the entire layout entry (called on session close). */
   removeLayout: (sessionId: SessionId) => void;
 }
@@ -91,6 +98,7 @@ export const usePaneLayoutStore = create<PaneLayoutStoreState>((set, get) => ({
           direction: "horizontal",
           slots: [{ id: slotId, terminalId, ratio: 1 }],
           focusedSlotId: slotId,
+          broadcastEnabled: false,
         },
       },
     }));
@@ -141,6 +149,11 @@ export const usePaneLayoutStore = create<PaneLayoutStoreState>((set, get) => ({
         ? (fallbackSlot?.id ?? layout.focusedSlotId)
         : layout.focusedSlotId;
 
+    // Safety: auto-reset broadcast when dropping below 2 panes.
+    // With only 1 pane there are no targets — silently becomes a no-op,
+    // but resetting is the safe and explicit choice.
+    const broadcastEnabled = next.length >= 2 ? layout.broadcastEnabled : false;
+
     set((state) => ({
       layouts: {
         ...state.layouts,
@@ -148,6 +161,7 @@ export const usePaneLayoutStore = create<PaneLayoutStoreState>((set, get) => ({
           ...layout,
           slots: redistributeRatios(next),
           focusedSlotId,
+          broadcastEnabled,
         },
       },
     }));
@@ -204,6 +218,17 @@ export const usePaneLayoutStore = create<PaneLayoutStoreState>((set, get) => ({
       layouts: {
         ...state.layouts,
         [sessionId]: { ...layout, direction },
+      },
+    }));
+  },
+
+  toggleBroadcast: (sessionId) => {
+    const layout = get().layouts[sessionId];
+    if (!layout) return;
+    set((state) => ({
+      layouts: {
+        ...state.layouts,
+        [sessionId]: { ...layout, broadcastEnabled: !layout.broadcastEnabled },
       },
     }));
   },

--- a/src/stores/paneLayoutStore.ts
+++ b/src/stores/paneLayoutStore.ts
@@ -225,6 +225,11 @@ export const usePaneLayoutStore = create<PaneLayoutStoreState>((set, get) => ({
   toggleBroadcast: (sessionId) => {
     const layout = get().layouts[sessionId];
     if (!layout) return;
+    // Safety invariant: broadcast can only be ENABLED when there are >=2 panes.
+    // Disabling is always allowed (regardless of slot count).
+    // The UI already gates the toggle button on paneCount>=2, but the store
+    // must self-enforce so programmatic callers cannot violate the invariant.
+    if (!layout.broadcastEnabled && layout.slots.length < 2) return;
     set((state) => ({
       layouts: {
         ...state.layouts,

--- a/src/styles/terminal.css
+++ b/src/styles/terminal.css
@@ -176,6 +176,7 @@
   display: flex;
   height: 100%;
   overflow: hidden;
+  position: relative; /* required for .terminal-broadcast-banner absolute positioning */
 }
 
 .terminal-split-horizontal {

--- a/src/styles/terminal.css
+++ b/src/styles/terminal.css
@@ -260,6 +260,79 @@
   cursor: not-allowed;
 }
 
+/* ── Broadcast toggle button (tab bar) ──────────── */
+
+/* Visible only when paneCount >= 2 (conditional render in TerminalTabs).
+   ON state: warning color + wash background.
+   OFF state: muted like other tab-bar buttons. */
+.terminal-tab-broadcast {
+  flex-shrink: 0;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: var(--fs-meta);
+  font-family: var(--font-sans);
+  padding: 2px 7px;
+  line-height: var(--lh-body);
+  transition: color var(--transition-fast), background-color var(--transition-fast);
+  white-space: nowrap;
+}
+
+.terminal-tab-broadcast:hover {
+  color: var(--text-primary);
+  background-color: var(--bg-raised);
+}
+
+/* ON state: warning token so it's clearly active */
+.terminal-tab-broadcast[aria-pressed="true"] {
+  color: var(--warning);
+  background-color: var(--warning-wash);
+}
+
+.terminal-tab-broadcast[aria-pressed="true"]:hover {
+  background-color: var(--warning-wash);
+}
+
+/* ── Broadcast banner (inside .terminal-split) ───── */
+
+/* Full-width strip at the top of the split container.
+   Uses --warning / --warning-wash LAMPLIGHT tokens.
+   z-index above terminal canvas but below dialogs.
+   NOT color-only: explicit text label required by design. */
+.terminal-broadcast-banner {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  background-color: var(--warning-wash);
+  border-bottom: 1px solid var(--warning);
+  color: var(--warning);
+  font-family: var(--font-sans);
+  font-size: var(--fs-meta);
+  line-height: var(--lh-body);
+  pointer-events: none; /* passthrough to terminal beneath */
+}
+
+.terminal-broadcast-banner-icon {
+  font-size: 12px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.terminal-broadcast-banner-text {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* ── Per-pane close button ───────────────────────── */
 
 /* Positioned absolutely in the top-right corner of the pane.

--- a/src/styles/terminal.css
+++ b/src/styles/terminal.css
@@ -340,7 +340,8 @@
    The pane (.terminal-split-pane) is already position:relative.
    Hidden by default; revealed on pane hover or keyboard focus.
    z-index above the terminal canvas but below dialogs.
-   Does NOT push xterm content — floats as an overlay. */
+   Does NOT push xterm content — floats as an overlay.
+   See broadcast-active override below for the banner-occlude fix. */
 .terminal-split-pane-close {
   position: absolute;
   top: 4px;
@@ -364,6 +365,17 @@
     background-color var(--transition-fast);
   /* pointer-events off when invisible so clicks reach the terminal */
   pointer-events: none;
+}
+
+/* When broadcast is active, the full-width banner strip covers top:0..~26px.
+   Push the close button below the banner so it is never occluded.
+   z-index:11 (> banner z-index:10) keeps it reachable. Works in both
+   LAMPLIGHT and DARK because it only shifts position, not color tokens.
+   The banner itself is pointer-events:none so the area beneath it is still
+   clickable — this rule ensures the close button is visible above the banner. */
+.terminal-split[data-broadcast="true"] .terminal-split-pane-close {
+  top: 30px; /* 26px banner height + 4px original offset */
+  z-index: 11; /* above banner (z-index:10) */
 }
 
 /* Reveal on pane hover */


### PR DESCRIPTION
## Summary

Final item of the terminal suite in the Voltius clean-room program. When a split layout has 2+ panes, a **broadcast** toggle mirrors the focused pane's keystrokes (and pastes) to all other live panes' terminals at once — the fleet-ops "run the same command on N servers" workflow. Clean-room: original pure fan-out + own store/UI; no Voltius (AGPL) code; frontend-only (no Rust).

## Safety (this sends keystrokes to multiple production servers)

- **Default OFF** and **never persisted** (the pane-layout store is ephemeral) — every session starts with broadcast off.
- **Store-enforced**: `toggleBroadcast` only enables with ≥2 panes; **auto-resets to OFF** when panes drop below 2 or the layout is destroyed. The pure `getBroadcastTargets` also returns no targets when the session isn't connected — so there is no path to a *silent* broadcast.
- **Prominent indicator**: a full-width warning banner (`--warning` tokens, `role="status"`, explicit "Broadcast ON" text — not color-only) across the split region, plus an `aria-pressed` labeled toggle.

## Correctness

- Fan-out covers both `onData` and `onBinary` (paste); the source pane is written exactly once (never double-written); targets exclude the source, pending, and disconnected panes.
- No feedback loop and no double command-history capture: fan-out writes straight to each target PTY, never through their `onData`.
- A target disconnecting mid-broadcast fails silently (no crash).

## Quality

- **457 tests green** (Vitest), `tsc --noEmit` clean
- **Strict TDD** throughout (6 work units + polish)
- **Adversarial review GO**: the no-silent-broadcast invariant verified across all paths; 3 MINOR follow-ups (store-level guard, disconnected-path test, banner/close-button overlap) all closed before this PR.
- **Clean-room verified**: no AGPL code.