### PR TITLE
feat(profile): persisted folder field for real sidebar grouping

### DIFF
--- a/src-tauri/src/commands/profile.rs
+++ b/src-tauri/src/commands/profile.rs
@@ -480,6 +480,7 @@ pub async fn import_profiles(
             users: users.clone(),
             startup_directory: None,
             startup_commands: Vec::new(),
+            folder: None,
             tunnels: Vec::new(),
             display_order: max_order + 1,
             created_at: now,

--- a/src-tauri/src/profile.rs
+++ b/src-tauri/src/profile.rs
@@ -137,6 +137,13 @@ pub struct ConnectionProfile {
     pub startup_directory: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub startup_commands: Vec<String>,
+    /// User-assigned folder name for sidebar grouping.
+    /// When set, the sidebar groups this profile under the folder name verbatim
+    /// instead of falling back to the name-heuristic group.
+    /// `#[serde(default)]` keeps pre-existing profiles (written before this
+    /// field) deserializing without error.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub folder: Option<String>,
     pub tunnels: Vec<TunnelConfig>,
     #[serde(default)]
     pub display_order: i32,
@@ -191,6 +198,7 @@ impl Default for ConnectionProfile {
             users: Vec::new(),
             startup_directory: None,
             startup_commands: Vec::new(),
+            folder: None,
             tunnels: Vec::new(),
             display_order: 0,
             created_at: Utc::now(),
@@ -903,6 +911,79 @@ mod tests {
         assert!(
             profile.startup_commands.is_empty(),
             "startup_commands must default to empty for old profiles"
+        );
+    }
+
+    // ─── folder field back-compat tests ────────────────────────────────────
+
+    #[test]
+    fn folder_field_defaults_none_on_old_profile() {
+        // A profile written before the folder field existed must still
+        // deserialize cleanly with folder == None (back-compat critical path).
+        let old_json = r#"{
+            "id": "00000000-0000-0000-0000-000000000020",
+            "name": "Old Server",
+            "host": "old.example.com",
+            "port": 22,
+            "users": [{
+                "id": "00000000-0000-0000-0000-000000000021",
+                "username": "root",
+                "authMethod": {"type": "password"},
+                "isDefault": true
+            }],
+            "startupDirectory": null,
+            "tunnels": [],
+            "displayOrder": 0,
+            "createdAt": "2024-01-01T00:00:00Z",
+            "updatedAt": "2024-01-01T00:00:00Z"
+        }"#;
+
+        let profile: ConnectionProfile = serde_json::from_str(old_json).unwrap();
+        assert!(
+            profile.folder.is_none(),
+            "missing folder key must default to None"
+        );
+    }
+
+    #[test]
+    fn folder_roundtrips_on_disk() {
+        let dir = std::env::temp_dir().join(format!("folder_roundtrip_test_{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let profiles = vec![ConnectionProfile {
+            name: "Folder Server".to_string(),
+            host: "folder.example.com".to_string(),
+            users: vec![UserCredential {
+                id: Uuid::new_v4(),
+                username: "deploy".to_string(),
+                auth_method: AuthMethodConfig::Password,
+                is_default: true,
+            }],
+            folder: Some("production".to_string()),
+            ..ConnectionProfile::default()
+        }];
+
+        save_profiles_to_disk(&profiles, Some(&dir)).unwrap();
+        let loaded = load_profiles_from_disk(Some(&dir)).unwrap();
+
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(
+            loaded[0].folder.as_deref(),
+            Some("production"),
+            "folder must survive save+load roundtrip"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn folder_omitted_from_json_when_none() {
+        // skip_serializing_if = "Option::is_none" keeps clean JSON when no folder.
+        let profile = test_profile("No Folder", "example.com", "user");
+        let json = serde_json::to_string(&profile).unwrap();
+        assert!(
+            !json.contains("folder"),
+            "folder must be omitted when None, got: {json}"
         );
     }
 

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -59,39 +59,12 @@ function middleEllipsis(str: string, maxLen = 30): string {
 }
 
 // ─── Client-side group derivation ─────────────────────────
-// No backend `group` field yet — derive from profile name heuristics.
-// Returns: "production" | "development" | "certification" | "staging" | "other"
-type GroupKey = "production" | "development" | "certification" | "staging" | "other";
-
-function deriveGroup(profile: ConnectionProfile): GroupKey {
-  const name = profile.name.toLowerCase();
-  if (/\b(prod|production|prd)\b/.test(name)) return "production";
-  if (/\b(dev|develop|development)\b/.test(name)) return "development";
-  if (/\b(cert|cer|qa|test|tst)\b/.test(name)) return "certification";
-  if (/\b(stag|staging|uat|pre\-?prod)\b/.test(name)) return "staging";
-  return "other";
-}
-
-// Stable group display order
-const GROUP_ORDER: GroupKey[] = ["production", "staging", "certification", "development", "other"];
-
-interface ProfileGroup {
-  key: GroupKey;
-  profiles: ConnectionProfile[];
-}
-
-function groupProfiles(profiles: ConnectionProfile[]): ProfileGroup[] {
-  const map = new Map<GroupKey, ConnectionProfile[]>();
-  for (const key of GROUP_ORDER) map.set(key, []);
-  for (const p of profiles) {
-    const key = deriveGroup(p);
-    map.get(key)!.push(p);
-  }
-  // Only emit groups that have profiles
-  return GROUP_ORDER
-    .filter((key) => map.get(key)!.length > 0)
-    .map((key) => ({ key, profiles: map.get(key)! }));
-}
+// Folder-first grouping: profile.folder takes priority; deriveGroup is the
+// fallback for profiles without an explicit folder assignment.
+// Logic is extracted to sidebarGrouping.ts for testability.
+import { groupProfiles, isLegacyGroupKey } from "./sidebarGrouping";
+import type { ProfileGroup } from "./sidebarGrouping";
+type GroupKey = string;
 
 // ─── Session elapsed time ─────────────────────────────────
 function formatElapsed(connectedAt: number): string {
@@ -462,16 +435,14 @@ function GroupHeader({
   count: number;
   t: (key: TranslationKey, params?: Record<string, string | number>) => string;
 }) {
-  const labelKey: TranslationKey =
-    groupKey === "production" ? "sidebar.group.production"
-    : groupKey === "development" ? "sidebar.group.development"
-    : groupKey === "certification" ? "sidebar.group.certification"
-    : groupKey === "staging" ? "sidebar.group.staging"
-    : "sidebar.group.other";
+  // Legacy heuristic keys map to i18n; user-assigned folder names render verbatim (uppercased).
+  const label = isLegacyGroupKey(groupKey)
+    ? t(`sidebar.group.${groupKey}` as TranslationKey)
+    : groupKey.toUpperCase();
 
   return (
     <div className="lp-group-header">
-      <span className="lp-group-label">{t(labelKey)}</span>
+      <span className="lp-group-label">{label}</span>
       <span className="lp-group-count">{count}</span>
     </div>
   );
@@ -735,9 +706,9 @@ export function Sidebar({
   // Group the filtered profiles (only group when not searching)
   const profileGroups = useMemo(() => {
     if (searchQuery.trim()) {
-      // When searching, show flat list under a single "PROFILES" group
+      // When searching, show flat list under the generic "PROFILES" bucket
       return filteredProfiles.length > 0
-        ? [{ key: "other" as GroupKey, profiles: filteredProfiles }]
+        ? [{ key: "other", profiles: filteredProfiles } satisfies ProfileGroup]
         : [];
     }
     return groupProfiles(filteredProfiles);

--- a/src/components/layout/sidebarGrouping.test.ts
+++ b/src/components/layout/sidebarGrouping.test.ts
@@ -1,0 +1,135 @@
+// sidebarGrouping.test.ts — TDD: folder-first grouping with deriveGroup fallback
+//
+// These tests drive the extracted groupProfiles / deriveGroup seam.
+// RED phase: tests written before implementation exists in sidebarGrouping.ts.
+
+import { describe, it, expect } from "vitest";
+import { groupProfiles, deriveGroup } from "./sidebarGrouping";
+import type { ConnectionProfile } from "../../lib/types";
+
+// ─── Minimal profile factory ──────────────────────────────────────────────────
+
+function makeProfile(
+  name: string,
+  overrides: Partial<ConnectionProfile> = {},
+): ConnectionProfile {
+  return {
+    id: crypto.randomUUID(),
+    name,
+    host: "example.com",
+    port: 22,
+    users: [],
+    tunnels: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// ─── deriveGroup fallback ─────────────────────────────────────────────────────
+
+describe("deriveGroup", () => {
+  it("matches production keywords", () => {
+    expect(deriveGroup(makeProfile("prod-server"))).toBe("production");
+    expect(deriveGroup(makeProfile("production-db"))).toBe("production");
+    expect(deriveGroup(makeProfile("prd-01"))).toBe("production");
+  });
+
+  it("matches staging keywords", () => {
+    expect(deriveGroup(makeProfile("stag-server"))).toBe("staging");
+    expect(deriveGroup(makeProfile("staging-api"))).toBe("staging");
+    expect(deriveGroup(makeProfile("uat-backend"))).toBe("staging");
+  });
+
+  it("matches development keywords", () => {
+    expect(deriveGroup(makeProfile("dev-machine"))).toBe("development");
+    expect(deriveGroup(makeProfile("develop-01"))).toBe("development");
+  });
+
+  it("matches certification keywords", () => {
+    expect(deriveGroup(makeProfile("cert-server"))).toBe("certification");
+    expect(deriveGroup(makeProfile("qa-node"))).toBe("certification");
+  });
+
+  it("falls back to other for unrecognized names", () => {
+    expect(deriveGroup(makeProfile("server1"))).toBe("other");
+    expect(deriveGroup(makeProfile("my-machine"))).toBe("other");
+  });
+});
+
+// ─── groupProfiles: folder takes precedence ───────────────────────────────────
+
+describe("groupProfiles", () => {
+  it("groups profile under its folder when folder is set", () => {
+    const p = makeProfile("server1", { folder: "my-team" });
+    const groups = groupProfiles([p]);
+
+    // Must appear under "my-team", not under deriveGroup result ("other")
+    const myTeamGroup = groups.find((g) => g.key === "my-team");
+    const otherGroup = groups.find((g) => g.key === "other");
+
+    expect(myTeamGroup).toBeDefined();
+    expect(myTeamGroup?.profiles).toContain(p);
+    expect(otherGroup).toBeUndefined();
+  });
+
+  it("falls back to deriveGroup when folder is absent", () => {
+    const p = makeProfile("prod-server");
+    const groups = groupProfiles([p]);
+
+    const productionGroup = groups.find((g) => g.key === "production");
+    expect(productionGroup).toBeDefined();
+    expect(productionGroup?.profiles).toContain(p);
+  });
+
+  it("falls back to deriveGroup when folder is empty string", () => {
+    const p = makeProfile("prod-server", { folder: "" });
+    const groups = groupProfiles([p]);
+
+    const productionGroup = groups.find((g) => g.key === "production");
+    expect(productionGroup).toBeDefined();
+    expect(productionGroup?.profiles).toContain(p);
+  });
+
+  it("falls back to other when no folder and name does not match heuristic", () => {
+    const p = makeProfile("server1");
+    const groups = groupProfiles([p]);
+
+    const otherGroup = groups.find((g) => g.key === "other");
+    expect(otherGroup).toBeDefined();
+    expect(otherGroup?.profiles).toContain(p);
+  });
+
+  it("emits only groups that have at least one profile", () => {
+    const p = makeProfile("server1", { folder: "infra" });
+    const groups = groupProfiles([p]);
+
+    // Only "infra" should appear — no empty legacy groups
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe("infra");
+  });
+
+  it("preserves profile insertion order within a group", () => {
+    const p1 = makeProfile("server1", { folder: "infra" });
+    const p2 = makeProfile("server2", { folder: "infra" });
+    const groups = groupProfiles([p1, p2]);
+
+    const infraGroup = groups.find((g) => g.key === "infra");
+    expect(infraGroup?.profiles[0]).toBe(p1);
+    expect(infraGroup?.profiles[1]).toBe(p2);
+  });
+
+  it("sorts user-assigned folders before heuristic groups", () => {
+    const folderProfile = makeProfile("server1", { folder: "my-team" });
+    const heuristicProfile = makeProfile("prod-server");
+    const groups = groupProfiles([heuristicProfile, folderProfile]);
+
+    // User-assigned folder should come first
+    expect(groups[0].key).toBe("my-team");
+    expect(groups[1].key).toBe("production");
+  });
+
+  it("handles empty profile list", () => {
+    expect(groupProfiles([])).toHaveLength(0);
+  });
+});

--- a/src/components/layout/sidebarGrouping.test.ts
+++ b/src/components/layout/sidebarGrouping.test.ts
@@ -106,7 +106,7 @@ describe("groupProfiles", () => {
 
     // Only "infra" should appear — no empty legacy groups
     expect(groups).toHaveLength(1);
-    expect(groups[0].key).toBe("infra");
+    expect(groups[0]?.key).toBe("infra");
   });
 
   it("preserves profile insertion order within a group", () => {
@@ -115,8 +115,9 @@ describe("groupProfiles", () => {
     const groups = groupProfiles([p1, p2]);
 
     const infraGroup = groups.find((g) => g.key === "infra");
-    expect(infraGroup?.profiles[0]).toBe(p1);
-    expect(infraGroup?.profiles[1]).toBe(p2);
+    expect(infraGroup).toBeDefined();
+    expect(infraGroup!.profiles[0]).toBe(p1);
+    expect(infraGroup!.profiles[1]).toBe(p2);
   });
 
   it("sorts user-assigned folders before heuristic groups", () => {
@@ -125,8 +126,8 @@ describe("groupProfiles", () => {
     const groups = groupProfiles([heuristicProfile, folderProfile]);
 
     // User-assigned folder should come first
-    expect(groups[0].key).toBe("my-team");
-    expect(groups[1].key).toBe("production");
+    expect(groups[0]?.key).toBe("my-team");
+    expect(groups[1]?.key).toBe("production");
   });
 
   it("handles empty profile list", () => {

--- a/src/components/layout/sidebarGrouping.ts
+++ b/src/components/layout/sidebarGrouping.ts
@@ -1,0 +1,104 @@
+// sidebarGrouping.ts — Folder-first profile grouping for the Sidebar
+//
+// Approach 1 (spec): profile.folder takes priority; deriveGroup is the fallback.
+// GroupKey is a plain string — user-defined folder names are verbatim; legacy
+// heuristic keys ("production", "staging", etc.) are a subset of that string space.
+
+import type { ConnectionProfile } from "../../lib/types";
+
+// ─── Legacy heuristic group keys ──────────────────────────────────────────────
+// These are the fixed i18n-backed keys produced by deriveGroup.
+
+export type LegacyGroupKey = "production" | "development" | "certification" | "staging" | "other";
+
+// Stable display order for legacy heuristic groups (shown AFTER user folders).
+const LEGACY_GROUP_ORDER: LegacyGroupKey[] = [
+  "production",
+  "staging",
+  "certification",
+  "development",
+  "other",
+];
+
+// ─── Profile group ────────────────────────────────────────────────────────────
+
+export interface ProfileGroup {
+  key: string;
+  profiles: ConnectionProfile[];
+}
+
+// ─── deriveGroup ──────────────────────────────────────────────────────────────
+// Pure heuristic: maps profile name to one of the five legacy group keys.
+// Used ONLY as a fallback when profile.folder is absent or empty.
+
+export function deriveGroup(profile: ConnectionProfile): LegacyGroupKey {
+  const name = profile.name.toLowerCase();
+  if (/\b(prod|production|prd)\b/.test(name)) return "production";
+  if (/\b(dev|develop|development)\b/.test(name)) return "development";
+  if (/\b(cert|cer|qa|test|tst)\b/.test(name)) return "certification";
+  if (/\b(stag|staging|uat|pre\-?prod)\b/.test(name)) return "staging";
+  return "other";
+}
+
+// ─── groupProfiles ────────────────────────────────────────────────────────────
+// Groups profiles by folder (when set) or by deriveGroup (when absent).
+//
+// Ordering:
+//   1. User-assigned folders (in insertion/encounter order, stable)
+//   2. Legacy heuristic groups (in LEGACY_GROUP_ORDER, stable)
+//
+// Only groups that contain at least one profile are emitted.
+
+export function groupProfiles(profiles: ConnectionProfile[]): ProfileGroup[] {
+  // Collect user-assigned folder names in encounter order (stable)
+  const userFolderOrder: string[] = [];
+  const userFolderMap = new Map<string, ConnectionProfile[]>();
+
+  // Collect legacy heuristic groups
+  const legacyMap = new Map<LegacyGroupKey, ConnectionProfile[]>();
+  for (const key of LEGACY_GROUP_ORDER) legacyMap.set(key, []);
+
+  for (const profile of profiles) {
+    const folder = profile.folder?.trim();
+    if (folder) {
+      // User-assigned folder
+      if (!userFolderMap.has(folder)) {
+        userFolderOrder.push(folder);
+        userFolderMap.set(folder, []);
+      }
+      userFolderMap.get(folder)!.push(profile);
+    } else {
+      // Fall back to heuristic
+      const key = deriveGroup(profile);
+      legacyMap.get(key)!.push(profile);
+    }
+  }
+
+  const result: ProfileGroup[] = [];
+
+  // 1. User-assigned folders first
+  for (const folder of userFolderOrder) {
+    const folderProfiles = userFolderMap.get(folder)!;
+    if (folderProfiles.length > 0) {
+      result.push({ key: folder, profiles: folderProfiles });
+    }
+  }
+
+  // 2. Legacy heuristic groups (only non-empty ones, in stable order)
+  for (const key of LEGACY_GROUP_ORDER) {
+    const keyProfiles = legacyMap.get(key)!;
+    if (keyProfiles.length > 0) {
+      result.push({ key, profiles: keyProfiles });
+    }
+  }
+
+  return result;
+}
+
+// ─── Type guard ───────────────────────────────────────────────────────────────
+// Returns true when a group key is one of the five legacy heuristic keys.
+// Used by GroupHeader to decide whether to look up an i18n key or render verbatim.
+
+export function isLegacyGroupKey(key: string): key is LegacyGroupKey {
+  return (LEGACY_GROUP_ORDER as string[]).includes(key);
+}

--- a/src/features/connection/ConnectionDialog.test.tsx
+++ b/src/features/connection/ConnectionDialog.test.tsx
@@ -34,6 +34,11 @@ const STABLE_PROFILES: never[] = [];
 const STABLE_SAVE = vi.fn().mockResolvedValue("profile-id-1");
 const STABLE_STORE_CRED = vi.fn();
 
+// ─── Mutable store override for edit-mode tests ────────────────────────────
+// The store mock below closes over this variable. Tests can swap it to inject
+// a profile list for a specific render; reset to STABLE_PROFILES in beforeEach.
+let currentMockProfiles: import("../../lib/types").ConnectionProfile[] = STABLE_PROFILES;
+
 // ─── Mocks ───────────────────────────────────────────────────────────────────
 
 const mockTauriInvoke = vi.fn();
@@ -58,7 +63,7 @@ vi.mock("../../lib/i18n", () => ({
 
 vi.mock("../../stores/profileStore", () => ({
   useProfileStore: () => ({
-    profiles: STABLE_PROFILES,
+    profiles: currentMockProfiles,
     saveProfile: STABLE_SAVE,
     storeCredential: STABLE_STORE_CRED,
   }),
@@ -188,6 +193,8 @@ describe("ConnectionDialog — SSH key picker dropdown", () => {
 describe("ConnectionDialog — folder field", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset to empty so tests that don't need edit-mode start clean
+    currentMockProfiles = STABLE_PROFILES;
     mockTauriInvoke.mockImplementation((cmd: string) => {
       if (cmd === "list_ssh_keys") return Promise.resolve([]);
       return Promise.resolve(undefined);
@@ -256,23 +263,41 @@ describe("ConnectionDialog — folder field", () => {
   });
 
   it("loads existing folder value when editing a profile", async () => {
-    // The store mock at the top of this file uses STABLE_PROFILES (empty).
-    // Use a separate render with an overridden mock via dynamic spying is complex;
-    // instead rely on the fact that ConnectionDialog reads profiles from the store
-    // and sets profile state from editProfileId. We verify folder renders correctly
-    // by directly rendering with the module-level mock (STABLE_PROFILES is empty
-    // so editProfileId won't find it — this test verifies the input is present
-    // and accepts typed values, which is sufficient for v1 coverage).
-    //
-    // A true edit-load test would require overriding the store mock per-test.
-    // That pattern is covered implicitly by the "typing" test above.
+    // Inject a profile with folder: "production" into the mutable store variable.
+    // The vi.mock closure above reads currentMockProfiles at call time, so the
+    // dialog's useEffect will find this profile when it calls profiles.find().
+    const EDIT_PROFILE_ID = "edit-profile-abc";
+    currentMockProfiles = [
+      {
+        id: EDIT_PROFILE_ID,
+        name: "Prod Server",
+        host: "prod.example.com",
+        port: 22,
+        users: [
+          {
+            id: "user-1",
+            username: "deploy",
+            authMethod: { type: "password" },
+            isDefault: true,
+          },
+        ],
+        folder: "production",
+        startupCommands: [],
+        tunnels: [],
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ];
+
     await act(async () => {
-      render(<ConnectionDialog open onClose={vi.fn()} />);
+      render(
+        <ConnectionDialog open onClose={vi.fn()} editProfileId={EDIT_PROFILE_ID} />,
+      );
     });
 
-    // At minimum, the folder input exists and starts empty for new profiles.
+    // The dialog should have loaded the existing profile's folder value
     const folderInput = document.querySelector<HTMLInputElement>("#profile-folder");
     expect(folderInput).not.toBeNull();
-    expect(folderInput?.value).toBe("");
+    expect(folderInput?.value).toBe("production");
   });
 });

--- a/src/features/connection/ConnectionDialog.test.tsx
+++ b/src/features/connection/ConnectionDialog.test.tsx
@@ -182,3 +182,97 @@ describe("ConnectionDialog — SSH key picker dropdown", () => {
     expect(document.querySelector(".cd-user-row")).not.toBeNull();
   });
 });
+
+// ─── Folder input ─────────────────────────────────────────────────────────────
+
+describe("ConnectionDialog — folder field", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTauriInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "list_ssh_keys") return Promise.resolve([]);
+      return Promise.resolve(undefined);
+    });
+  });
+
+  it("renders a folder input in the Connection section", async () => {
+    await act(async () => {
+      render(<ConnectionDialog open onClose={vi.fn()} />);
+    });
+
+    // The folder input should be present (label key or input id)
+    const folderInput = document.querySelector("#profile-folder");
+    expect(folderInput).not.toBeNull();
+  });
+
+  it("folder value is empty for a new profile", async () => {
+    await act(async () => {
+      render(<ConnectionDialog open onClose={vi.fn()} />);
+    });
+
+    const folderInput = document.querySelector<HTMLInputElement>("#profile-folder");
+    expect(folderInput).not.toBeNull();
+    expect(folderInput?.value).toBe("");
+  });
+
+  it("typing a folder name updates the profile state and is saved", async () => {
+    vi.mocked(STABLE_SAVE).mockResolvedValue("new-profile-id");
+
+    // Re-mock the profile store with a save spy
+    const { unmount } = await act(async () =>
+      render(<ConnectionDialog open onClose={vi.fn()} />),
+    );
+
+    const folderInput = document.querySelector<HTMLInputElement>("#profile-folder");
+    expect(folderInput).not.toBeNull();
+
+    await act(async () => {
+      if (folderInput) fireEvent.change(folderInput, { target: { value: "staging" } });
+    });
+
+    expect(folderInput?.value).toBe("staging");
+
+    // Fill in required fields to pass validation
+    await act(async () => {
+      const nameInput = document.querySelector<HTMLInputElement>("#profile-name");
+      const hostInput = document.querySelector<HTMLInputElement>("#profile-host");
+      const userInput = document.querySelector<HTMLInputElement>(".cd-user-row-input");
+      if (nameInput) fireEvent.change(nameInput, { target: { value: "My Server" } });
+      if (hostInput) fireEvent.change(hostInput, { target: { value: "example.com" } });
+      if (userInput) fireEvent.change(userInput, { target: { value: "admin" } });
+    });
+
+    const saveBtn = screen.getByText("connection.save");
+    await act(async () => {
+      fireEvent.click(saveBtn);
+    });
+
+    await waitFor(() => {
+      expect(STABLE_SAVE).toHaveBeenCalledWith(
+        expect.objectContaining({ folder: "staging" }),
+      );
+    });
+
+    unmount();
+  });
+
+  it("loads existing folder value when editing a profile", async () => {
+    // The store mock at the top of this file uses STABLE_PROFILES (empty).
+    // Use a separate render with an overridden mock via dynamic spying is complex;
+    // instead rely on the fact that ConnectionDialog reads profiles from the store
+    // and sets profile state from editProfileId. We verify folder renders correctly
+    // by directly rendering with the module-level mock (STABLE_PROFILES is empty
+    // so editProfileId won't find it — this test verifies the input is present
+    // and accepts typed values, which is sufficient for v1 coverage).
+    //
+    // A true edit-load test would require overriding the store mock per-test.
+    // That pattern is covered implicitly by the "typing" test above.
+    await act(async () => {
+      render(<ConnectionDialog open onClose={vi.fn()} />);
+    });
+
+    // At minimum, the folder input exists and starts empty for new profiles.
+    const folderInput = document.querySelector<HTMLInputElement>("#profile-folder");
+    expect(folderInput).not.toBeNull();
+    expect(folderInput?.value).toBe("");
+  });
+});

--- a/src/features/connection/ConnectionDialog.tsx
+++ b/src/features/connection/ConnectionDialog.tsx
@@ -363,6 +363,18 @@ export function ConnectionDialog({
             placeholder="My Server"
             autoFocus
           />
+          <Input
+            id="profile-folder"
+            label={t("connection.folder")}
+            value={profile.folder ?? ""}
+            onChange={(e) =>
+              setProfile((p) => ({
+                ...p,
+                folder: e.target.value || undefined,
+              }))
+            }
+            placeholder={t("connection.folderPlaceholder")}
+          />
           <div className="cd-row">
             <Input
               id="profile-host"

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -144,7 +144,6 @@ export const en = {
   "sidebar.group.certification": "CERTIFICATION",
   "sidebar.group.staging": "STAGING",
   "sidebar.group.other": "PROFILES",
-  "sidebar.group.ungrouped": "PROFILES",
   // Connection dialog — folder field
   "connection.folder": "Folder",
   "connection.folderPlaceholder": "e.g. Production",

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -144,6 +144,10 @@ export const en = {
   "sidebar.group.certification": "CERTIFICATION",
   "sidebar.group.staging": "STAGING",
   "sidebar.group.other": "PROFILES",
+  "sidebar.group.ungrouped": "PROFILES",
+  // Connection dialog — folder field
+  "connection.folder": "Folder",
+  "connection.folderPlaceholder": "e.g. Production",
   // Sidebar credentials label
   "sidebar.credentials": "{n} credentials",
   "sidebar.overflow": "More actions",

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -146,7 +146,6 @@ export const es: Record<TranslationKey, string> = {
   "sidebar.group.certification": "CERTIFICACIÓN",
   "sidebar.group.staging": "STAGING",
   "sidebar.group.other": "PERFILES",
-  "sidebar.group.ungrouped": "PERFILES",
   // Connection dialog — folder field
   "connection.folder": "Carpeta",
   "connection.folderPlaceholder": "ej. Producción",

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -146,6 +146,10 @@ export const es: Record<TranslationKey, string> = {
   "sidebar.group.certification": "CERTIFICACIÓN",
   "sidebar.group.staging": "STAGING",
   "sidebar.group.other": "PERFILES",
+  "sidebar.group.ungrouped": "PERFILES",
+  // Connection dialog — folder field
+  "connection.folder": "Carpeta",
+  "connection.folderPlaceholder": "ej. Producción",
   // Sidebar credentials label
   "sidebar.credentials": "{n} credenciales",
   "sidebar.overflow": "Más acciones",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -31,6 +31,10 @@ export interface ConnectionProfile {
   users: UserCredential[];
   startupDirectory?: string;
   startupCommands?: string[];
+  /** User-assigned folder for sidebar grouping. When set the sidebar shows
+   *  this profile under the folder name; when absent, falls back to
+   *  name-heuristic grouping (deriveGroup). */
+  folder?: string;
   tunnels: TunnelConfig[];
   displayOrder?: number;
   createdAt: string; // ISO 8601


### PR DESCRIPTION
## Summary

First non-terminal item of the Voltius clean-room program, and the foundational organization unblocker. Gives `ConnectionProfile` a persisted, optional `folder` so the sidebar groups profiles by **real, user-assigned folders** instead of guessing from the profile name (the old `deriveGroup` name-regex heuristic). Clean-room, local-only (no sync/cloud/team semantics); no Voltius (AGPL) code.

## What changed

- **Rust**: `folder: Option<String>` on `ConnectionProfile` with `#[serde(default, skip_serializing_if = "Option::is_none")]` — the same back-compat pattern as `startup_commands`. **Existing `profiles.json` loads unchanged** (folder = None); a dedicated test deserializes a realistic pre-upgrade profile to prove no data loss.
- **Sidebar**: groups by `folder` when set (rendered verbatim), falling back to the existing `deriveGroup` heuristic for profiles without one — so nothing regresses for current users. Grouping logic extracted to a testable `sidebarGrouping` module.
- **Profile editor**: a folder input (empty → unset, never "").

## Quality

- **Rust** `cargo test` 174, `clippy -D warnings` + `fmt` clean; **frontend** 474 tests + `tsc` clean
- **Strict TDD** (back-compat test written first)
- **Adversarial review GO**: profile data back-compat verified (no profile loss on upgrade), grouping non-regressive, dialog wiring correct, clean-room; the two MINOR findings (a false-confidence edit-load test, a dead i18n key) were fixed before this PR.
- Tags deferred to a future change.

## Note

Folder is not yet carried through profile export/import (imported profiles land unfoldered) — a small follow-up.