### PR TITLE
feat(ssh): exec-and-capture primitive (run remote commands, capture stdout/stderr/exit)

### DIFF
--- a/src-tauri/src/commands/exec.rs
+++ b/src-tauri/src/commands/exec.rs
@@ -1,0 +1,181 @@
+// commands/exec.rs — SSH exec-and-capture Tauri command
+//
+// Exposes a single `ssh_exec` command that runs a one-shot remote command and
+// returns its complete stdout, stderr, and exit code.
+//
+// Pattern:
+// 1. Lock sessions briefly to open the SSH channel + capture the CancellationToken.
+// 2. RELEASE the lock before calling run_on_channel (no lock held across the
+//    channel event loop — mirrors tunnel.rs brief-lock pattern exactly).
+// 3. Return ExecOutput (serializable, camelCase) to the frontend.
+
+use tauri::State;
+use uuid::Uuid;
+
+use crate::error::AppError;
+use crate::ssh::exec::{self, ExecOptions, ExecOutput};
+use crate::state::{AppState, SessionId, SessionState};
+
+// ─── Inner logic (extracted for testability) ────────────
+
+/// Core implementation of ssh_exec, accepting a plain `&AppState` reference
+/// so unit tests can call it without going through Tauri's command machinery.
+pub(crate) async fn ssh_exec_inner(
+    state: &AppState,
+    session_id: SessionId,
+    command: String,
+    timeout_secs: Option<u64>,
+) -> Result<ExecOutput, AppError> {
+    // ── Brief lock: validate state, open channel, release ──
+    //
+    // The lock scope is a block so it drops BEFORE the channel event loop.
+    // Holding a tokio::sync::Mutex across an await point in the channel loop
+    // would deadlock: other commands (e.g. open_terminal) also need the lock.
+    let (channel, cancel_token) = {
+        let sessions_guard = state.sessions.lock().await;
+        let session = sessions_guard
+            .get(&session_id)
+            .ok_or(AppError::SessionNotFound(session_id))?;
+
+        if session.state != SessionState::Connected {
+            return Err(AppError::NotConnected);
+        }
+
+        let ssh_handle = session.ssh_handle.as_ref().ok_or(AppError::NotConnected)?;
+        let cancel_token = session.cancel_token.clone();
+
+        // Open the session channel while the lock is held. channel_open_session
+        // sends a packet over the SSH connection; it completes quickly (one
+        // round-trip) and does not require processing further ChannelMsg events,
+        // so holding the lock here is safe and does not risk deadlock.
+        let channel = ssh_handle
+            .channel_open_session()
+            .await
+            .map_err(AppError::Ssh)?;
+
+        // Guard drops here — the event loop runs without any lock.
+        (channel, cancel_token)
+    };
+
+    let opts = ExecOptions {
+        timeout_secs: timeout_secs.unwrap_or(ExecOptions::default().timeout_secs),
+        ..ExecOptions::default()
+    };
+
+    tracing::debug!("ssh_exec: session={session_id} command={command:?}");
+
+    let output = exec::run_on_channel(channel, command, opts, Some(cancel_token)).await?;
+
+    tracing::debug!(
+        "ssh_exec: session={session_id} exit_code={:?} stdout_len={} stderr_len={}",
+        output.exit_code,
+        output.stdout.len(),
+        output.stderr.len()
+    );
+
+    Ok(output)
+}
+
+// ─── Tauri command ───────────────────────────────────────
+
+/// Run a one-shot remote command on an active SSH session.
+///
+/// # Arguments
+/// * `session_id` — the UUID of an active Connected session.
+/// * `command` — the command string to execute on the remote host.
+/// * `timeout_secs` — optional timeout override (default: 30 s).
+///
+/// # Returns
+/// `ExecOutput` with stdout, stderr, exit_code, exit_signal, and truncation flags.
+///
+/// # Errors
+/// * `SessionNotFound` — session_id does not exist.
+/// * `NotConnected` — session exists but is not in Connected state.
+/// * `ExecTimeout` — command did not complete within the timeout.
+/// * `Ssh` — russh channel error.
+#[tauri::command]
+pub async fn ssh_exec(
+    state: State<'_, AppState>,
+    session_id: Uuid,
+    command: String,
+    timeout_secs: Option<u64>,
+) -> Result<ExecOutput, AppError> {
+    ssh_exec_inner(&state, session_id, command, timeout_secs).await
+}
+
+// ─── Tests ──────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use tokio::sync::Mutex;
+    use uuid::Uuid;
+
+    use crate::state::{AppState, SessionHandle, SessionState};
+
+    // ── WU4: error-path tests (no live SSH needed) ──
+
+    fn make_empty_state() -> AppState {
+        AppState {
+            sessions: Arc::new(Mutex::new(HashMap::new())),
+            ..Default::default()
+        }
+    }
+
+    fn make_disconnected_session(session_id: Uuid) -> SessionHandle {
+        SessionHandle {
+            id: session_id,
+            profile: Default::default(),
+            user_id: Uuid::nil(),
+            username: "testuser".to_string(),
+            state: SessionState::Disconnected,
+            ssh_handle: None,
+            bastion_handle: None,
+            terminals: HashMap::new(),
+            sftp: None,
+            tunnels: HashMap::new(),
+            keepalive_task: None,
+            cancel_token: tokio_util::sync::CancellationToken::new(),
+            remote_forward_registry: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn session_not_found_returns_error() {
+        let state = make_empty_state();
+        let result = super::ssh_exec_inner(&state, Uuid::new_v4(), "ls".to_string(), None).await;
+
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("Session not found"),
+            "Unexpected error message: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn not_connected_returns_error() {
+        let session_id = Uuid::new_v4();
+        let sessions = Arc::new(Mutex::new(HashMap::new()));
+        {
+            let mut guard = sessions.lock().await;
+            guard.insert(session_id, make_disconnected_session(session_id));
+        }
+
+        let state = AppState {
+            sessions,
+            ..Default::default()
+        };
+
+        let result = super::ssh_exec_inner(&state, session_id, "ls".to_string(), None).await;
+
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("Not connected"),
+            "Unexpected error message: {msg}"
+        );
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,6 +4,7 @@
 // registered in main.rs via generate_handler![].
 
 pub mod connection;
+pub mod exec;
 pub mod keygen;
 pub mod profile;
 pub mod sftp;

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -70,6 +70,9 @@ pub enum AppError {
     #[error("Exec timeout")]
     ExecTimeout,
 
+    #[error("Exec cancelled")]
+    ExecCancelled,
+
     #[error("User selection required: profile has multiple users — provide a userId")]
     UserSelectionRequired,
 
@@ -153,6 +156,13 @@ mod tests {
     }
 
     #[test]
+    fn exec_cancelled_serializes() {
+        let err = AppError::ExecCancelled;
+        let serialized = serde_json::to_string(&err).unwrap();
+        assert_eq!(serialized, "\"Exec cancelled\"");
+    }
+
+    #[test]
     fn all_variants_serialize() {
         let id = uuid::Uuid::nil();
         let variants: Vec<AppError> = vec![
@@ -175,6 +185,7 @@ mod tests {
             AppError::KeyError("test".into()),
             AppError::ConnectionTimeout,
             AppError::ExecTimeout,
+            AppError::ExecCancelled,
             AppError::UserSelectionRequired,
             AppError::UserNotFound(id),
             AppError::Other("test".into()),

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -67,6 +67,9 @@ pub enum AppError {
     #[error("Connection timeout")]
     ConnectionTimeout,
 
+    #[error("Exec timeout")]
+    ExecTimeout,
+
     #[error("User selection required: profile has multiple users — provide a userId")]
     UserSelectionRequired,
 
@@ -171,6 +174,7 @@ mod tests {
             AppError::TransferCancelled,
             AppError::KeyError("test".into()),
             AppError::ConnectionTimeout,
+            AppError::ExecTimeout,
             AppError::UserSelectionRequired,
             AppError::UserNotFound(id),
             AppError::Other("test".into()),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -184,6 +184,8 @@ pub fn run() {
             commands::tunnel::list_tunnels,
             // SSH keygen
             commands::keygen::generate_ssh_key,
+            // SSH exec
+            commands::exec::ssh_exec,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/ssh/exec.rs
+++ b/src-tauri/src/ssh/exec.rs
@@ -1,0 +1,464 @@
+// ssh/exec.rs — SSH exec-and-capture primitive
+//
+// Provides a one-shot "run command and collect output" capability distinct from
+// the interactive PTY channel in terminal.rs. Used by monitoring, docker, and
+// proxmox features that need complete stdout/stderr/exit-code without a TTY.
+//
+// Architecture:
+// - ExecAccumulator: pure struct (no russh dependency) — fully unit-testable.
+//   Processes AccumulatorEvent values and tracks stdout/stderr/exit.
+// - run_on_channel: async fn that drives a real russh channel through exec,
+//   translates ChannelMsg into AccumulatorEvent, enforces timeout and
+//   cancellation, and cleans up the channel on every exit path.
+// - ssh_exec is in commands/exec.rs — it opens the channel under a brief
+//   sessions-lock scope (mirror of tunnel.rs) and then calls run_on_channel.
+//
+// CRITICAL correctness invariants (from SSH spec):
+// 1. ExitStatus arrives BEFORE Eof — do NOT terminate the loop on ExitStatus.
+//    Only Eof / Close / None terminate the accumulation loop.
+// 2. ChannelMsg is #[non_exhaustive] — the match MUST have a wildcard arm.
+// 3. russh::client::Handle is NOT Clone — callers open the channel under a
+//    brief lock and pass it here; we never hold the sessions Mutex ourselves.
+// 4. stdout ← ChannelMsg::Data; stderr ← ExtendedData { ext: 1 } (SSH_EXTENDED_DATA_STDERR).
+// 5. Output cap: 10 MB per stream. On overflow: set truncated=true, stop
+//    appending that stream, but keep draining until Eof/Close so the channel
+//    closes cleanly.
+// 6. On any error/timeout/cancel path: `let _ = channel.close().await;`.
+
+use std::time::Duration;
+
+use tokio_util::sync::CancellationToken;
+
+use crate::error::AppError;
+
+// ─── Constants ──────────────────────────────────────────
+
+pub const DEFAULT_TIMEOUT_SECS: u64 = 30;
+pub const DEFAULT_OUTPUT_CAP_BYTES: usize = 10 * 1024 * 1024; // 10 MB
+
+// ─── ExecOutput ─────────────────────────────────────────
+
+/// Outcome of a single exec-and-capture call.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecOutput {
+    /// UTF-8 lossy decoded stdout
+    pub stdout: String,
+    /// UTF-8 lossy decoded stderr
+    pub stderr: String,
+    /// Exit code, if the server sent one. None if the process was killed by a
+    /// signal or the session ended abnormally before the exit status arrived.
+    pub exit_code: Option<i32>,
+    /// Signal name that killed the process, if any (e.g. "KILL", "TERM").
+    pub exit_signal: Option<String>,
+    /// True if stdout exceeded the output cap and was truncated.
+    pub stdout_truncated: bool,
+    /// True if stderr exceeded the output cap and was truncated.
+    pub stderr_truncated: bool,
+}
+
+// ─── ExecOptions ────────────────────────────────────────
+
+/// Options controlling a run_on_channel call.
+#[derive(Debug, Clone)]
+pub struct ExecOptions {
+    /// Timeout in seconds for the entire exec call. Default: DEFAULT_TIMEOUT_SECS.
+    pub timeout_secs: u64,
+    /// Maximum bytes to accumulate per stream before truncating. Default: DEFAULT_OUTPUT_CAP_BYTES.
+    pub output_cap_bytes: usize,
+}
+
+impl Default for ExecOptions {
+    fn default() -> Self {
+        Self {
+            timeout_secs: DEFAULT_TIMEOUT_SECS,
+            output_cap_bytes: DEFAULT_OUTPUT_CAP_BYTES,
+        }
+    }
+}
+
+// ─── AccumulatorEvent ───────────────────────────────────
+
+/// Mirror of the ChannelMsg variants relevant to exec — decoupled from russh so
+/// ExecAccumulator can be unit-tested without a live SSH connection.
+#[derive(Debug)]
+pub enum AccumulatorEvent {
+    /// Bytes received on stdout (ChannelMsg::Data).
+    Stdout(Vec<u8>),
+    /// Bytes received on stderr (ChannelMsg::ExtendedData { ext: 1 }).
+    Stderr(Vec<u8>),
+    /// Process exited with the given code (ChannelMsg::ExitStatus).
+    ExitCode(u32),
+    /// Process was killed by a signal (ChannelMsg::ExitSignal).
+    ExitSignal(String),
+    /// Channel is done — accumulation should stop (Eof, Close, or None).
+    Done,
+}
+
+// ─── ExecAccumulator ────────────────────────────────────
+
+/// Pure, synchronous accumulator — no async, no russh dependency.
+///
+/// Call `process()` for each event, then call `finish()` to consume the
+/// accumulator and produce an ExecOutput. The `done` field becomes true
+/// when a `Done` event is processed.
+pub struct ExecAccumulator {
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+    exit_code: Option<i32>,
+    exit_signal: Option<String>,
+    stdout_truncated: bool,
+    stderr_truncated: bool,
+    /// True once a Done event has been received.
+    pub done: bool,
+    cap: usize,
+}
+
+impl ExecAccumulator {
+    /// Create a new accumulator with the given output cap per stream.
+    pub fn new(cap: usize) -> Self {
+        Self {
+            stdout: Vec::new(),
+            stderr: Vec::new(),
+            exit_code: None,
+            exit_signal: None,
+            stdout_truncated: false,
+            stderr_truncated: false,
+            done: false,
+            cap,
+        }
+    }
+
+    /// Process a single event. After receiving `Done`, further events are ignored.
+    pub fn process(&mut self, event: AccumulatorEvent) {
+        if self.done {
+            return;
+        }
+        match event {
+            AccumulatorEvent::Stdout(data) => {
+                if !self.stdout_truncated {
+                    let remaining = self.cap.saturating_sub(self.stdout.len());
+                    if data.len() > remaining {
+                        self.stdout.extend_from_slice(&data[..remaining]);
+                        self.stdout_truncated = true;
+                    } else {
+                        self.stdout.extend_from_slice(&data);
+                    }
+                }
+                // When truncated, keep draining (caller's loop must continue) —
+                // we just stop appending.
+            }
+            AccumulatorEvent::Stderr(data) => {
+                if !self.stderr_truncated {
+                    let remaining = self.cap.saturating_sub(self.stderr.len());
+                    if data.len() > remaining {
+                        self.stderr.extend_from_slice(&data[..remaining]);
+                        self.stderr_truncated = true;
+                    } else {
+                        self.stderr.extend_from_slice(&data);
+                    }
+                }
+            }
+            AccumulatorEvent::ExitCode(code) => {
+                // u32 from SSH → i32 for usability (most callers expect signed).
+                self.exit_code = Some(code as i32);
+            }
+            AccumulatorEvent::ExitSignal(signal) => {
+                self.exit_signal = Some(signal);
+            }
+            AccumulatorEvent::Done => {
+                self.done = true;
+            }
+        }
+    }
+
+    /// Consume the accumulator and produce the final ExecOutput.
+    pub fn finish(self) -> ExecOutput {
+        ExecOutput {
+            stdout: String::from_utf8_lossy(&self.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&self.stderr).into_owned(),
+            exit_code: self.exit_code,
+            exit_signal: self.exit_signal,
+            stdout_truncated: self.stdout_truncated,
+            stderr_truncated: self.stderr_truncated,
+        }
+    }
+}
+
+// ─── run_on_channel ─────────────────────────────────────
+
+/// Core exec primitive.
+///
+/// Takes an already-opened session channel (opened by the caller under a brief
+/// sessions-lock, mirroring tunnel.rs), sends the exec request, accumulates
+/// output, and returns ExecOutput.
+///
+/// # Cancellation
+///
+/// Pass a `CancellationToken` to allow the caller to abort the exec. On
+/// cancellation the channel is closed and `AppError::ExecCancelled` is returned.
+///
+/// # Timeout
+///
+/// The entire operation is wrapped in `tokio::time::timeout`. On expiry the
+/// channel is closed and `AppError::ExecTimeout` is returned.
+///
+/// # Error paths
+///
+/// On every error/timeout/cancel path, `channel.close().await` is called
+/// (best-effort, error ignored) to prevent channel leaks.
+pub async fn run_on_channel(
+    mut channel: russh::Channel<russh::client::Msg>,
+    command: impl Into<Vec<u8>>,
+    opts: ExecOptions,
+    cancel_token: Option<CancellationToken>,
+) -> Result<ExecOutput, AppError> {
+    use russh::ChannelMsg;
+
+    let command_bytes: Vec<u8> = command.into();
+
+    // Send the exec request.
+    channel
+        .exec(true, command_bytes)
+        .await
+        .map_err(AppError::Ssh)?;
+
+    let mut acc = ExecAccumulator::new(opts.output_cap_bytes);
+    let timeout_dur = Duration::from_secs(opts.timeout_secs);
+
+    // Wrap the accumulation loop in a timeout.
+    let loop_result = tokio::time::timeout(timeout_dur, async {
+        loop {
+            if let Some(ref token) = cancel_token {
+                tokio::select! {
+                    _ = token.cancelled() => {
+                        return Err(AppError::Other("exec cancelled".to_string()));
+                    }
+                    msg = channel.wait() => {
+                        match msg {
+                            Some(ChannelMsg::Data { data }) => {
+                                acc.process(AccumulatorEvent::Stdout(data.to_vec()));
+                            }
+                            Some(ChannelMsg::ExtendedData { data, ext }) => {
+                                if ext == 1 {
+                                    acc.process(AccumulatorEvent::Stderr(data.to_vec()));
+                                }
+                                // Other ext types (rare/unknown) — drain but discard.
+                            }
+                            Some(ChannelMsg::ExitStatus { exit_status }) => {
+                                // ExitStatus arrives BEFORE Eof per SSH spec — capture
+                                // it but do NOT terminate; data may still arrive.
+                                acc.process(AccumulatorEvent::ExitCode(exit_status));
+                            }
+                            Some(ChannelMsg::ExitSignal { signal_name, .. }) => {
+                                acc.process(AccumulatorEvent::ExitSignal(
+                                    format!("{signal_name:?}"),
+                                ));
+                            }
+                            Some(ChannelMsg::Eof) | Some(ChannelMsg::Close) | None => {
+                                acc.process(AccumulatorEvent::Done);
+                                break;
+                            }
+                            Some(_) => {
+                                // #[non_exhaustive]: WindowAdjusted, Success, etc. — ignore.
+                            }
+                        }
+                    }
+                }
+            } else {
+                match channel.wait().await {
+                    Some(ChannelMsg::Data { data }) => {
+                        acc.process(AccumulatorEvent::Stdout(data.to_vec()));
+                    }
+                    Some(ChannelMsg::ExtendedData { data, ext }) => {
+                        if ext == 1 {
+                            acc.process(AccumulatorEvent::Stderr(data.to_vec()));
+                        }
+                    }
+                    Some(ChannelMsg::ExitStatus { exit_status }) => {
+                        acc.process(AccumulatorEvent::ExitCode(exit_status));
+                    }
+                    Some(ChannelMsg::ExitSignal { signal_name, .. }) => {
+                        acc.process(AccumulatorEvent::ExitSignal(format!("{signal_name:?}")));
+                    }
+                    Some(ChannelMsg::Eof) | Some(ChannelMsg::Close) | None => {
+                        acc.process(AccumulatorEvent::Done);
+                        break;
+                    }
+                    Some(_) => {
+                        // #[non_exhaustive]: ignore unknown variants.
+                    }
+                }
+            }
+        }
+        Ok(acc)
+    })
+    .await;
+
+    match loop_result {
+        Ok(Ok(accumulator)) => Ok(accumulator.finish()),
+        Ok(Err(e)) => {
+            // Cancelled — close channel best-effort.
+            let _ = channel.close().await;
+            Err(e)
+        }
+        Err(_timeout) => {
+            // Timeout — close channel best-effort.
+            let _ = channel.close().await;
+            Err(AppError::ExecTimeout)
+        }
+    }
+}
+
+// ─── Tests ──────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── WU1: ExecAccumulator unit tests (pure, no russh) ──
+
+    #[test]
+    fn stdout_accumulates() {
+        let mut acc = ExecAccumulator::new(DEFAULT_OUTPUT_CAP_BYTES);
+        acc.process(AccumulatorEvent::Stdout(b"hello ".to_vec()));
+        acc.process(AccumulatorEvent::Stdout(b"world".to_vec()));
+        acc.process(AccumulatorEvent::Done);
+        let out = acc.finish();
+        assert_eq!(out.stdout, "hello world");
+        assert!(!out.stdout_truncated);
+    }
+
+    #[test]
+    fn stderr_separated_from_stdout() {
+        let mut acc = ExecAccumulator::new(DEFAULT_OUTPUT_CAP_BYTES);
+        acc.process(AccumulatorEvent::Stdout(b"out".to_vec()));
+        acc.process(AccumulatorEvent::Stderr(b"err".to_vec()));
+        acc.process(AccumulatorEvent::Done);
+        let out = acc.finish();
+        assert_eq!(out.stdout, "out");
+        assert_eq!(out.stderr, "err");
+    }
+
+    #[test]
+    fn exit_code_captured() {
+        let mut acc = ExecAccumulator::new(DEFAULT_OUTPUT_CAP_BYTES);
+        acc.process(AccumulatorEvent::ExitCode(42));
+        acc.process(AccumulatorEvent::Done);
+        let out = acc.finish();
+        assert_eq!(out.exit_code, Some(42));
+    }
+
+    #[test]
+    fn exit_signal_captured() {
+        let mut acc = ExecAccumulator::new(DEFAULT_OUTPUT_CAP_BYTES);
+        acc.process(AccumulatorEvent::ExitSignal("KILL".to_string()));
+        acc.process(AccumulatorEvent::Done);
+        let out = acc.finish();
+        assert_eq!(out.exit_signal.as_deref(), Some("KILL"));
+    }
+
+    #[test]
+    fn eof_terminates_via_done_event() {
+        let mut acc = ExecAccumulator::new(DEFAULT_OUTPUT_CAP_BYTES);
+        assert!(!acc.done);
+        acc.process(AccumulatorEvent::Done);
+        assert!(acc.done);
+        // Further events are ignored after Done.
+        acc.process(AccumulatorEvent::Stdout(b"ignored".to_vec()));
+        let out = acc.finish();
+        assert_eq!(out.stdout, "");
+    }
+
+    #[test]
+    fn stdout_truncated_at_cap() {
+        let cap = 10;
+        let mut acc = ExecAccumulator::new(cap);
+        // Send exactly cap bytes — no truncation yet.
+        acc.process(AccumulatorEvent::Stdout(b"0123456789".to_vec()));
+        assert!(!acc.finish_ref().stdout_truncated());
+
+        let mut acc2 = ExecAccumulator::new(cap);
+        // Send cap + 1 bytes in one chunk.
+        acc2.process(AccumulatorEvent::Stdout(b"01234567890".to_vec()));
+        let out = acc2.finish();
+        assert!(out.stdout_truncated);
+        assert_eq!(out.stdout.len(), cap);
+    }
+
+    #[test]
+    fn stderr_truncated_at_cap() {
+        let cap = 5;
+        let mut acc = ExecAccumulator::new(cap);
+        acc.process(AccumulatorEvent::Stderr(b"123456".to_vec()));
+        let out = acc.finish();
+        assert!(out.stderr_truncated);
+        assert_eq!(out.stderr.len(), cap);
+    }
+
+    #[test]
+    fn utf8_lossy_decoding() {
+        let mut acc = ExecAccumulator::new(DEFAULT_OUTPUT_CAP_BYTES);
+        // Invalid UTF-8 bytes — should not panic, replaced with U+FFFD.
+        acc.process(AccumulatorEvent::Stdout(vec![0xFF, 0xFE, b'X']));
+        acc.process(AccumulatorEvent::Done);
+        let out = acc.finish();
+        assert!(out.stdout.contains('X'));
+        // Contains the replacement character for the invalid bytes.
+        assert!(out.stdout.contains('\u{FFFD}'));
+    }
+
+    #[test]
+    fn no_exit_code_gives_none() {
+        let mut acc = ExecAccumulator::new(DEFAULT_OUTPUT_CAP_BYTES);
+        acc.process(AccumulatorEvent::Done);
+        let out = acc.finish();
+        assert_eq!(out.exit_code, None);
+    }
+
+    #[test]
+    fn multiple_data_chunks_concatenate() {
+        let mut acc = ExecAccumulator::new(DEFAULT_OUTPUT_CAP_BYTES);
+        for i in 0..5u8 {
+            acc.process(AccumulatorEvent::Stdout(vec![b'a' + i]));
+        }
+        acc.process(AccumulatorEvent::Done);
+        let out = acc.finish();
+        assert_eq!(out.stdout, "abcde");
+    }
+
+    #[test]
+    fn exit_status_before_eof_does_not_terminate() {
+        // Simulates SSH spec: ExitStatus arrives before Eof. Data after
+        // ExitStatus must still be captured.
+        let mut acc = ExecAccumulator::new(DEFAULT_OUTPUT_CAP_BYTES);
+        acc.process(AccumulatorEvent::ExitCode(0));
+        assert!(!acc.done, "ExitCode must NOT set done=true");
+        acc.process(AccumulatorEvent::Stdout(b"late data".to_vec()));
+        acc.process(AccumulatorEvent::Done);
+        let out = acc.finish();
+        assert_eq!(out.stdout, "late data");
+        assert_eq!(out.exit_code, Some(0));
+    }
+
+    // ── finish_ref helper ──────────────────────────────────────────────────────
+    // finish() consumes self, but stdout_truncated_at_cap needs to check the
+    // flag on a still-alive accumulator (first assertion). We use a tiny
+    // by-ref view struct scoped inside the test module.
+
+    struct ExecOutputRef<'a> {
+        acc: &'a ExecAccumulator,
+    }
+
+    impl ExecOutputRef<'_> {
+        fn stdout_truncated(&self) -> bool {
+            self.acc.stdout_truncated
+        }
+    }
+
+    impl ExecAccumulator {
+        fn finish_ref(&self) -> ExecOutputRef<'_> {
+            ExecOutputRef { acc: self }
+        }
+    }
+}

--- a/src-tauri/src/ssh/exec.rs
+++ b/src-tauri/src/ssh/exec.rs
@@ -185,6 +185,31 @@ impl ExecAccumulator {
     }
 }
 
+// ─── Signal helpers ─────────────────────────────────────
+
+/// Map a russh `Sig` to its bare SSH signal name (e.g. `Sig::KILL` → `"KILL"`).
+///
+/// `Sig::name()` is private in russh 0.48, so we maintain an explicit match.
+/// `Sig::Custom(s)` yields `s` as-is — callers that store e.g. `"SIGFOO"` get
+/// back `"SIGFOO"` with no extra prefix or wrapping quotes.
+pub fn sig_name(sig: &russh::Sig) -> String {
+    match sig {
+        russh::Sig::ABRT => "ABRT".to_string(),
+        russh::Sig::ALRM => "ALRM".to_string(),
+        russh::Sig::FPE => "FPE".to_string(),
+        russh::Sig::HUP => "HUP".to_string(),
+        russh::Sig::ILL => "ILL".to_string(),
+        russh::Sig::INT => "INT".to_string(),
+        russh::Sig::KILL => "KILL".to_string(),
+        russh::Sig::PIPE => "PIPE".to_string(),
+        russh::Sig::QUIT => "QUIT".to_string(),
+        russh::Sig::SEGV => "SEGV".to_string(),
+        russh::Sig::TERM => "TERM".to_string(),
+        russh::Sig::USR1 => "USR1".to_string(),
+        russh::Sig::Custom(s) => s.clone(),
+    }
+}
+
 // ─── run_on_channel ─────────────────────────────────────
 
 /// Core exec primitive.
@@ -196,7 +221,7 @@ impl ExecAccumulator {
 /// # Cancellation
 ///
 /// Pass a `CancellationToken` to allow the caller to abort the exec. On
-/// cancellation the channel is closed and `AppError::ExecCancelled` is returned.
+/// cancellation the channel is closed and [`AppError::ExecCancelled`] is returned.
 ///
 /// # Timeout
 ///
@@ -232,7 +257,7 @@ pub async fn run_on_channel(
             if let Some(ref token) = cancel_token {
                 tokio::select! {
                     _ = token.cancelled() => {
-                        return Err(AppError::Other("exec cancelled".to_string()));
+                        return Err(AppError::ExecCancelled);
                     }
                     msg = channel.wait() => {
                         match msg {
@@ -252,7 +277,7 @@ pub async fn run_on_channel(
                             }
                             Some(ChannelMsg::ExitSignal { signal_name, .. }) => {
                                 acc.process(AccumulatorEvent::ExitSignal(
-                                    format!("{signal_name:?}"),
+                                    sig_name(&signal_name),
                                 ));
                             }
                             Some(ChannelMsg::Eof) | Some(ChannelMsg::Close) | None => {
@@ -279,7 +304,7 @@ pub async fn run_on_channel(
                         acc.process(AccumulatorEvent::ExitCode(exit_status));
                     }
                     Some(ChannelMsg::ExitSignal { signal_name, .. }) => {
-                        acc.process(AccumulatorEvent::ExitSignal(format!("{signal_name:?}")));
+                        acc.process(AccumulatorEvent::ExitSignal(sig_name(&signal_name)));
                     }
                     Some(ChannelMsg::Eof) | Some(ChannelMsg::Close) | None => {
                         acc.process(AccumulatorEvent::Done);
@@ -439,6 +464,26 @@ mod tests {
         let out = acc.finish();
         assert_eq!(out.stdout, "late data");
         assert_eq!(out.exit_code, Some(0));
+    }
+
+    // ── sig_name tests ────────────────────────────────────────────────────────
+
+    #[test]
+    fn sig_name_standard_gives_bare_name() {
+        assert_eq!(sig_name(&russh::Sig::KILL), "KILL");
+        assert_eq!(sig_name(&russh::Sig::TERM), "TERM");
+        assert_eq!(sig_name(&russh::Sig::SEGV), "SEGV");
+        assert_eq!(sig_name(&russh::Sig::INT), "INT");
+        assert_eq!(sig_name(&russh::Sig::HUP), "HUP");
+    }
+
+    #[test]
+    fn sig_name_custom_gives_raw_string() {
+        // Custom("SIGFOO") → "SIGFOO" (no prefix, no quotes)
+        assert_eq!(
+            sig_name(&russh::Sig::Custom("SIGFOO".to_string())),
+            "SIGFOO"
+        );
     }
 
     // ── finish_ref helper ──────────────────────────────────────────────────────

--- a/src-tauri/src/ssh/mod.rs
+++ b/src-tauri/src/ssh/mod.rs
@@ -3,6 +3,7 @@
 // All SSH protocol interactions (connection, auth, terminal, SFTP, tunneling)
 // are encapsulated in this module and its submodules.
 
+pub mod exec;
 pub mod handler;
 pub mod keygen;
 pub mod keys;


### PR DESCRIPTION
## Summary

Adds a foundational SSH **exec-and-capture** primitive: run a one-shot command on the remote host (not an interactive PTY) and capture its stdout, stderr, and exit code. NexTerm previously had only the interactive PTY channel and SFTP — no way to run a command and collect its output. **This is the reusable foundation for the upcoming system-monitoring, Docker, and Proxmox features** (they all run remote commands and parse output). Clean-room, built on russh's public channel API + NexTerm's own patterns; no Voltius (AGPL) code.

## What's included

- **Pure `ExecAccumulator`** (src-tauri/src/ssh/exec.rs): folds channel events → { stdout, stderr, exit_code, exit_signal, truncated } with a hard output cap. Fully unit-tested (13 tests) without a live SSH session.
- **`run_on_channel`**: the real ChannelMsg loop (mirrors the PTY loop) — accumulates Data→stdout / ExtendedData{ext:1}→stderr, captures ExitStatus/ExitSignal **without terminating early** (per SSH spec, exit-status precedes EOF), and ends on Eof/Close.
- **`ssh_exec` Tauri command** using the brief-lock-open-channel-release pattern (no mutex held across the await loop).

## Safety

- **Output cap** (10 MB/stream): on exceed, marks truncated and stops appending but keeps draining so the channel closes cleanly — a huge-output command can't OOM.
- **Timeout** (30 s default) → `ExecTimeout`; **cancellation** via the session token → `ExecCancelled`; the channel is explicitly closed on every error/timeout/cancel path (no leak).
- stdout/stderr separated (ext==1 = stderr); exit signals resolved to bare names (incl. custom signals).

## Quality

- **Rust** cargo test 238 + clippy/fmt clean
- **Strict TDD** (pure accumulator first)
- **Adversarial review GO**: the two HIGH invariants verified — loop correctness (no early-terminate on ExitStatus, drain-after-cap, close-on-all-paths) and no-lock-across-await; two MINORs (custom-signal formatting, cancellation error variant) fixed.
- **Clean-room verified**.

## Known follow-up

`run_on_channel` has no direct integration test (would need a mock/localhost SSH harness); the monitoring feature will exercise it end-to-end next. The pure accumulator (the core logic) is fully tested.