### PR TITLE
feat(keygen): in-app SSH key generation

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,7 +25,7 @@ russh-keys = "0.48"
 russh-sftp = "2.0.5"
 
 # Key parsing
-ssh-key = { version = "0.6", features = ["rsa", "ed25519", "ecdsa", "encryption"] }
+ssh-key = { version = "0.6", features = ["rsa", "ed25519", "ecdsa", "encryption", "rand_core"] }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/src-tauri/src/commands/keygen.rs
+++ b/src-tauri/src/commands/keygen.rs
@@ -88,12 +88,15 @@ pub async fn generate_ssh_key(
     let priv_path_c = priv_path.clone();
     let pub_path_c = pub_path.clone();
     let comment_c = comment.clone();
-    let passphrase_ref: Option<String> = passphrase_z.as_deref().map(|s| s.to_owned());
+    // Move `passphrase_z` (Zeroizing<String>) into the blocking closure so the
+    // passphrase never exists as a plain, non-zeroizing String copy on the heap.
+    // We deref to &str only inside the closure, which is on the blocking thread.
+    let passphrase_z_owned = passphrase_z;
 
     // ── Generate the keypair ─────────────────────────────────────────────
     // RSA generation is CPU-bound — always run in a blocking thread.
     let (private_pem, public_openssh) = task::spawn_blocking(move || {
-        let pass_ref = passphrase_ref.as_deref();
+        let pass_ref = passphrase_z_owned.as_deref().map(|s| s.as_str());
         let output = generate_keypair(algorithm, &comment_c, pass_ref)?;
         Ok::<_, AppError>((output.private_pem, output.public_openssh))
     })

--- a/src-tauri/src/commands/keygen.rs
+++ b/src-tauri/src/commands/keygen.rs
@@ -1,0 +1,245 @@
+// commands/keygen.rs — Tauri IPC command for SSH keypair generation
+//
+// Thin adapter between the Tauri async runtime and `ssh::keygen::generate_keypair`.
+// RSA generation is moved to a blocking thread via `tokio::task::spawn_blocking`
+// because RSA key generation is CPU-bound (1–5 s) and would stall the runtime.
+//
+// Security notes:
+// - `passphrase` is immediately wrapped in `Zeroizing` to wipe it on drop.
+// - Private key PEM returned from the pure function is `Zeroizing<String>`.
+// - NEVER log or expose `private_pem` in error messages.
+// - Overwrite protection: both `filename` and `filename.pub` are checked for
+//   existence BEFORE writing. If either exists, an error is returned.
+
+use std::path::PathBuf;
+
+use tokio::task;
+use zeroize::Zeroizing;
+
+use crate::error::AppError;
+use crate::fs_secure;
+use crate::ssh::keygen::{generate_keypair, KeyAlgorithm};
+use crate::ssh::keys::default_ssh_dir;
+
+// ─── Result Type ─────────────────────────────────────────
+
+/// Returned to the frontend after a successful key generation.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GenerateSshKeyResult {
+    /// The one-line authorized_keys public key string.
+    pub public_key_openssh: String,
+    /// Absolute path to the private key file written to disk.
+    pub private_key_path: String,
+    /// Absolute path to the public key file written to disk.
+    pub public_key_path: String,
+}
+
+// ─── Tauri Command ───────────────────────────────────────
+
+/// Generate a new SSH keypair and write it to `~/.ssh/{filename}` (private)
+/// and `~/.ssh/{filename}.pub` (public).
+///
+/// # Arguments
+/// * `algorithm`  – key algorithm (Ed25519, Rsa2048, Rsa4096, EcdsaP256, EcdsaP384)
+/// * `comment`    – comment embedded in the public key (e.g. "user@hostname")
+/// * `passphrase` – optional passphrase for private key encryption
+/// * `filename`   – bare filename only (e.g. "id_ed25519"), no path, no extension
+///
+/// # Errors
+/// Returns `AppError::KeyError` if either target file already exists (refuse-overwrite
+/// protection) or if generation or file I/O fails.
+#[tauri::command]
+pub async fn generate_ssh_key(
+    algorithm: KeyAlgorithm,
+    comment: String,
+    passphrase: Option<String>,
+    filename: String,
+) -> Result<GenerateSshKeyResult, AppError> {
+    // Zeroize the passphrase immediately so it is wiped when this scope ends.
+    let passphrase_z = passphrase.map(Zeroizing::new);
+
+    // Resolve output paths
+    let ssh_dir = default_ssh_dir();
+    let priv_path = ssh_dir.join(&filename);
+    let pub_path = ssh_dir.join(format!("{filename}.pub"));
+
+    // ── Security: refuse to overwrite existing keys ──────────────────────
+    // Check both paths before writing. This must happen BEFORE generation to
+    // avoid generating a key we'll never write.
+    if priv_path.exists() || pub_path.exists() {
+        let existing = if priv_path.exists() {
+            priv_path.display().to_string()
+        } else {
+            pub_path.display().to_string()
+        };
+        return Err(AppError::KeyError(format!(
+            "Key already exists: {existing} — delete it first or choose a different filename"
+        )));
+    }
+
+    // Ensure ~/.ssh/ exists
+    if !ssh_dir.exists() {
+        std::fs::create_dir_all(&ssh_dir)
+            .map_err(|e| AppError::KeyError(format!("Failed to create ~/.ssh/: {e}")))?;
+    }
+
+    // Clone paths for the blocking closure (closures can't borrow across await)
+    let priv_path_c = priv_path.clone();
+    let pub_path_c = pub_path.clone();
+    let comment_c = comment.clone();
+    let passphrase_ref: Option<String> = passphrase_z.as_deref().map(|s| s.to_owned());
+
+    // ── Generate the keypair ─────────────────────────────────────────────
+    // RSA generation is CPU-bound — always run in a blocking thread.
+    let (private_pem, public_openssh) = task::spawn_blocking(move || {
+        let pass_ref = passphrase_ref.as_deref();
+        let output = generate_keypair(algorithm, &comment_c, pass_ref)?;
+        Ok::<_, AppError>((output.private_pem, output.public_openssh))
+    })
+    .await
+    .map_err(|e| AppError::KeyError(format!("Key generation task panicked: {e}")))??;
+
+    // ── Write private key (0600 via fs_secure) ───────────────────────────
+    fs_secure::secure_write(&priv_path_c, private_pem.as_bytes())?;
+
+    // ── Write public key (0644 via std::fs + explicit chmod on Unix) ──────
+    write_public_key(&pub_path_c, public_openssh.as_bytes())?;
+
+    Ok(GenerateSshKeyResult {
+        public_key_openssh: public_openssh,
+        private_key_path: priv_path.display().to_string(),
+        public_key_path: pub_path.display().to_string(),
+    })
+}
+
+// ─── Public Key Write ────────────────────────────────────
+
+/// Write a public key file with 0644 permissions (Unix) or default ACL (Windows/fallback).
+///
+/// `fs_secure::secure_write` uses 0600 which is too strict for the public key,
+/// so we use `std::fs::write` + `set_permissions` (Unix-only, cfg-gated).
+fn write_public_key(path: &PathBuf, content: &[u8]) -> Result<(), AppError> {
+    std::fs::write(path, content)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o644);
+        std::fs::set_permissions(path, perms)?;
+    }
+
+    Ok(())
+}
+
+// ─── Tests ───────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Helper: redirect `default_ssh_dir()` by temporarily manipulating state
+    /// isn't possible without full Tauri context, so we test the sub-functions
+    /// and path logic directly.
+
+    #[test]
+    fn write_public_key_creates_file_with_correct_perms() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("id_test.pub");
+        write_public_key(&path, b"ssh-ed25519 AAAA test@host").unwrap();
+
+        assert!(path.exists(), "Public key file must be created");
+
+        let contents = fs::read_to_string(&path).unwrap();
+        assert_eq!(contents, "ssh-ed25519 AAAA test@host");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let meta = fs::metadata(&path).unwrap();
+            let mode = meta.permissions().mode() & 0o777;
+            assert_eq!(mode, 0o644, "Public key must be 0644, got {:?}", mode);
+        }
+    }
+
+    #[test]
+    fn refuse_overwrite_when_private_key_exists() {
+        // We test the logic directly since we can't call the async Tauri command
+        // in a unit test without a Tauri context.
+        // The logic is: if priv_path.exists() || pub_path.exists() → error.
+        let tmp = TempDir::new().unwrap();
+        let priv_path = tmp.path().join("id_ed25519");
+        let pub_path = tmp.path().join("id_ed25519.pub");
+
+        // Pre-create private key
+        fs::write(&priv_path, "fake private key").unwrap();
+
+        let private_exists = priv_path.exists();
+        let public_exists = pub_path.exists();
+
+        assert!(private_exists || public_exists);
+
+        // Confirm the guard condition
+        let should_refuse = priv_path.exists() || pub_path.exists();
+        assert!(should_refuse, "Must refuse when private key exists");
+    }
+
+    #[test]
+    fn refuse_overwrite_when_public_key_exists() {
+        let tmp = TempDir::new().unwrap();
+        let priv_path = tmp.path().join("id_ed25519");
+        let pub_path = tmp.path().join("id_ed25519.pub");
+
+        // Pre-create only the public key
+        fs::write(&pub_path, "fake public key").unwrap();
+
+        let should_refuse = priv_path.exists() || pub_path.exists();
+        assert!(should_refuse, "Must refuse when public key exists");
+    }
+
+    /// Async integration test: generate + write + verify perms end-to-end.
+    /// Uses a real temp directory but bypasses the Tauri command layer.
+    #[tokio::test]
+    async fn generate_and_write_ed25519_files() {
+        let tmp = TempDir::new().unwrap();
+        let priv_path = tmp.path().join("id_ed25519_test");
+        let pub_path = tmp.path().join("id_ed25519_test.pub");
+
+        // Generate via pure function
+        let output = generate_keypair(KeyAlgorithm::Ed25519, "test@machine", None)
+            .expect("Generation must succeed");
+
+        // Write private key (secure_write applies 0600)
+        fs_secure::secure_write(&priv_path, output.private_pem.as_bytes())
+            .expect("Private key write must succeed");
+
+        // Write public key
+        write_public_key(&pub_path, output.public_openssh.as_bytes())
+            .expect("Public key write must succeed");
+
+        assert!(priv_path.exists(), "Private key must exist");
+        assert!(pub_path.exists(), "Public key must exist");
+
+        // Verify private key is parseable
+        let key_data = Zeroizing::new(fs::read_to_string(&priv_path).unwrap());
+        let parsed = ssh_key::PrivateKey::from_openssh(key_data.as_bytes())
+            .expect("Written private key must be parseable");
+        assert!(matches!(parsed.algorithm(), ssh_key::Algorithm::Ed25519));
+
+        // Verify public key content
+        let pub_content = fs::read_to_string(&pub_path).unwrap();
+        assert!(pub_content.starts_with("ssh-ed25519 "));
+        assert!(pub_content.contains("test@machine"));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let priv_mode = fs::metadata(&priv_path).unwrap().permissions().mode() & 0o777;
+            let pub_mode = fs::metadata(&pub_path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(priv_mode, 0o600, "Private key must be 0600");
+            assert_eq!(pub_mode, 0o644, "Public key must be 0644");
+        }
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,6 +4,7 @@
 // registered in main.rs via generate_handler![].
 
 pub mod connection;
+pub mod keygen;
 pub mod profile;
 pub mod sftp;
 pub mod terminal;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -182,6 +182,8 @@ pub fn run() {
             commands::tunnel::stop_tunnel,
             commands::tunnel::remove_tunnel,
             commands::tunnel::list_tunnels,
+            // SSH keygen
+            commands::keygen::generate_ssh_key,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/ssh/keygen.rs
+++ b/src-tauri/src/ssh/keygen.rs
@@ -5,7 +5,10 @@
 // Private key is always OpenSSH format; passphrase encryption via AES-256-CTR + bcrypt-pbkdf.
 
 use rand::rngs::OsRng;
-use ssh_key::{Algorithm, EcdsaCurve, LineEnding, PrivateKey};
+use ssh_key::{
+    private::{KeypairData, RsaKeypair},
+    Algorithm, EcdsaCurve, LineEnding, PrivateKey,
+};
 use zeroize::Zeroizing;
 
 use crate::error::AppError;
@@ -51,21 +54,41 @@ pub fn generate_keypair(
     comment: &str,
     passphrase: Option<&str>,
 ) -> Result<KeypairOutput, AppError> {
-    let ssh_algorithm = match algorithm {
-        KeyAlgorithm::Ed25519 => Algorithm::Ed25519,
-        KeyAlgorithm::Rsa2048 | KeyAlgorithm::Rsa4096 => Algorithm::Rsa { hash: None },
-        KeyAlgorithm::EcdsaP256 => Algorithm::Ecdsa {
-            curve: EcdsaCurve::NistP256,
-        },
-        KeyAlgorithm::EcdsaP384 => Algorithm::Ecdsa {
-            curve: EcdsaCurve::NistP384,
-        },
+    // Generate the raw keypair.
+    //
+    // RSA requires an explicit bit-size at construction time.
+    // PrivateKey::random() uses DEFAULT_RSA_KEY_SIZE (4096) for *all* RSA
+    // variants, so we must use RsaKeypair::random() directly and wrap it.
+    // Ed25519 / ECDSA have no user-visible size parameter and use PrivateKey::random().
+    let mut key: PrivateKey = match algorithm {
+        KeyAlgorithm::Rsa2048 | KeyAlgorithm::Rsa4096 => {
+            let bits = match algorithm {
+                KeyAlgorithm::Rsa2048 => 2048_usize,
+                KeyAlgorithm::Rsa4096 => 4096_usize,
+                _ => unreachable!(),
+            };
+            let kp = RsaKeypair::random(&mut OsRng, bits)
+                .map_err(|e| AppError::KeyError(format!("RSA generation failed: {e}")))?;
+            PrivateKey::new(KeypairData::from(kp), "")
+                .map_err(|e| AppError::KeyError(format!("RSA key construction failed: {e}")))?
+        }
+        KeyAlgorithm::Ed25519 => PrivateKey::random(&mut OsRng, Algorithm::Ed25519)
+            .map_err(|e| AppError::KeyError(format!("Key generation failed: {e}")))?,
+        KeyAlgorithm::EcdsaP256 => PrivateKey::random(
+            &mut OsRng,
+            Algorithm::Ecdsa {
+                curve: EcdsaCurve::NistP256,
+            },
+        )
+        .map_err(|e| AppError::KeyError(format!("Key generation failed: {e}")))?,
+        KeyAlgorithm::EcdsaP384 => PrivateKey::random(
+            &mut OsRng,
+            Algorithm::Ecdsa {
+                curve: EcdsaCurve::NistP384,
+            },
+        )
+        .map_err(|e| AppError::KeyError(format!("Key generation failed: {e}")))?,
     };
-
-    // Generate the raw keypair
-    let mut key = PrivateKey::random(&mut OsRng, ssh_algorithm).map_err(|e| {
-        AppError::KeyError(format!("Key generation failed: {e}"))
-    })?;
 
     // Set the comment (modifies in-place via public_key_mut)
     key.set_comment(comment);
@@ -80,9 +103,8 @@ pub fn generate_keypair(
     let private_pem: Zeroizing<String> = if let Some(pass) = passphrase {
         if pass.is_empty() {
             // Treat empty passphrase as "no passphrase"
-            key.to_openssh(LineEnding::LF).map_err(|e| {
-                AppError::KeyError(format!("Failed to encode private key: {e}"))
-            })?
+            key.to_openssh(LineEnding::LF)
+                .map_err(|e| AppError::KeyError(format!("Failed to encode private key: {e}")))?
         } else {
             let encrypted = key
                 .encrypt(&mut OsRng, pass)
@@ -92,9 +114,8 @@ pub fn generate_keypair(
                 .map_err(|e| AppError::KeyError(format!("Failed to encode encrypted key: {e}")))?
         }
     } else {
-        key.to_openssh(LineEnding::LF).map_err(|e| {
-            AppError::KeyError(format!("Failed to encode private key: {e}"))
-        })?
+        key.to_openssh(LineEnding::LF)
+            .map_err(|e| AppError::KeyError(format!("Failed to encode private key: {e}")))?
     };
 
     Ok(KeypairOutput {
@@ -124,7 +145,10 @@ mod tests {
         assert!(!reparsed.is_encrypted());
     }
 
-    /// RSA 2048 roundtrip: generate → encode → re-parse, verify bit length
+    /// RSA 2048: generated key must have a 2048-bit modulus (not 4096).
+    ///
+    /// This test is the RED guard for CRITICAL-1. It MUST fail if both Rsa2048
+    /// and Rsa4096 silently produce 4096-bit keys.
     #[test]
     fn rsa_2048_key_has_correct_bits() {
         let output = generate_keypair(KeyAlgorithm::Rsa2048, "rsa@host", None)
@@ -133,10 +157,59 @@ mod tests {
         let reparsed = SshPrivateKey::from_openssh(output.private_pem.as_bytes())
             .expect("RSA private PEM must be parseable");
 
-        match reparsed.algorithm() {
-            Algorithm::Rsa { .. } => {}
-            other => panic!("Expected RSA algorithm, got {:?}", other),
-        }
+        let rsa_pub = match reparsed.key_data() {
+            ssh_key::private::KeypairData::Rsa(kp) => &kp.public,
+            other => panic!("Expected RSA keypair, got {:?}", other),
+        };
+
+        // The modulus `n` is stored as a big-endian mpint. Strip the leading
+        // sign byte (0x00) that OpenSSH prepends when the MSB is set, then
+        // count the significant bits: byte_count * 8, adjusted for leading
+        // zero bits in the first data byte.
+        let n_bytes = rsa_pub
+            .n
+            .as_positive_bytes()
+            .expect("RSA modulus must be a positive integer");
+        let bit_len = (n_bytes.len() * 8)
+            - n_bytes
+                .first()
+                .map(|b| b.leading_zeros() as usize)
+                .unwrap_or(0);
+
+        assert_eq!(
+            bit_len, 2048,
+            "RSA 2048 key must have a 2048-bit modulus, got {bit_len} bits"
+        );
+    }
+
+    /// RSA 4096: generated key must have a 4096-bit modulus.
+    #[test]
+    fn rsa_4096_key_has_correct_bits() {
+        let output = generate_keypair(KeyAlgorithm::Rsa4096, "rsa4096@host", None)
+            .expect("RSA 4096 generation must not fail");
+
+        let reparsed = SshPrivateKey::from_openssh(output.private_pem.as_bytes())
+            .expect("RSA 4096 private PEM must be parseable");
+
+        let rsa_pub = match reparsed.key_data() {
+            ssh_key::private::KeypairData::Rsa(kp) => &kp.public,
+            other => panic!("Expected RSA keypair, got {:?}", other),
+        };
+
+        let n_bytes = rsa_pub
+            .n
+            .as_positive_bytes()
+            .expect("RSA modulus must be a positive integer");
+        let bit_len = (n_bytes.len() * 8)
+            - n_bytes
+                .first()
+                .map(|b| b.leading_zeros() as usize)
+                .unwrap_or(0);
+
+        assert_eq!(
+            bit_len, 4096,
+            "RSA 4096 key must have a 4096-bit modulus, got {bit_len} bits"
+        );
     }
 
     /// Passphrase: encrypted key decrypts with correct passphrase, fails with wrong one
@@ -204,6 +277,9 @@ mod tests {
         let reparsed = SshPrivateKey::from_openssh(output.private_pem.as_bytes())
             .expect("PEM must be parseable");
 
-        assert!(!reparsed.is_encrypted(), "Empty passphrase must not encrypt");
+        assert!(
+            !reparsed.is_encrypted(),
+            "Empty passphrase must not encrypt"
+        );
     }
 }

--- a/src-tauri/src/ssh/keygen.rs
+++ b/src-tauri/src/ssh/keygen.rs
@@ -1,0 +1,209 @@
+// ssh/keygen.rs — In-app SSH keypair generation
+//
+// Pure generation logic with no Tauri dependencies — fully unit-testable.
+// Supports Ed25519 (default), RSA 2048/4096, ECDSA P-256/P-384.
+// Private key is always OpenSSH format; passphrase encryption via AES-256-CTR + bcrypt-pbkdf.
+
+use rand::rngs::OsRng;
+use ssh_key::{Algorithm, EcdsaCurve, LineEnding, PrivateKey};
+use zeroize::Zeroizing;
+
+use crate::error::AppError;
+
+// ─── Algorithm Enum ─────────────────────────────────────
+
+/// Supported key algorithms for generation.
+/// Mirrors the frontend `KeyAlgorithm` enum (serde camelCase).
+#[derive(Debug, Clone, Copy, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum KeyAlgorithm {
+    Ed25519,
+    Rsa2048,
+    Rsa4096,
+    EcdsaP256,
+    EcdsaP384,
+}
+
+// ─── Generation Result ───────────────────────────────────
+
+/// Output of `generate_keypair`.
+pub struct KeypairOutput {
+    /// OpenSSH-encoded private key (PEM), zeroized on drop.
+    pub private_pem: Zeroizing<String>,
+    /// One-line authorized_keys format public key (includes comment if set).
+    pub public_openssh: String,
+}
+
+// ─── Core Generation ─────────────────────────────────────
+
+/// Generate a keypair synchronously.
+///
+/// **IMPORTANT**: For RSA algorithms this is CPU-bound (1–5 s). Callers MUST
+/// wrap this function in `tokio::task::spawn_blocking` to avoid stalling the
+/// async runtime.
+///
+/// # Arguments
+/// * `algorithm` – key algorithm and size
+/// * `comment`   – user-visible comment embedded in the key (e.g. "user@host")
+/// * `passphrase` – optional passphrase; `None` produces an unencrypted key
+pub fn generate_keypair(
+    algorithm: KeyAlgorithm,
+    comment: &str,
+    passphrase: Option<&str>,
+) -> Result<KeypairOutput, AppError> {
+    let ssh_algorithm = match algorithm {
+        KeyAlgorithm::Ed25519 => Algorithm::Ed25519,
+        KeyAlgorithm::Rsa2048 | KeyAlgorithm::Rsa4096 => Algorithm::Rsa { hash: None },
+        KeyAlgorithm::EcdsaP256 => Algorithm::Ecdsa {
+            curve: EcdsaCurve::NistP256,
+        },
+        KeyAlgorithm::EcdsaP384 => Algorithm::Ecdsa {
+            curve: EcdsaCurve::NistP384,
+        },
+    };
+
+    // Generate the raw keypair
+    let mut key = PrivateKey::random(&mut OsRng, ssh_algorithm).map_err(|e| {
+        AppError::KeyError(format!("Key generation failed: {e}"))
+    })?;
+
+    // Set the comment (modifies in-place via public_key_mut)
+    key.set_comment(comment);
+
+    // Build public key line BEFORE possible encryption consumes `key`
+    let public_key = key.public_key().clone();
+    let public_openssh = public_key
+        .to_openssh()
+        .map_err(|e| AppError::KeyError(format!("Failed to encode public key: {e}")))?;
+
+    // Optionally encrypt the private key
+    let private_pem: Zeroizing<String> = if let Some(pass) = passphrase {
+        if pass.is_empty() {
+            // Treat empty passphrase as "no passphrase"
+            key.to_openssh(LineEnding::LF).map_err(|e| {
+                AppError::KeyError(format!("Failed to encode private key: {e}"))
+            })?
+        } else {
+            let encrypted = key
+                .encrypt(&mut OsRng, pass)
+                .map_err(|e| AppError::KeyError(format!("Failed to encrypt private key: {e}")))?;
+            encrypted
+                .to_openssh(LineEnding::LF)
+                .map_err(|e| AppError::KeyError(format!("Failed to encode encrypted key: {e}")))?
+        }
+    } else {
+        key.to_openssh(LineEnding::LF).map_err(|e| {
+            AppError::KeyError(format!("Failed to encode private key: {e}"))
+        })?
+    };
+
+    Ok(KeypairOutput {
+        private_pem,
+        public_openssh,
+    })
+}
+
+// ─── Tests ───────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ssh_key::PrivateKey as SshPrivateKey;
+
+    /// Ed25519 roundtrip: generate → encode → re-parse
+    #[test]
+    fn generate_ed25519_key_roundtrip() {
+        let output = generate_keypair(KeyAlgorithm::Ed25519, "test@host", None)
+            .expect("Ed25519 generation must not fail");
+
+        // Private key must round-trip through OpenSSH parser
+        let reparsed = SshPrivateKey::from_openssh(output.private_pem.as_bytes())
+            .expect("Generated private PEM must be parseable");
+
+        assert!(matches!(reparsed.algorithm(), Algorithm::Ed25519));
+        assert!(!reparsed.is_encrypted());
+    }
+
+    /// RSA 2048 roundtrip: generate → encode → re-parse, verify bit length
+    #[test]
+    fn rsa_2048_key_has_correct_bits() {
+        let output = generate_keypair(KeyAlgorithm::Rsa2048, "rsa@host", None)
+            .expect("RSA 2048 generation must not fail");
+
+        let reparsed = SshPrivateKey::from_openssh(output.private_pem.as_bytes())
+            .expect("RSA private PEM must be parseable");
+
+        match reparsed.algorithm() {
+            Algorithm::Rsa { .. } => {}
+            other => panic!("Expected RSA algorithm, got {:?}", other),
+        }
+    }
+
+    /// Passphrase: encrypted key decrypts with correct passphrase, fails with wrong one
+    #[test]
+    fn passphrase_encrypted_private_decrypts_and_fails_without() {
+        let output = generate_keypair(KeyAlgorithm::Ed25519, "enc@host", Some("s3cr3t"))
+            .expect("Encrypted key generation must not fail");
+
+        // Must be parseable as encrypted OpenSSH
+        let encrypted_key = SshPrivateKey::from_openssh(output.private_pem.as_bytes())
+            .expect("Encrypted PEM must be parseable");
+
+        assert!(encrypted_key.is_encrypted(), "Key must be encrypted");
+
+        // Correct passphrase succeeds
+        encrypted_key
+            .decrypt("s3cr3t")
+            .expect("Correct passphrase must decrypt");
+
+        // Re-parse and try wrong passphrase
+        let encrypted_key2 = SshPrivateKey::from_openssh(output.private_pem.as_bytes()).unwrap();
+        let bad_result = encrypted_key2.decrypt("wr0ng");
+        assert!(
+            bad_result.is_err(),
+            "Wrong passphrase must not decrypt successfully"
+        );
+    }
+
+    /// Comment is embedded in the public key output
+    #[test]
+    fn public_key_comment_is_set() {
+        let comment = "alice@wonderland";
+        let output = generate_keypair(KeyAlgorithm::Ed25519, comment, None)
+            .expect("Generation must not fail");
+
+        assert!(
+            output.public_openssh.contains(comment),
+            "Public key authorized_keys line must contain the comment"
+        );
+    }
+
+    /// ECDSA P-256 roundtrip
+    #[test]
+    fn ecdsa_p256_roundtrip() {
+        let output = generate_keypair(KeyAlgorithm::EcdsaP256, "ecdsa@host", None)
+            .expect("ECDSA P-256 generation must not fail");
+
+        let reparsed = SshPrivateKey::from_openssh(output.private_pem.as_bytes())
+            .expect("ECDSA P-256 PEM must be parseable");
+
+        match reparsed.algorithm() {
+            Algorithm::Ecdsa {
+                curve: EcdsaCurve::NistP256,
+            } => {}
+            other => panic!("Expected ECDSA P-256, got {:?}", other),
+        }
+    }
+
+    /// Empty passphrase is treated as no passphrase (unencrypted key)
+    #[test]
+    fn empty_passphrase_produces_unencrypted_key() {
+        let output = generate_keypair(KeyAlgorithm::Ed25519, "user@host", Some(""))
+            .expect("Generation must not fail");
+
+        let reparsed = SshPrivateKey::from_openssh(output.private_pem.as_bytes())
+            .expect("PEM must be parseable");
+
+        assert!(!reparsed.is_encrypted(), "Empty passphrase must not encrypt");
+    }
+}

--- a/src-tauri/src/ssh/mod.rs
+++ b/src-tauri/src/ssh/mod.rs
@@ -4,6 +4,7 @@
 // are encapsulated in this module and its submodules.
 
 pub mod handler;
+pub mod keygen;
 pub mod keys;
 pub mod known_hosts;
 pub mod session;

--- a/src/features/connection/ConnectionDialog.test.tsx
+++ b/src/features/connection/ConnectionDialog.test.tsx
@@ -301,3 +301,27 @@ describe("ConnectionDialog — folder field", () => {
     expect(folderInput?.value).toBe("production");
   });
 });
+
+// ─── Keygen button ────────────────────────────────────────────────────────────
+
+describe("ConnectionDialog — Generate new key button", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    currentMockProfiles = STABLE_PROFILES;
+    mockTauriInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "list_ssh_keys") return Promise.resolve(MOCK_KEYS);
+      return Promise.resolve(undefined);
+    });
+  });
+
+  it("shows a 'Generate new key' button when publicKey auth is selected", async () => {
+    await renderDialogAndWaitForKeys();
+    await switchToPublicKeyAuth();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTitle("connection.keygen.hint"),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/features/connection/ConnectionDialog.tsx
+++ b/src/features/connection/ConnectionDialog.tsx
@@ -14,6 +14,7 @@ import { useI18n } from "../../lib/i18n";
 import type { ConnectionProfile, AuthMethodConfig, UserCredential, TestConnectionResult, KeyInfo } from "../../lib/types";
 import { classifyTestResult, type TestTone } from "./testResult";
 import { normalizeStartupCommands } from "./startupCommands";
+import { KeygenDialog } from "./KeygenDialog";
 
 interface ConnectionDialogProps {
   open: boolean;
@@ -126,6 +127,8 @@ export function ConnectionDialog({
   const [testResults, setTestResults] = useState<Record<string, { tone: TestTone; message: string }>>({});
   // Discovered SSH keys for the key picker dropdown
   const [availableKeys, setAvailableKeys] = useState<KeyInfo[]>([]);
+  // Keygen dialog state: which user we're generating a key for (null = closed)
+  const [keygenForUserId, setKeygenForUserId] = useState<string | null>(null);
 
   useEffect(() => {
     if (open) {
@@ -506,6 +509,18 @@ export function ConnectionDialog({
 
                       return (
                         <div className="cd-key-picker">
+                          <button
+                            type="button"
+                            className="cd-keygen-hint-btn"
+                            title={t("connection.keygen.hint")}
+                            onClick={() => setKeygenForUserId(user.id)}
+                          >
+                            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                              <line x1="12" y1="5" x2="12" y2="19" />
+                              <line x1="5" y1="12" x2="19" y2="12" />
+                            </svg>
+                            {t("connection.keygen.hint")}
+                          </button>
                           <select
                             data-testid="key-picker-select"
                             className={`cd-user-row-input cd-key-picker-select ${errors[`user-${user.id}-keyPath`] ? "cd-user-row-input-error" : ""}`}
@@ -666,6 +681,31 @@ export function ConnectionDialog({
           </Button>
         </div>
       </div>
+
+      {/* ─── Keygen Dialog (nested, opens when user clicks "Generate new key") ─── */}
+      <KeygenDialog
+        open={keygenForUserId !== null}
+        onClose={() => setKeygenForUserId(null)}
+        onKeyGenerated={(privateKeyPath) => {
+          if (keygenForUserId === null) return;
+          // Set the generated private key as this user's identity
+          const user = profile.users.find((u) => u.id === keygenForUserId);
+          if (user && user.authMethod.type === "publicKey") {
+            updateUser(keygenForUserId, {
+              authMethod: {
+                type: "publicKey",
+                privateKeyPath,
+                passphraseInKeychain: user.authMethod.passphraseInKeychain,
+              },
+            });
+          }
+          setKeygenForUserId(null);
+          // Refresh the key list so the new key appears in the dropdown
+          void tauriInvoke<KeyInfo[]>("list_ssh_keys")
+            .then(setAvailableKeys)
+            .catch(() => {});
+        }}
+      />
     </Dialog>
   );
 }

--- a/src/features/connection/KeygenDialog.test.tsx
+++ b/src/features/connection/KeygenDialog.test.tsx
@@ -1,0 +1,250 @@
+// KeygenDialog.test.tsx — TDD tests for in-app SSH key generation dialog
+//
+// Written BEFORE the component (RED phase).
+
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// jsdom does not implement native <dialog> modal API
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal = function showModal() {
+    this.open = true;
+  };
+  HTMLDialogElement.prototype.close = function close() {
+    this.open = false;
+  };
+});
+
+// ─── Mocks ────────────────────────────────────────────────
+
+const mockTauriInvoke = vi.fn();
+
+vi.mock("../../lib/tauri", () => ({
+  tauriInvoke: (...args: unknown[]) => mockTauriInvoke(...args),
+  AppError: class AppError extends Error {
+    constructor(_cmd: string, msg: string) {
+      super(msg);
+    }
+  },
+}));
+
+vi.mock("../../lib/i18n", () => ({
+  useI18n: () => ({
+    t: (k: string) => {
+      const keys: Record<string, string> = {
+        "keygen.title": "Generate SSH Key",
+        "keygen.algorithm": "Algorithm",
+        "keygen.comment": "Comment",
+        "keygen.commentPlaceholder": "user@hostname",
+        "keygen.passphrase": "Passphrase",
+        "keygen.passphrasePlaceholder": "Optional — leave blank for no passphrase",
+        "keygen.filename": "Filename",
+        "keygen.filenamePlaceholder": "e.g. id_ed25519",
+        "keygen.generate": "Generate",
+        "keygen.generating": "Generating…",
+        "keygen.cancel": "Cancel",
+        "keygen.publicKeyLabel":
+          "Public key — add this to your server's ~/.ssh/authorized_keys",
+        "keygen.copyPublicKey": "Copy",
+        "keygen.copied": "Copied!",
+        "keygen.useThisKey": "Use this key",
+        "keygen.done": "Done",
+        "keygen.errorAlreadyExists": "Key already exists",
+        "keygen.hint": "Generate new key",
+      };
+      return keys[k] ?? k;
+    },
+  }),
+}));
+
+vi.mock("../../components/ui/Dialog", () => ({
+  Dialog: ({
+    open,
+    children,
+  }: {
+    open: boolean;
+    children: React.ReactNode;
+    onClose: () => void;
+    title: string;
+  }) => (open ? <div role="dialog">{children}</div> : null),
+}));
+
+import { KeygenDialog } from "./KeygenDialog";
+
+// ─── Tests ────────────────────────────────────────────────
+
+describe("KeygenDialog", () => {
+  it("renders algorithm options with Ed25519 selected by default", () => {
+    render(
+      <KeygenDialog
+        open
+        onClose={vi.fn()}
+        onKeyGenerated={vi.fn()}
+      />,
+    );
+
+    const select = screen.getByLabelText("Algorithm") as HTMLSelectElement;
+    expect(select).toBeInTheDocument();
+    expect(select.value).toBe("ed25519");
+
+    // All algorithm options must be present
+    const options = Array.from(select.options).map((o) => o.value);
+    expect(options).toContain("ed25519");
+    expect(options).toContain("rsa2048");
+    expect(options).toContain("rsa4096");
+    expect(options).toContain("ecdsaP256");
+    expect(options).toContain("ecdsaP384");
+  });
+
+  it("calls generate_ssh_key with correct params when Generate is clicked", async () => {
+    const user = userEvent.setup();
+    const mockResult = {
+      publicKeyOpenssh: "ssh-ed25519 AAAA test@host",
+      privateKeyPath: "/home/user/.ssh/id_ed25519_test",
+      publicKeyPath: "/home/user/.ssh/id_ed25519_test.pub",
+    };
+    mockTauriInvoke.mockResolvedValueOnce(mockResult);
+
+    render(
+      <KeygenDialog
+        open
+        onClose={vi.fn()}
+        onKeyGenerated={vi.fn()}
+      />,
+    );
+
+    // Fill filename (required)
+    const filenameInput = screen.getByLabelText("Filename");
+    await user.clear(filenameInput);
+    await user.type(filenameInput, "id_ed25519_test");
+
+    await user.click(screen.getByRole("button", { name: "Generate" }));
+
+    await waitFor(() => {
+      expect(mockTauriInvoke).toHaveBeenCalledWith("generate_ssh_key", {
+        algorithm: "ed25519",
+        comment: expect.any(String),
+        passphrase: null,
+        filename: "id_ed25519_test",
+      });
+    });
+  });
+
+  it("shows the public key in a code block after successful generation", async () => {
+    const user = userEvent.setup();
+    const mockResult = {
+      publicKeyOpenssh: "ssh-ed25519 AAAA test@host",
+      privateKeyPath: "/home/user/.ssh/id_ed25519",
+      publicKeyPath: "/home/user/.ssh/id_ed25519.pub",
+    };
+    mockTauriInvoke.mockResolvedValueOnce(mockResult);
+
+    render(
+      <KeygenDialog
+        open
+        onClose={vi.fn()}
+        onKeyGenerated={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Generate" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("ssh-ed25519 AAAA test@host")).toBeInTheDocument();
+    });
+  });
+
+  it("shows a Copy button after successful generation", async () => {
+    const user = userEvent.setup();
+    mockTauriInvoke.mockResolvedValueOnce({
+      publicKeyOpenssh: "ssh-ed25519 AAAA copy@test",
+      privateKeyPath: "/home/user/.ssh/id_test",
+      publicKeyPath: "/home/user/.ssh/id_test.pub",
+    });
+
+    render(
+      <KeygenDialog
+        open
+        onClose={vi.fn()}
+        onKeyGenerated={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Generate" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Copy" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("calls onKeyGenerated with the private key path when 'Use this key' is clicked", async () => {
+    const user = userEvent.setup();
+    const onKeyGenerated = vi.fn();
+    const mockResult = {
+      publicKeyOpenssh: "ssh-ed25519 AAAA use@test",
+      privateKeyPath: "/home/user/.ssh/id_use_test",
+      publicKeyPath: "/home/user/.ssh/id_use_test.pub",
+    };
+    mockTauriInvoke.mockResolvedValueOnce(mockResult);
+
+    render(
+      <KeygenDialog
+        open
+        onClose={vi.fn()}
+        onKeyGenerated={onKeyGenerated}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Generate" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Use this key" })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Use this key" }));
+    expect(onKeyGenerated).toHaveBeenCalledWith("/home/user/.ssh/id_use_test");
+  });
+
+  it("shows an error message when generation fails", async () => {
+    const user = userEvent.setup();
+    const { AppError } = await import("../../lib/tauri");
+    mockTauriInvoke.mockRejectedValueOnce(
+      new AppError("generate_ssh_key", "Key already exists: /home/user/.ssh/id_ed25519"),
+    );
+
+    render(
+      <KeygenDialog
+        open
+        onClose={vi.fn()}
+        onKeyGenerated={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Generate" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Key already exists/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("calls onClose when Cancel button is clicked", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(
+      <KeygenDialog
+        open
+        onClose={onClose}
+        onKeyGenerated={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/src/features/connection/KeygenDialog.tsx
+++ b/src/features/connection/KeygenDialog.tsx
@@ -1,0 +1,275 @@
+// features/connection/KeygenDialog.tsx — In-app SSH keypair generation dialog
+//
+// Lets users generate Ed25519 (default), RSA 2048/4096, or ECDSA P-256/P-384
+// keypairs directly inside NexTerm.
+//
+// v1 scope:
+// - Generate keypair + write to ~/.ssh/{filename} / {filename}.pub
+// - Show public key in a code block with a Copy button
+// - "Use this key" callback sets the generated private key as the connection identity
+// - DEFER: authorized_keys push (show pubkey + instruct user to ssh-copy-id)
+
+import { useState } from "react";
+import { Dialog } from "../../components/ui/Dialog";
+import { useI18n } from "../../lib/i18n";
+import { tauriInvoke } from "../../lib/tauri";
+import type { GenerateSshKeyResult } from "../../lib/types";
+
+// ─── Algorithm Options ────────────────────────────────────
+
+const ALGORITHM_OPTIONS = [
+  { value: "ed25519", label: "Ed25519 (recommended)" },
+  { value: "rsa2048", label: "RSA 2048" },
+  { value: "rsa4096", label: "RSA 4096" },
+  { value: "ecdsaP256", label: "ECDSA P-256" },
+  { value: "ecdsaP384", label: "ECDSA P-384" },
+] as const;
+
+type AlgorithmValue = (typeof ALGORITHM_OPTIONS)[number]["value"];
+
+// ─── Props ────────────────────────────────────────────────
+
+interface KeygenDialogProps {
+  open: boolean;
+  onClose: () => void;
+  /** Called with the private key path when the user clicks "Use this key" */
+  onKeyGenerated: (privateKeyPath: string) => void;
+}
+
+// ─── Component ────────────────────────────────────────────
+
+export function KeygenDialog({ open, onClose, onKeyGenerated }: KeygenDialogProps) {
+  const { t } = useI18n();
+
+  // Form state
+  const [algorithm, setAlgorithm] = useState<AlgorithmValue>("ed25519");
+  const [comment, setComment] = useState("");
+  const [passphrase, setPassphrase] = useState("");
+  const [filename, setFilename] = useState("id_ed25519");
+
+  // Generation state
+  const [generating, setGenerating] = useState(false);
+  const [result, setResult] = useState<GenerateSshKeyResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  // Sync default filename when algorithm changes
+  function handleAlgorithmChange(value: AlgorithmValue) {
+    setAlgorithm(value);
+    // Only auto-update filename if still at a default value
+    const defaults: Record<AlgorithmValue, string> = {
+      ed25519: "id_ed25519",
+      rsa2048: "id_rsa",
+      rsa4096: "id_rsa",
+      ecdsaP256: "id_ecdsa",
+      ecdsaP384: "id_ecdsa",
+    };
+    const isDefaultFilename = Object.values(defaults).includes(filename);
+    if (isDefaultFilename) {
+      setFilename(defaults[value]);
+    }
+  }
+
+  async function handleGenerate() {
+    if (!filename.trim()) return;
+
+    setGenerating(true);
+    setError(null);
+    setResult(null);
+
+    try {
+      const res = await tauriInvoke<GenerateSshKeyResult>("generate_ssh_key", {
+        algorithm,
+        comment: comment.trim() || "",
+        passphrase: passphrase.trim() || null,
+        filename: filename.trim(),
+      });
+      setResult(res);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setGenerating(false);
+    }
+  }
+
+  async function handleCopy() {
+    if (!result) return;
+    try {
+      await navigator.clipboard.writeText(result.publicKeyOpenssh);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard write failed — ignore silently
+    }
+  }
+
+  function handleUseKey() {
+    if (!result) return;
+    onKeyGenerated(result.privateKeyPath);
+    handleClose();
+  }
+
+  function handleClose() {
+    // Reset state on close so re-opening starts fresh
+    setAlgorithm("ed25519");
+    setComment("");
+    setPassphrase("");
+    setFilename("id_ed25519");
+    setGenerating(false);
+    setResult(null);
+    setError(null);
+    setCopied(false);
+    onClose();
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      title=""
+      width="520px"
+      aria-labelledby="keygen-dialog-title"
+    >
+      <div className="cd-header">
+        <div className="cd-header-text">
+          <h3 id="keygen-dialog-title" className="cd-title">
+            {t("keygen.title")}
+          </h3>
+        </div>
+      </div>
+
+      {/* ─── Generation Form (shown before success) ─── */}
+      {!result && (
+        <div className="cd-section">
+          <div className="cd-section-content">
+            {/* Algorithm */}
+            <div className="cd-field">
+              <label htmlFor="keygen-algorithm" className="cd-field-label">
+                {t("keygen.algorithm")}
+              </label>
+              <select
+                id="keygen-algorithm"
+                className="cd-user-row-input"
+                value={algorithm}
+                onChange={(e) => handleAlgorithmChange(e.target.value as AlgorithmValue)}
+                disabled={generating}
+              >
+                {ALGORITHM_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Comment */}
+            <div className="cd-field">
+              <label htmlFor="keygen-comment" className="cd-field-label">
+                {t("keygen.comment")}
+              </label>
+              <input
+                id="keygen-comment"
+                type="text"
+                className="cd-user-row-input"
+                value={comment}
+                onChange={(e) => setComment(e.target.value)}
+                placeholder={t("keygen.commentPlaceholder")}
+                disabled={generating}
+                spellCheck={false}
+              />
+            </div>
+
+            {/* Passphrase */}
+            <div className="cd-field">
+              <label htmlFor="keygen-passphrase" className="cd-field-label">
+                {t("keygen.passphrase")}
+              </label>
+              <input
+                id="keygen-passphrase"
+                type="password"
+                className="cd-user-row-input"
+                value={passphrase}
+                onChange={(e) => setPassphrase(e.target.value)}
+                placeholder={t("keygen.passphrasePlaceholder")}
+                disabled={generating}
+                autoComplete="new-password"
+              />
+            </div>
+
+            {/* Filename */}
+            <div className="cd-field">
+              <label htmlFor="keygen-filename" className="cd-field-label">
+                {t("keygen.filename")}
+              </label>
+              <input
+                id="keygen-filename"
+                type="text"
+                className="cd-user-row-input"
+                value={filename}
+                onChange={(e) => setFilename(e.target.value)}
+                placeholder={t("keygen.filenamePlaceholder")}
+                disabled={generating}
+                spellCheck={false}
+              />
+            </div>
+
+            {/* Error */}
+            {error && (
+              <p className="cd-error-text" role="alert">
+                {error}
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* ─── Public Key Result (shown after success) ─── */}
+      {result && (
+        <div className="cd-section">
+          <div className="cd-section-content">
+            <p className="keygen-pubkey-label">{t("keygen.publicKeyLabel")}</p>
+            <div className="keygen-pubkey-block">
+              <code className="keygen-pubkey-code">{result.publicKeyOpenssh}</code>
+            </div>
+            <div className="keygen-pubkey-actions">
+              <button
+                type="button"
+                className="btn-ghost keygen-copy-btn"
+                onClick={handleCopy}
+              >
+                {copied ? t("keygen.copied") : t("keygen.copyPublicKey")}
+              </button>
+            </div>
+            <p className="keygen-path-hint">
+              {result.privateKeyPath}
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* ─── Footer Actions ─── */}
+      <div className="cd-actions">
+        <button type="button" className="btn-ghost" onClick={handleClose}>
+          {result ? t("keygen.done") : t("keygen.cancel")}
+        </button>
+
+        <div className="cd-actions-right">
+          {result ? (
+            <button type="button" className="btn-primary" onClick={handleUseKey}>
+              {t("keygen.useThisKey")}
+            </button>
+          ) : (
+            <button
+              type="button"
+              className="btn-primary"
+              onClick={handleGenerate}
+              disabled={generating || !filename.trim()}
+            >
+              {generating ? t("keygen.generating") : t("keygen.generate")}
+            </button>
+          )}
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -93,6 +93,7 @@ export const en = {
   "connection.testMitm": "Host key changed or revoked",
   "connection.sectionStartup": "Startup Commands",
   "connection.startupPlaceholder": "One command per line — run after connect",
+  "connection.keygen.hint": "Generate new key",
 
   // Host key dialog
   "hostKey.unknownTitle": "New Host",
@@ -474,6 +475,26 @@ export const en = {
   "general.close": "Close",
   "general.error": "Error",
   "general.loading": "Loading...",
+
+  // SSH key generation dialog
+  "keygen.title": "Generate SSH Key",
+  "keygen.algorithm": "Algorithm",
+  "keygen.comment": "Comment",
+  "keygen.commentPlaceholder": "user@hostname",
+  "keygen.passphrase": "Passphrase",
+  "keygen.passphrasePlaceholder": "Optional — leave blank for no passphrase",
+  "keygen.filename": "Filename",
+  "keygen.filenamePlaceholder": "e.g. id_ed25519",
+  "keygen.generate": "Generate",
+  "keygen.generating": "Generating…",
+  "keygen.cancel": "Cancel",
+  "keygen.publicKeyLabel": "Public key — add this to your server's ~/.ssh/authorized_keys",
+  "keygen.copyPublicKey": "Copy",
+  "keygen.copied": "Copied!",
+  "keygen.useThisKey": "Use this key",
+  "keygen.done": "Done",
+  "keygen.errorAlreadyExists": "Key already exists",
+  "keygen.hint": "Generate new key",
 } as const;
 
 export type TranslationKey = keyof typeof en;

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -95,6 +95,7 @@ export const es: Record<TranslationKey, string> = {
   "connection.testMitm": "Clave de host cambiada o revocada",
   "connection.sectionStartup": "Comandos de Inicio",
   "connection.startupPlaceholder": "Un comando por línea — se ejecutan al conectar",
+  "connection.keygen.hint": "Generar nueva clave",
 
   // Host key dialog
   "hostKey.unknownTitle": "Host Nuevo",
@@ -476,4 +477,24 @@ export const es: Record<TranslationKey, string> = {
   "general.close": "Cerrar",
   "general.error": "Error",
   "general.loading": "Cargando...",
+
+  // SSH key generation dialog
+  "keygen.title": "Generar clave SSH",
+  "keygen.algorithm": "Algoritmo",
+  "keygen.comment": "Comentario",
+  "keygen.commentPlaceholder": "usuario@hostname",
+  "keygen.passphrase": "Frase de contraseña",
+  "keygen.passphrasePlaceholder": "Opcional — dejar en blanco para sin frase",
+  "keygen.filename": "Nombre de archivo",
+  "keygen.filenamePlaceholder": "ej. id_ed25519",
+  "keygen.generate": "Generar",
+  "keygen.generating": "Generando…",
+  "keygen.cancel": "Cancelar",
+  "keygen.publicKeyLabel": "Clave pública — agregá esto al ~/.ssh/authorized_keys de tu servidor",
+  "keygen.copyPublicKey": "Copiar",
+  "keygen.copied": "Copiado!",
+  "keygen.useThisKey": "Usar esta clave",
+  "keygen.done": "Listo",
+  "keygen.errorAlreadyExists": "La clave ya existe",
+  "keygen.hint": "Generar nueva clave",
 };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -284,6 +284,15 @@ export interface SearchResult {
   relativePath: string;  // path relative to search base_path
 }
 
+// ─── SSH Key Generation ──────────────────────────────
+
+/** Mirrors commands/keygen.rs GenerateSshKeyResult (serde camelCase) */
+export interface GenerateSshKeyResult {
+  publicKeyOpenssh: string;
+  privateKeyPath: string;
+  publicKeyPath: string;
+}
+
 // ─── File Content (SFTP file viewer) ────────────────
 
 export interface FileContent {


### PR DESCRIPTION
## Summary

In-app SSH key generation — create an Ed25519 / RSA (2048 or 4096) / ECDSA (P-256 or P-384) keypair without leaving NexTerm, closing the biggest onboarding gap (password-only → key auth). Clean-room via the ssh-key crate (already a dependency); no Voltius (AGPL) code.

## What's included

- **Pure generation module** (src-tauri/src/ssh/keygen.rs): Ed25519 (default), RSA 2048/4096, ECDSA P-256/P-384; OpenSSH private (optionally passphrase-encrypted) + public (authorized_keys format with comment).
- **generate_ssh_key command** with **overwrite protection** (refuses to clobber an existing key or its .pub) and secure writes (private 0600 via fs_secure, public 0644). RSA generation runs in spawn_blocking so it never stalls the runtime.
- **KeygenDialog** reachable from the connection form: algorithm picker, optional comment + passphrase, output filename; on success shows the public key with a Copy button + a note to add it to the server, and a 'Use this key' action that sets it as the connection identity.

## Correctness & security

- **RSA bit size is honored**: 'RSA 2048' produces a 2048-bit key and 'RSA 4096' a 4096-bit key (verified by tests asserting the actual modulus). (The first cut accidentally produced 4096 for both — ssh-key's PrivateKey::random ignores size and defaults to 4096; the review caught it and it's fixed via explicit RsaKeypair::random(bits).)
- Private key + passphrase are zeroized and never logged; OsRng for entropy.

## Quality

- **Rust** cargo test 222 + clippy/fmt clean; **frontend** 584 tests + tsc clean
- **Strict TDD** throughout
- **Dual adversarial review**: NO-GO on the RSA-bit-size bug (and the vacuous test that let it through) → fixed with real modulus-asserting tests (RED-verified) + a passphrase-zeroize hardening → re-review GO.
- **Clean-room verified**.

## Deferred

Pushing the new public key to the server's authorized_keys (NexTerm has no exec channel yet; v1 shows the key to copy / use ssh-copy-id).